### PR TITLE
Menu: Fixup disabled button not being greyed

### DIFF
--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -158,14 +158,22 @@ class AutomationMenu
         let newStatus = !(localStorage.getItem(id) == "true");
         if (newStatus)
         {
-            button.classList.remove("btn-danger");
-            button.classList.add("btn-success");
+            // Only update the class if the button was not disabled
+            if (!button.classList.contains("btn-secondary"))
+            {
+                button.classList.remove("btn-danger");
+                button.classList.add("btn-success");
+            }
             button.innerText = "On";
         }
         else
         {
-            button.classList.remove("btn-success");
-            button.classList.add("btn-danger");
+            // Only update the class if the button was not disabled
+            if (!button.classList.contains("btn-secondary"))
+            {
+                button.classList.remove("btn-success");
+                button.classList.add("btn-danger");
+            }
             button.innerText = "Off";
         }
 


### PR DESCRIPTION
In some rare cases the button's state is changed while being disabled.
In such case, the button's class must not be updated, only its label.

Fixes #4 