### PR TITLE
Utils: Fixup the move to town method

### DIFF
--- a/src/lib/Utils.js
+++ b/src/lib/Utils.js
@@ -72,7 +72,7 @@ class AutomationUtils
             }
 
             // Move the player to the region first, if needed
-            if (town.region != player.town().region)
+            if (town.region != player.region)
             {
                 MapHelper.moveToTown(GameConstants.DockTowns[town.region]);
                 player.region = town.region;


### PR DESCRIPTION
The player.town().region was used insteaded of the player.region
In some rare cases the town points to an old instance in another region