### PR TITLE
Add the 'Focus on' feature

### DIFF
--- a/src/Automation.js
+++ b/src/Automation.js
@@ -4,6 +4,7 @@ class Automation
     static Click = AutomationClick;
     static Dungeon = AutomationDungeon;
     static Farm = AutomationFarm;
+    static Focus = AutomationFocus;
     static Gym = AutomationGym;
     static Hatchery = AutomationHatchery;
     static Items = AutomationItems;
@@ -34,6 +35,7 @@ class Automation
                 this.Trivia.start();
 
                 this.Click.start();
+                this.Focus.start();
                 this.Hatchery.start();
                 this.Underground.start();
                 this.Farm.start();

--- a/src/ComponentLoader.js
+++ b/src/ComponentLoader.js
@@ -27,6 +27,7 @@ class AutomationComponentLoader
         this.__addScript("src/lib/Click.js");
         this.__addScript("src/lib/Dungeon.js");
         this.__addScript("src/lib/Farm.js");
+        this.__addScript("src/lib/Focus.js");
         this.__addScript("src/lib/Gym.js");
         this.__addScript("src/lib/Hatchery.js");
         this.__addScript("src/lib/Items.js");

--- a/src/ComponentLoader.js
+++ b/src/ComponentLoader.js
@@ -24,6 +24,9 @@ class AutomationComponentLoader
         this.__baseUrl = baseUrl;
 
         // From the least dependant, to the most dependent
+        this.__addScript("src/lib/Focus/Achievements.js");
+
+        this.__loadingOrder += 1;
         this.__addScript("src/lib/Click.js");
         this.__addScript("src/lib/Dungeon.js");
         this.__addScript("src/lib/Farm.js");

--- a/src/jsconfig.json
+++ b/src/jsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6"
+    }
+}

--- a/src/lib/Click.js
+++ b/src/lib/Click.js
@@ -1,40 +1,21 @@
 /**
- * @class The AutomationClick regroups the 'Auto attack' button and 'Best route' button functionalities
+ * @class The AutomationClick regroups the 'Auto attack' button functionalities
  */
 class AutomationClick
 {
     static __autoClickLoop = null;
-    static __bestRouteLoop = null;
 
     /**
      * @brief Builds the menu, and retores previous running state if needed
-     *
-     * The 'Best Route' functionality is disabled by default (if never set in a previous session)
      */
     static start()
     {
-        // Disable best route by default
-        if (localStorage.getItem("bestRouteClickEnabled") == null)
-        {
-            localStorage.setItem("bestRouteClickEnabled", false);
-        }
-
         // Add auto click button
         let autoClickTooltip = "Attack clicks are performed every 50ms"
                              + Automation.Menu.__tooltipSeparator()
                              + "Applies to battle, gym and dungeon";
         let autoClickButton = Automation.Menu.__addAutomationButton("Auto attack", "autoClickEnabled", autoClickTooltip);
         autoClickButton.addEventListener("click", this.__toggleAutoClick.bind(this), false);
-
-        // Add best route button
-        let bestRouteTooltip = "Automatically moves to the best route"
-                             + Automation.Menu.__tooltipSeparator()
-                             + "Such route is the highest unlocked one\n"
-                             + "with HP lower than Click Attack";
-        let bestRouteButton = Automation.Menu.__addAutomationButton("Best route", "bestRouteClickEnabled", bestRouteTooltip);
-
-        // Toggle best route loop on click
-        bestRouteButton.addEventListener("click", this.__toggleBestRoute.bind(this), false);
 
         // Restore previous session state
         this.__toggleAutoClick();
@@ -46,7 +27,7 @@ class AutomationClick
      * If the feature was enabled and it's toggled to disabled, the auto attack loop will be stopped.
      * If the feature was disabled and it's toggled to enabled, the auto attack loop will be started.
      *
-     * @param enable: [Optional] If a boolean is passed, it will used to set the right state.
+     * @param enable: [Optional] If a boolean is passed, it will be used to set the right state.
      *                Otherwise, the cookie stored value will be used
      */
     static __toggleAutoClick(enable)
@@ -71,40 +52,6 @@ class AutomationClick
             // Unregister the loop
             clearInterval(this.__autoClickLoop);
             this.__autoClickLoop = null;
-        }
-    }
-
-    /**
-     * @brief Toggles the 'Best route' feature
-     *
-     * If the feature was enabled and it's toggled to disabled, the auto attack loop will be stopped.
-     * If the feature was disabled and it's toggled to enabled, the auto attack loop will be started.
-     *
-     * @param enable: [Optional] If a boolean is passed, it will used to set the right state.
-     *                Otherwise, the cookie stored value will be used
-     */
-    static __toggleBestRoute(enable)
-    {
-        // If we got the click event, use the button status
-        if ((enable !== true) && (enable !== false))
-        {
-            enable = (localStorage.getItem("bestRouteClickEnabled") === "true");
-        }
-
-        if (enable)
-        {
-            // Only set a loop if there is none active
-            if (this.__bestRouteLoop === null)
-            {
-                // Set best route refresh loop
-                this.__bestRouteLoop = setInterval(this.__goToBestRoute.bind(this), 10000); // Refresh every 10s
-            }
-        }
-        else
-        {
-            // Unregister the loop
-            clearInterval(this.__bestRouteLoop);
-            this.__bestRouteLoop = null;
         }
     }
 
@@ -139,34 +86,5 @@ class AutomationClick
                 DungeonBattle.clickAttack();
             }
         }
-    }
-
-    /**
-     * @brief Moves the player to the best route for EXP farming
-     *
-     * If the user is in a state in which he cannot de moved, the 'Best Route' feature is automatically disabled.
-     * This includes:
-     *   - Being in an instance
-     *   - Using the 'Gym AutoFight' feature
-     *   - Using the 'Dungeon AutoFight' feature
-     *
-     * @todo (03/06/2022): Disable the best route button in such case to inform the user
-     *                     that the feature cannot be used at the moment
-     *
-     * @see Utils.Route.__moveToBestRouteForExp
-     */
-    static __goToBestRoute()
-    {
-        // Disable best route if any other auto-farm is enabled, or an instance is in progress, and exit
-        if ((localStorage.getItem("dungeonFightEnabled") == "true")
-            || (localStorage.getItem("gymFightEnabled") == "true")
-            || Automation.Utils.__isInInstanceState())
-        {
-            Automation.Menu.__forceAutomationState("bestRouteClickEnabled", false);
-
-            return;
-        }
-
-        Automation.Utils.Route.__moveToBestRouteForExp();
     }
 }

--- a/src/lib/Dungeon.js
+++ b/src/lib/Dungeon.js
@@ -47,10 +47,10 @@ class AutomationDungeon
     /**
      * @brief Toggles the 'Dungeon AutoFight' feature
      *
-     * If the feature was enabled and it's toggled to disabled, the auto attack loop will be stopped.
-     * If the feature was disabled and it's toggled to enabled, the auto attack loop will be started.
+     * If the feature was enabled and it's toggled to disabled, the loop will be stopped.
+     * If the feature was disabled and it's toggled to enabled, the loop will be started.
      *
-     * @param enable: [Optional] If a boolean is passed, it will used to set the right state.
+     * @param enable: [Optional] If a boolean is passed, it will be used to set the right state.
      *                Otherwise, the cookie stored value will be used
      */
     static __toggleDungeonFight(enable)

--- a/src/lib/Farm.js
+++ b/src/lib/Farm.js
@@ -91,10 +91,10 @@ class AutomationFarm
     /**
      * @brief Toggles the 'Farming' feature
      *
-     * If the feature was enabled and it's toggled to disabled, the auto attack loop will be stopped.
-     * If the feature was disabled and it's toggled to enabled, the auto attack loop will be started.
+     * If the feature was enabled and it's toggled to disabled, the loop will be stopped.
+     * If the feature was disabled and it's toggled to enabled, the loop will be started.
      *
-     * @param enable: [Optional] If a boolean is passed, it will used to set the right state.
+     * @param enable: [Optional] If a boolean is passed, it will be used to set the right state.
      *                Otherwise, the cookie stored value will be used
      */
     static __toggleAutoFarming(enable)
@@ -1224,7 +1224,7 @@ class AutomationFarm
     {
         this.__unlockStrategySelection.push(
             {
-                // Check if the slot is unlocked
+                // Check if all berries are in sufficient amount
                 isNeeded: function()
                 {
                     return !berriesToGather.every((berryType) => (App.game.farming.berryList[berryType]() >= berriesMinAmount));
@@ -1234,7 +1234,7 @@ class AutomationFarm
                 forbiddenOakItem: null,
                 requiredPokemon: null,
                 requiresDiscord: false,
-                // If not unlocked, then farm some needed berries
+                // If not, then farm some needed berries
                 action: function()
                 {
                     let plotIndex = 0;

--- a/src/lib/Focus.js
+++ b/src/lib/Focus.js
@@ -1,0 +1,215 @@
+/**
+ * @class The AutomationFocus regroups the 'Focus on' button functionalities
+ */
+class AutomationFocus
+{
+    static __focusLoop = null;
+    static __activeFocus = null;
+    static __focusSelectElem = null;
+
+    static __functionalities = [];
+
+    /**
+     * @brief Initializes the component
+     */
+    static start()
+    {
+        this.__buildFunctionalitiesList();
+        this.__buildMenu();
+    }
+
+    /**
+     * @brief Builds the menu, and retores previous running state if needed
+     *
+     * The 'Focus on' functionality is disabled by default (if never set in a previous session)
+     */
+    static __buildMenu()
+    {
+        let focusFeatureId = "focusOnTopicEnabled";
+
+        // Disable 'Focus on' by default
+        if (localStorage.getItem(focusFeatureId) === null)
+        {
+            localStorage.setItem(focusFeatureId, false);
+        }
+
+        // Add the related buttons to the automation menu
+        let focusContainer = document.createElement("div");
+        focusContainer.style.textAlign = "center";
+        Automation.Menu.__automationButtonsDiv.appendChild(focusContainer);
+
+        Automation.Menu.__addSeparator(focusContainer);
+
+        // Add the title
+        let titleDiv = Automation.Menu.__createTitle("Focus on");
+        focusContainer.appendChild(titleDiv);
+
+        // Button and list container
+        let buttonContainer = document.createElement("div");
+        buttonContainer.style.textAlign = "right";
+        buttonContainer.classList.add("hasAutomationTooltip");
+        focusContainer.appendChild(buttonContainer);
+
+        // Add the drop-down list
+        this.__focusSelectElem = Automation.Menu.__createDropDownList("focusSelection");
+        this.__focusSelectElem.style.width = "calc(100% - 55px)";
+        this.__focusSelectElem.style.paddingLeft = "3px";
+        buttonContainer.appendChild(this.__focusSelectElem);
+
+        this.__populateFocusOptions();
+        this.__focusOnChanged(false);
+        this.__focusSelectElem.onchange = function() { Automation.Focus.__focusOnChanged(); };
+
+        // Add the 'Focus on' button
+        let focusButton = Automation.Menu.__createButtonElement(focusFeatureId);
+        focusButton.textContent = (localStorage.getItem(focusFeatureId) === "true") ? "On" : "Off";
+        focusButton.classList.add((localStorage.getItem(focusFeatureId) === "true") ? "btn-success" : "btn-danger");
+        focusButton.onclick = function() { Automation.Menu.__toggleButton(focusFeatureId) };
+        focusButton.style.marginTop = "3px";
+        focusButton.style.marginLeft = "5px";
+        focusButton.style.marginRight = "10px";
+        buttonContainer.appendChild(focusButton);
+
+        // Toggle the 'Focus on' loop on click
+        focusButton.addEventListener("click", this.__toggleFocus.bind(this), false);
+
+        // Restore previous session state
+        this.__toggleFocus();
+    }
+
+    /**
+     * @brief Toggles the 'Focus on' feature
+     *
+     * If the feature was enabled and it's toggled to disabled, the loop will be stopped.
+     * If the feature was disabled and it's toggled to enabled, the loop will be started.
+     *
+     * @param enable: [Optional] If a boolean is passed, it will be used to set the right state.
+     *                Otherwise, the cookie stored value will be used
+     */
+    static __toggleFocus(enable)
+    {
+        // If we got the click event, use the button status
+        if ((enable !== true) && (enable !== false))
+        {
+            enable = (localStorage.getItem("focusOnTopicEnabled") === "true");
+        }
+
+        if (enable)
+        {
+            // Only set a loop if there is none active
+            if (this.__focusLoop === null)
+            {
+                // Save the active focus
+                this.__activeFocus = this.__functionalities.filter((functionality) => functionality.id === this.__focusSelectElem.value)[0];
+
+                // First loop run (to avoid waiting too long before the first iteration, in case of long refresh rate)
+                this.__activeFocus.run();
+
+                // Set focus loop
+                this.__focusLoop = setInterval(this.__activeFocus.run, this.__activeFocus.refreshRateAsMs);
+            }
+        }
+        else
+        {
+            // Unregister the loop
+            clearInterval(this.__focusLoop);
+            this.__focusLoop = null;
+            this.__activeFocus = null;
+        }
+    }
+
+    /**
+     * @brief Build the list of available elements that the player will be able to set the focus on
+     */
+    static __buildFunctionalitiesList()
+    {
+        this.__functionalities.push({
+                                        id: "XP",
+                                        name: "Experience",
+                                        tooltip: "Automatically moves to the best route for EXP"
+                                               + Automation.Menu.__tooltipSeparator()
+                                               + "Such route is the highest unlocked one\n"
+                                               + "with HP lower than Click Attack",
+                                        run: function (){ this.__goToBestRouteForExp(); }.bind(this),
+                                        refreshRateAsMs: 10000 // Refresh every 10s
+                                    });
+    }
+
+    /**
+     * @brief Populates the drop-down list based on the registered functionalities
+     */
+    static __populateFocusOptions()
+    {
+        let lastAutomationFocusedTopic = localStorage.getItem("lastAutomationFocusedTopic");
+        this.__functionalities.forEach(
+            (functionality) =>
+            {
+                let opt = document.createElement("option");
+                opt.value = functionality.id;
+                opt.id = functionality.id;
+
+                if (lastAutomationFocusedTopic === functionality.id)
+                {
+                    // Restore previous session selected element
+                    opt.selected = true;
+                }
+
+                opt.textContent = functionality.name;
+
+                this.__focusSelectElem.options.add(opt);
+            });
+    }
+
+    /**
+     * @brief Updates the tooltip and action on selected value changed event
+     *
+     * If a 'Focus on' action was in progress, it will be stopped
+     *
+     * @param forceOff: If set to True (default value) the 'Focus on' feature will be turned off
+     */
+    static __focusOnChanged(forceOff = true)
+    {
+        // Stop the current loop if any, and turn the button off
+        if (forceOff)
+        {
+            // Stop the current loop if any, and disable the button
+            Automation.Menu.__forceAutomationState("focusOnTopicEnabled", false);
+        }
+
+        // Update the tooltip
+        let activeFocus = this.__functionalities.filter((functionality) => functionality.id === this.__focusSelectElem.value)[0];
+        this.__focusSelectElem.parentElement.setAttribute("automation-tooltip-text", activeFocus.tooltip);
+
+        // Save the last selected topic
+        localStorage.setItem("lastAutomationFocusedTopic", this.__focusSelectElem.value);
+    }
+
+    /**
+     * @brief Moves the player to the best route for EXP farming
+     *
+     * If the user is in a state in which he cannot be moved, the feature is automatically disabled.
+     *
+     * @todo (03/06/2022): Disable the button in such case to inform the user
+     *                     that the feature cannot be used at the moment
+     *
+     * @see Automation.Utils.Route.__moveToBestRouteForExp
+     */
+    static __goToBestRouteForExp()
+    {
+        // Ask the dungeon auto-fight to stop, if the feature is enabled
+        if (localStorage.getItem("dungeonFightEnabled") === "true")
+        {
+            Automation.Dungeon.__stopRequested = true;
+            return;
+        }
+
+        // Disable 'Focus on' if an instance is in progress, and exit
+        if (Automation.Utils.__isInInstanceState())
+        {
+            Automation.Menu.__forceAutomationState("focusOnTopicEnabled", false);
+            return;
+        }
+
+        Automation.Utils.Route.__moveToBestRouteForExp();
+    }
+}

--- a/src/lib/Focus.js
+++ b/src/lib/Focus.js
@@ -171,6 +171,52 @@ class AutomationFocus
                                               },
                                         refreshRateAsMs: 3000 // Refresh every 3s
                                     });
+
+        this.__addGemsFocusFunctionalities();
+    }
+
+    /**
+     * @brief Adds a separator to the focus drop-down list
+     *
+     * @param title: The separator text to display
+     */
+    static __addFunctionalitySeparator(title)
+    {
+        this.__functionalities.push({ id: "separator", name: title, tooltip: "" });
+    }
+
+    /**
+     * @brief Registers all gem focus features to the drop-down list
+     */
+    static __addGemsFocusFunctionalities()
+    {
+        this.__addFunctionalitySeparator("==== Gems ====");
+
+        [...Array(Gems.nTypes).keys()].forEach(
+            (gemType) =>
+            {
+                let gemTypeName = PokemonType[gemType];
+
+                this.__functionalities.push(
+                    {
+                        id: gemTypeName + "Gems",
+                        name: gemTypeName + " Gems",
+                        tooltip: "Moves to the best route to make " + gemTypeName + " gems"
+                            + Automation.Menu.__tooltipSeparator()
+                            + "The best route is the one that will give the most\n"
+                            + gemTypeName + " gems per game tick.",
+                        run: function ()
+                        {
+                            let { bestRoute, bestRouteRegion } = Automation.Utils.Route.__findBestRouteForFarmingType(gemType);
+                            if ((player.route() !== bestRoute) || (player.region !== bestRouteRegion))
+                            {
+                                Automation.Utils.Route.__moveToRoute(bestRoute, bestRouteRegion);
+                            }
+                        },
+                        stop: function (){},
+                        refreshRateAsMs: 10000 // Refresh every 10s
+                    });
+            }, this);
     }
 
     /**
@@ -183,15 +229,22 @@ class AutomationFocus
             (functionality) =>
             {
                 let opt = document.createElement("option");
-                opt.value = functionality.id;
-                opt.id = functionality.id;
 
-                if (lastAutomationFocusedTopic === functionality.id)
+                if (functionality.id == "separator")
                 {
-                    // Restore previous session selected element
-                    opt.selected = true;
+                    opt.disabled = true;
                 }
+                else
+                {
+                    opt.value = functionality.id;
+                    opt.id = functionality.id;
 
+                    if (lastAutomationFocusedTopic === functionality.id)
+                    {
+                        // Restore previous session selected element
+                        opt.selected = true;
+                    }
+                }
                 opt.textContent = functionality.name;
 
                 this.__focusSelectElem.options.add(opt);

--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -1,0 +1,278 @@
+/**
+ * @class The AutomationFocusAchievements regroups the 'Focus on' button 'Achievements' functionalities
+ */
+class AutomationFocusAchievements
+{
+    static __achievementLoop = null;
+    static __currentAchievement = null;
+
+    static __registerFunctionalities(functionalitiesList)
+    {
+        functionalitiesList.push(
+            {
+                id: "Achievements",
+                name: "Achievements",
+                tooltip: "Completes the pending achivements"
+                       + Automation.Menu.__tooltipSeparator()
+                       + "This feature handles the following achievements:\n"
+                       + "Route Kill, Clear Gym and Clear Dungeon\n"
+                       + "The achievements will be completed in region order.\n"
+                       + "The current achievement will be pinned to the tracker",
+                run: function (){ this.__start(); }.bind(this),
+                stop: function (){ this.__stop(); }.bind(this),
+                refreshRateAsMs: Automation.Focus.__noFunctionalityRefresh
+            });
+    }
+
+    static __start()
+    {
+        // Set achievement loop
+        this.__achievementLoop = setInterval(this.__focusOnAchievements.bind(this), 1000); // Runs every second
+    }
+
+    static __stop()
+    {
+        this.__currentAchievement = null;
+
+        // Unregister the loop
+        clearInterval(this.__achievementLoop);
+        this.__achievementLoop = null;
+
+        if (Automation.Utils.__isInInstanceState())
+        {
+            Automation.Dungeon.__stopRequested = true;
+        }
+        Automation.Menu.__forceAutomationState("gymFightEnabled", false);
+        App.game.pokeballs.alreadyCaughtSelection = GameConstants.Pokeball.None;
+    }
+
+    /**
+     * @brief The achievement main loop
+     */
+    static __focusOnAchievements()
+    {
+        // Already fighting, nothing to do for now
+        if (!Automation.Focus.__ensureNoInstanceIsInProgress())
+        {
+            return;
+        }
+
+        // Get a new achievement if needed
+        this.__updateTheAchievementIfNeeded();
+
+        // Work on the current achievement
+        this.__workOnAchievement();
+    }
+
+    /**
+     * @brief Updates the focused achievement if there is none, or the current one is completed
+     */
+    static __updateTheAchievementIfNeeded()
+    {
+        if ((this.__currentAchievement === null) || this.__currentAchievement.isCompleted())
+        {
+            this.__currentAchievement = this.__getNextAchievement();
+
+            if (this.__currentAchievement === null)
+            {
+                // No more achievements, stop the feature
+                Automation.Menu.__forceAutomationState("focusOnTopicEnabled", false);
+                Automation.Utils.__sendWarningNotif("No more achievement to automate.\nTurning the feature off", "Focus");
+
+                return;
+            }
+
+            App.game.achievementTracker.trackAchievement(this.__currentAchievement);
+        }
+    }
+
+    /**
+     * @brief Works on the currently selected achievement
+     */
+    static __workOnAchievement()
+    {
+        // Reset any equipped pokeball
+        App.game.pokeballs.alreadyCaughtSelection = GameConstants.Pokeball.None;
+
+        if (this.__currentAchievement.property instanceof RouteKillRequirement)
+        {
+            this.__workOnRouteKillRequirement();
+        }
+        else if (this.__currentAchievement.property instanceof ClearGymRequirement)
+        {
+            this.__workOnClearGymRequirement();
+        }
+        else if (this.__currentAchievement.property instanceof ClearDungeonRequirement)
+        {
+            this.__workOnClearDungeonRequirement();
+        }
+    }
+
+    /**
+     * @brief Works on a RouteKillRequirement.
+     *
+     * The player is moved to the achievement requested location to defeat pokemons
+     */
+    static __workOnRouteKillRequirement()
+    {
+        // Equip the Oak item Exp loadout
+        Automation.Utils.OakItem.__equipLoadout(Automation.Utils.OakItem.Setup.PokemonExp);
+
+        // Move to the selected route
+        Automation.Utils.Route.__moveToRoute(this.__currentAchievement.property.route, this.__currentAchievement.property.region);
+    }
+
+    /**
+     * @brief Works on a ClearGymRequirement.
+     *
+     * The player is moved to the achievement requested location and the 'Auto gym' fight is enabled
+     *
+     * @todo Merge with Automation.Quest.__workOnDefeatGymQuest()
+     */
+    static __workOnClearGymRequirement()
+    {
+        let gymName = GameConstants.RegionGyms.flat()[this.__currentAchievement.property.gymIndex];
+        let townToGoTo = gymName;
+
+        // If a ligue champion is the target, the gymTown points to the champion instead of the town
+        if (!TownList[townToGoTo])
+        {
+            townToGoTo = GymList[townToGoTo].parent.name;
+        }
+
+        // Move to the associated gym if needed
+        if ((player.route() != 0) || (townToGoTo !== player.town().name))
+        {
+            Automation.Utils.Route.__moveToTown(townToGoTo);
+        }
+        else if (localStorage.getItem("gymFightEnabled") === "false")
+        {
+            Automation.Menu.__forceAutomationState("gymFightEnabled", true);
+        }
+        else
+        {
+            // Select the right gym to fight
+            if (document.getElementById("selectedAutomationGym").value != gymName)
+            {
+                document.getElementById("selectedAutomationGym").value = gymName;
+            }
+        }
+    }
+
+    /**
+     * @brief Works on a ClearDungeonRequirement.
+     *
+     * If the player does not have enough dungeon token to enter the dungeon, some balls are equipped
+     * and the player is moved to the best road to farm some token.
+     * Otherwise, the player is moved to the achievement requested location, and the Auto Dungeon feature is enabled
+     *
+     * @see AutomationDungeon class
+     *
+     * @todo Merge with Automation.Quest.__workOnDefeatDungeonQuest()
+     */
+    static __workOnClearDungeonRequirement()
+    {
+        let targetedDungeonName = GameConstants.RegionDungeons.flat()[this.__currentAchievement.property.dungeonIndex];
+        // If we don't have enough tokens, go farm some
+        if (TownList[targetedDungeonName].dungeon.tokenCost > App.game.wallet.currencies[Currency.dungeonToken]())
+        {
+            Automation.Focus.__goToBestRouteForDungeonToken();
+            return;
+        }
+
+        // Move to dungeon if needed
+        if ((player.route() != 0) || targetedDungeonName !== player.town().name)
+        {
+            Automation.Utils.Route.__moveToTown(targetedDungeonName);
+
+            // Let a tick to the menu to show up
+            return;
+        }
+
+        // Disable pokedex stop
+        Automation.Menu.__forceAutomationState("stopDungeonAtPokedexCompletion", false);
+
+        // Enable auto dungeon fight
+        Automation.Menu.__forceAutomationState("dungeonFightEnabled", true);
+    }
+
+    /**
+     * @brief Gets the next achivement to complete
+     *
+     * @returns The pokeclicker Achievement object if any achievement is available, null otherwise
+     */
+    static __getNextAchievement()
+    {
+        let result = null;
+
+        let availableAchievements = AchievementHandler.achievementList.filter(
+            (achievement) =>
+            {
+                // Only handle supported kinds of achievements, if achievable and not already completed
+                if (achievement.isCompleted()
+                    || !achievement.achievable()
+                    || (achievement.region > player.highestRegion()))
+                {
+                    return false;
+                }
+
+                // Consider RouteKill achievements, if the player can move to the target route
+                if (achievement.property instanceof RouteKillRequirement)
+                {
+                    return (Automation.Utils.Route.__canMoveToRegion(achievement.region)
+                            && MapHelper.accessToRoute(achievement.property.route, achievement.property.region));
+                }
+
+                // Consider ClearGym achievements, if the player can move to the target town
+                if (achievement.property instanceof ClearGymRequirement)
+                {
+                    let townName = GameConstants.RegionGyms.flat()[achievement.property.gymIndex];
+
+                    // If a ligue champion is the target, the gymTown points to the champion instead of the town
+                    if (!TownList[townName])
+                    {
+                        townName = GymList[townName].parent.name;
+                    }
+
+                    return (Automation.Utils.Route.__canMoveToRegion(achievement.region)
+                            && MapHelper.accessToTown(townName));
+                }
+
+                // Consider ClearDungeon achievements, if the player can move to the target dungeon
+                if (achievement.property instanceof ClearDungeonRequirement)
+                {
+                    let dungeonName = GameConstants.RegionDungeons.flat()[achievement.property.dungeonIndex];
+                    return (Automation.Utils.Route.__canMoveToRegion(achievement.region)
+                            && MapHelper.accessToTown(dungeonName));
+                }
+
+                return false;
+            });
+
+        if (availableAchievements.length > 0)
+        {
+            result = availableAchievements.sort(
+                (a, b) =>
+                {
+                    // Favor lower region quests
+                    if (a.region < b.region) return -1;
+                    if (a.region > b.region) return 1;
+
+                    // Then route kill
+                    if (a.property instanceof RouteKillRequirement) return -1;
+                    if (b.property instanceof RouteKillRequirement) return 1;
+
+                    // Then Gym clear
+                    if (a.property instanceof ClearGymRequirement) return -1;
+                    if (b.property instanceof ClearGymRequirement) return 1;
+
+                    // Finally Dungeon clear
+                    if (a.property instanceof ClearDungeonRequirement) return -1;
+                    if (b.property instanceof ClearDungeonRequirement) return 1;
+                }
+            )[0];
+        }
+
+        return result;
+    }
+}

--- a/src/lib/Gym.js
+++ b/src/lib/Gym.js
@@ -40,10 +40,10 @@
     /**
      * @brief Toggles the 'Gym AutoFight' feature
      *
-     * If the feature was enabled and it's toggled to disabled, the auto attack loop will be stopped.
-     * If the feature was disabled and it's toggled to enabled, the auto attack loop will be started.
+     * If the feature was enabled and it's toggled to disabled, the loop will be stopped.
+     * If the feature was disabled and it's toggled to enabled, the loop will be started.
      *
-     * @param enable: [Optional] If a boolean is passed, it will used to set the right state.
+     * @param enable: [Optional] If a boolean is passed, it will be used to set the right state.
      *                Otherwise, the cookie stored value will be used
      */
     static __toggleGymFight(enable)

--- a/src/lib/Hatchery.js
+++ b/src/lib/Hatchery.js
@@ -88,10 +88,10 @@ class AutomationHatchery
     /**
      * @brief Toggles the 'Hatchery' feature
      *
-     * If the feature was enabled and it's toggled to disabled, the auto attack loop will be stopped.
-     * If the feature was disabled and it's toggled to enabled, the auto attack loop will be started.
+     * If the feature was enabled and it's toggled to disabled, the loop will be stopped.
+     * If the feature was disabled and it's toggled to enabled, the loop will be started.
      *
-     * @param enable: [Optional] If a boolean is passed, it will used to set the right state.
+     * @param enable: [Optional] If a boolean is passed, it will be used to set the right state.
      *                Otherwise, the cookie stored value will be used
      */
     static __toggleAutoHatchery(enable)

--- a/src/lib/Items.js
+++ b/src/lib/Items.js
@@ -47,19 +47,7 @@ class AutomationItems
         Automation.Menu.__addSeparator(this.__upgradeContainer);
 
         /** Title **/
-        let titleDiv = document.createElement("div");
-        titleDiv.style.textAlign = "center";
-        titleDiv.style.marginBottom = "3px";
-        let titleSpan = document.createElement("span");
-        titleSpan.textContent = "Auto Upgrade";
-        titleSpan.style.borderRadius = "4px";
-        titleSpan.style.borderWidth = "1px";
-        titleSpan.style.borderColor = "#aaaaaa";
-        titleSpan.style.borderStyle = "solid";
-        titleSpan.style.display = "block";
-        titleSpan.style.marginLeft = "10px";
-        titleSpan.style.marginRight = "10px";
-        titleDiv.appendChild(titleSpan);
+        let titleDiv = Automation.Menu.__createTitle("Auto Upgrade");
         this.__upgradeContainer.appendChild(titleDiv);
 
         /** Oak items **/
@@ -131,10 +119,10 @@ class AutomationItems
     /**
      * @brief Toggles the 'Oak Item Upgrade' feature
      *
-     * If the feature was enabled and it's toggled to disabled, the auto attack loop will be stopped.
-     * If the feature was disabled and it's toggled to enabled, the auto attack loop will be started.
+     * If the feature was enabled and it's toggled to disabled, the loop will be stopped.
+     * If the feature was disabled and it's toggled to enabled, the loop will be started.
      *
-     * @param enable: [Optional] If a boolean is passed, it will used to set the right state.
+     * @param enable: [Optional] If a boolean is passed, it will be used to set the right state.
      *                Otherwise, the cookie stored value will be used
      */
     static __toggleAutoOakUpgrade(enable)
@@ -165,10 +153,10 @@ class AutomationItems
     /**
      * @brief Toggles the 'Gem Upgrade' feature
      *
-     * If the feature was enabled and it's toggled to disabled, the auto attack loop will be stopped.
-     * If the feature was disabled and it's toggled to enabled, the auto attack loop will be started.
+     * If the feature was enabled and it's toggled to disabled, the loop will be stopped.
+     * If the feature was disabled and it's toggled to enabled, the loop will be started.
      *
-     * @param enable: [Optional] If a boolean is passed, it will used to set the right state.
+     * @param enable: [Optional] If a boolean is passed, it will be used to set the right state.
      *                Otherwise, the cookie stored value will be used
      */
     static __toggleAutoGemUpgrade(enable)

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -236,6 +236,9 @@ class AutomationMenu
         newSelect.style.width = "calc(100% - 10px)";
         newSelect.style.borderRadius = "4px";
         newSelect.style.marginTop = "3px";
+        newSelect.style.paddingTop = "0px";
+        newSelect.style.paddingBottom = "0px";
+        newSelect.style.height = "25px";
 
         return newSelect;
     }
@@ -266,6 +269,32 @@ class AutomationMenu
         newButton.style.verticalAlign = "middle";
 
         return newButton;
+    }
+
+    /**
+     * @brief Creates a title
+     *
+     * @param titleText: The text to display
+     *
+     * @returns The created element (It's the caller's responsibility to add it to the DOM at some point)
+     */
+    static __createTitle(titleText)
+    {
+        let titleDiv = document.createElement("div");
+        titleDiv.style.textAlign = "center";
+        titleDiv.style.marginBottom = "3px";
+        let titleSpan = document.createElement("span");
+        titleSpan.textContent = titleText;
+        titleSpan.style.borderRadius = "4px";
+        titleSpan.style.borderWidth = "1px";
+        titleSpan.style.borderColor = "#aaaaaa";
+        titleSpan.style.borderStyle = "solid";
+        titleSpan.style.display = "block";
+        titleSpan.style.marginLeft = "10px";
+        titleSpan.style.marginRight = "10px";
+        titleDiv.appendChild(titleSpan);
+
+        return titleDiv;
     }
 
     /**

--- a/src/lib/Quest.js
+++ b/src/lib/Quest.js
@@ -81,10 +81,10 @@ class AutomationQuest
     /**
      * @brief Toggles the 'Daily Quest' feature
      *
-     * If the feature was enabled and it's toggled to disabled, the auto attack loop will be stopped.
-     * If the feature was disabled and it's toggled to enabled, the auto attack loop will be started.
+     * If the feature was enabled and it's toggled to disabled, the loop will be stopped.
+     * If the feature was disabled and it's toggled to enabled, the loop will be started.
      *
-     * @param enable: [Optional] If a boolean is passed, it will used to set the right state.
+     * @param enable: [Optional] If a boolean is passed, it will be used to set the right state.
      *                Otherwise, the cookie stored value will be used
      */
     static __toggleAutoQuest(enable)
@@ -111,7 +111,7 @@ class AutomationQuest
                 // Disable other modes button
                 let disableReason = "The 'AutoQuests' feature is enabled";
                 Automation.Menu.__disableButton("autoClickEnabled", true, disableReason);
-                Automation.Menu.__disableButton("bestRouteClickEnabled", true, disableReason);
+                Automation.Menu.__disableButton("focusOnTopicEnabled", true, disableReason);
                 Automation.Menu.__disableButton("hatcheryAutomationEnabled", true, disableReason);
                 Automation.Menu.__disableButton("autoFarmingEnabled", true, disableReason);
                 Automation.Menu.__disableButton("autoUnlockFarmingEnabled", true, disableReason);
@@ -127,8 +127,8 @@ class AutomationQuest
                 Automation.Farm.__toggleAutoFarming(true);
                 Automation.Underground.__toggleAutoMining(true);
 
-                // Force disable best route mode
-                Automation.Click.__toggleBestRoute(false);
+                // Force disable the 'Focus on' mode
+                Automation.Focus.__toggleFocus(false);
             }
         }
         else if (this.__autoQuestLoop !== null)
@@ -143,13 +143,14 @@ class AutomationQuest
 
             // Reset other modes status
             Automation.Click.__toggleAutoClick();
+            Automation.Focus.__toggleFocus();
             Automation.Hatchery.__toggleAutoHatchery();
             Automation.Farm.__toggleAutoFarming();
             Automation.Underground.__toggleAutoMining();
 
             // Re-enable other modes button
             Automation.Menu.__disableButton("autoClickEnabled", false);
-            Automation.Menu.__disableButton("bestRouteClickEnabled", false);
+            Automation.Menu.__disableButton("focusOnTopicEnabled", false);
             Automation.Menu.__disableButton("hatcheryAutomationEnabled", false);
             Automation.Menu.__disableButton("autoFarmingEnabled", false);
             Automation.Menu.__disableButton("autoUnlockFarmingEnabled", false);

--- a/src/lib/Underground.js
+++ b/src/lib/Underground.js
@@ -64,10 +64,10 @@ class AutomationUnderground
     /**
      * @brief Toggles the 'Mining' feature
      *
-     * If the feature was enabled and it's toggled to disabled, the auto attack loop will be stopped.
-     * If the feature was disabled and it's toggled to enabled, the auto attack loop will be started.
+     * If the feature was enabled and it's toggled to disabled, the loop will be stopped.
+     * If the feature was disabled and it's toggled to enabled, the loop will be started.
      *
-     * @param enable: [Optional] If a boolean is passed, it will used to set the right state.
+     * @param enable: [Optional] If a boolean is passed, it will be used to set the right state.
      *                Otherwise, the cookie stored value will be used
      */
     static __toggleAutoMining(enable)


### PR DESCRIPTION
This feature replaces the 'Best route' one.

It is a button associated to a drop-down list of many possible focuses:
- Experience: Focus on earning experience to improve the player's pokemon
- Money: Focus on earning money fast (formerly the 'Best route' feature)
  It now uses Gyms since they give way more money than routes
- Dungeon tokens: Focus on earning Dungeon tokens fast
- Achievements: Focus on completing achievements, the following achievement types are implemented:
  - Route kill
  - Gym clear
  - Dungeon clear
- \<Type\> Gems: Focus on earning the selected \<Type\> of gems, fast