### PR TITLE
Utils: mutualize some code

### DIFF
--- a/src/lib/Dungeon.js
+++ b/src/lib/Dungeon.js
@@ -106,7 +106,7 @@ class AutomationDungeon
             //    - it was requested by another module
             //    - the pokedex is full for this dungeon, and it has been ask for
             if (this.__stopRequested
-                || ((localStorage.getItem("stopDungeonAtPokedexCompletion") == "true")
+                || ((localStorage.getItem("stopDungeonAtPokedexCompletion") === "true")
                     && DungeonRunner.dungeonCompleted(player.town().dungeon, false)))
             {
                 Automation.Menu.__forceAutomationState("dungeonFightEnabled", false);

--- a/src/lib/Farm.js
+++ b/src/lib/Farm.js
@@ -1294,6 +1294,8 @@ class AutomationFarm
         if (this.__internalStrategy === null)
         {
             this.__disableAutoUnlock("No more automated unlock possible");
+            Automation.Utils.__sendWarningNotif("No more automated unlock possible.\nDisabling the 'Auto unlock' feature",
+                                                "Farming");
             return;
         }
 
@@ -1429,7 +1431,7 @@ class AutomationFarm
     {
         if (this.__plantedBerryCount > 0)
         {
-            Automation.Utils.__sendNotif("Harvested " + this.__harvestCount.toString() + " berries<br>" + details);
+            Automation.Utils.__sendNotif("Harvested " + this.__harvestCount.toString() + " berries<br>" + details, "Farming");
         }
     }
 }

--- a/src/lib/Hatchery.js
+++ b/src/lib/Hatchery.js
@@ -200,7 +200,7 @@ class AutomationHatchery
             while ((i < filteredEggList.length) && App.game.breeding.hasFreeEggSlot())
             {
                 App.game.breeding.addPokemonToHatchery(filteredEggList[i]);
-                Automation.Utils.__sendNotif("Added " + filteredEggList[i].name + " to the Hatchery!");
+                Automation.Utils.__sendNotif("Added " + filteredEggList[i].name + " to the Hatchery!", "Hatchery");
                 i++;
             }
         }
@@ -236,7 +236,7 @@ class AutomationHatchery
                                                       || (App.game.breeding.eggList[index]().pokemonType2 === pokemonType))))
                 {
                     eggType.use();
-                    Automation.Utils.__sendNotif("Added a " + eggType.displayName + " to the Hatchery!");
+                    Automation.Utils.__sendNotif("Added a " + eggType.displayName + " to the Hatchery!", "Hatchery");
                 }
             }, this);
     }
@@ -273,7 +273,7 @@ class AutomationHatchery
             {
                 // Hatching a fossil is performed by selling it
                 Underground.sellMineItem(type.id);
-                Automation.Utils.__sendNotif("Added a " + type.name + " to the Hatchery!");
+                Automation.Utils.__sendNotif("Added a " + type.name + " to the Hatchery!", "Hatchery");
             }
 
             i++;

--- a/src/lib/Quest.js
+++ b/src/lib/Quest.js
@@ -535,7 +535,7 @@ class AutomationQuest
         if (hasBalls)
         {
             // Go to the highest route, for higher quest point income
-            this.__goToHighestDungeonTokenIncomeRoute(ballType);
+            Automation.Utils.Route.__moveToHighestDungeonTokenIncomeRoute(ballType);
         }
     }
 
@@ -674,60 +674,6 @@ class AutomationQuest
         }
 
         return true;
-    }
-
-    /**
-     * @brief Moves the player to the most suitable route for dungeon token farming
-     *
-     * Such route is the ine giving the most token per game tick
-     */
-    static __goToHighestDungeonTokenIncomeRoute(ballTypeToUse)
-    {
-        let bestRoute = 0;
-        let bestRouteRegion = 0;
-        let bestRouteIncome = 0;
-
-        let playerClickAttack = App.game.party.calculateClickAttack();
-        let catchTimeTicks = App.game.pokeballs.calculateCatchTime(ballTypeToUse) / 50;
-
-        // Fortunately routes are sorted by attack
-        Routes.regionRoutes.every(
-            (route) =>
-            {
-                if (!route.isUnlocked())
-                {
-                    return false;
-                }
-
-                // Skip any route that we can't access
-                if (!Automation.Utils.Route.__canMoveToRegion(route.region))
-                {
-                    return true;
-                }
-
-                let routeIncome = PokemonFactory.routeDungeonTokens(route.number, route.region);
-
-                let routeAvgHp = PokemonFactory.routeHealth(route.number, route.region);
-                if (routeAvgHp > playerClickAttack)
-                {
-                    let nbClickToDefeat = Math.ceil(routeAvgHp / playerClickAttack);
-                    routeIncome = routeIncome / (nbClickToDefeat + catchTimeTicks);
-                }
-
-                if (routeIncome > bestRouteIncome)
-                {
-                    bestRoute = route.number;
-                    bestRouteRegion = route.region;
-                    bestRouteIncome = routeIncome;
-                }
-
-                return true;
-            }, this);
-
-        if (player.route() !== bestRoute)
-        {
-            Automation.Utils.Route.__moveToRoute(bestRoute, bestRouteRegion);
-        }
     }
 
     /**

--- a/src/lib/Quest.js
+++ b/src/lib/Quest.js
@@ -62,31 +62,6 @@ class AutomationQuest
     }
 
     /**
-     * @class The OakItemSetup lists the different setup to use based on the current objectives
-     */
-    static OakItemSetup = class AutomationOakItemSetup
-    {
-        /**
-         * @brief The most efficient setup to catch pokemons
-         */
-        static PokemonCatch = [
-                                  OakItemType.Magic_Ball,
-                                  OakItemType.Shiny_Charm,
-                                  OakItemType.Poison_Barb,
-                                  OakItemType.Exp_Share
-                              ];
-        /**
-         * @brief The most efficient setup to increase the pokemon power and make money
-         */
-        static PokemonExp = [
-                                OakItemType.Poison_Barb,
-                                OakItemType.Amulet_Coin,
-                                OakItemType.Blaze_Cassette,
-                                OakItemType.Exp_Share
-                            ];
-    }
-
-    /**
      * @brief Watches for the in-game functionality to be unlocked.
      *        Once unlocked, the menu will be displayed to the user
      */
@@ -330,11 +305,11 @@ class AutomationQuest
             if (quest instanceof CatchShiniesQuest)
             {
                 this.__tryBuyBallIfUnderThreshold(GameConstants.Pokeball.Ultraball, 10);
-                this.__selectOwkItems(this.OakItemSetup.PokemonCatch);
+                Automation.Utils.OakItem.__equipLoadout(Automation.Utils.OakItem.Setup.PokemonCatch);
             }
             else
             {
-                this.__selectOwkItems(this.OakItemSetup.PokemonExp);
+                Automation.Utils.OakItem.__equipLoadout(Automation.Utils.OakItem.Setup.PokemonExp);
             }
 
             // Disable catching pokemons if enabled, and go to the best farming route
@@ -392,7 +367,7 @@ class AutomationQuest
 
         // Add a pokeball to the Caught type and set the PokemonCatch setup
         let hasBalls = this.__selectBallToCatch(GameConstants.Pokeball.Ultraball);
-        this.__selectOwkItems(this.OakItemSetup.PokemonCatch);
+        Automation.Utils.OakItem.__equipLoadout(Automation.Utils.OakItem.Setup.PokemonCatch);
 
         if (hasBalls && (player.route() !== bestRoute))
         {
@@ -492,7 +467,7 @@ class AutomationQuest
         {
             Automation.Utils.Route.__moveToRoute(quest.route, quest.region);
         }
-        this.__selectOwkItems(this.OakItemSetup.PokemonExp);
+        Automation.Utils.OakItem.__equipLoadout(Automation.Utils.OakItem.Setup.PokemonExp);
     }
 
     /**
@@ -505,7 +480,7 @@ class AutomationQuest
     static __workOnGainGemsQuest(quest)
     {
         this.__selectBallToCatch(GameConstants.Pokeball.None);
-        this.__selectOwkItems(this.OakItemSetup.PokemonExp);
+        Automation.Utils.OakItem.__equipLoadout(Automation.Utils.OakItem.Setup.PokemonExp);
 
         let { bestRoute, bestRouteRegion } = this.__findBestRouteForFarmingType(quest.type);
         Automation.Utils.Route.__moveToRoute(bestRoute, bestRouteRegion);
@@ -528,7 +503,7 @@ class AutomationQuest
         else
         {
             // Select the right oak item
-            let customOakLoadout = this.OakItemSetup.PokemonExp;
+            let customOakLoadout = Automation.Utils.OakItem.Setup.PokemonExp;
 
             // Remove the item from the default loadout if it already exists, so we are sure it ends up in the 1st position
             customOakLoadout = customOakLoadout.filter((item) => item !== quest.item);
@@ -536,7 +511,7 @@ class AutomationQuest
             // Prepend the needed item
             customOakLoadout.unshift(quest.item);
 
-            this.__selectOwkItems(customOakLoadout);
+            Automation.Utils.OakItem.__equipLoadout(customOakLoadout);
 
             // Go kill some pokemon
             this.__selectBallToCatch(GameConstants.Pokeball.None);
@@ -555,7 +530,7 @@ class AutomationQuest
     static __workOnUsePokeballQuest(ballType, enforceType = false)
     {
         let hasBalls = this.__selectBallToCatch(ballType, enforceType);
-        this.__selectOwkItems(this.OakItemSetup.PokemonCatch);
+        Automation.Utils.OakItem.__equipLoadout(Automation.Utils.OakItem.Setup.PokemonCatch);
 
         if (hasBalls)
         {
@@ -699,44 +674,6 @@ class AutomationQuest
         }
 
         return true;
-    }
-
-    /**
-     * @brief Updates the Oak item loadout with the provided @p loadoutCandidates
-     *
-     * The @p loadoutCandidates contains three items but the user might have less slots unlocked.
-     *
-     * @param loadoutCandidates: The wanted loadout composition
-     */
-    static __selectOwkItems(loadoutCandidates)
-    {
-        let possibleEquippedItem = 0;
-        let expectedLoadout = loadoutCandidates.filter(
-            (item) =>
-            {
-                // Skip any forbidden item
-                if (item === Automation.Quest.__forbiddenItem)
-                {
-                    return false;
-                }
-
-                if (App.game.oakItems.itemList[item].isUnlocked())
-                {
-                    if (possibleEquippedItem < App.game.oakItems.maxActiveCount())
-                    {
-                        possibleEquippedItem++;
-                        return true;
-                    }
-                }
-                return false;
-            });
-
-        App.game.oakItems.deactivateAll();
-        expectedLoadout.forEach(
-            (item) =>
-            {
-                App.game.oakItems.activate(item);
-            });
     }
 
     /**

--- a/src/lib/Underground.js
+++ b/src/lib/Underground.js
@@ -166,7 +166,8 @@ class AutomationUnderground
             if (nothingElseToDo)
             {
                 Automation.Utils.__sendNotif("Performed mining actions " + this.__actionCount.toString() + " times,"
-                                           + " energy left: " + Math.floor(App.game.underground.energy).toString() + "!");
+                                           + " energy left: " + Math.floor(App.game.underground.energy).toString() + "!",
+                                             "Mining");
                 clearInterval(miningLoop);
                 return;
             }

--- a/src/lib/Utils.js
+++ b/src/lib/Utils.js
@@ -105,8 +105,8 @@ class AutomationUtils
         /**
          * @brief Moves the player to the given @p route, in the @p region
          *
-         * @param route: The number of the route to move to
-         * @param region: The region number of the route to move to
+         * @param {number} route: The number of the route to move to
+         * @param {number} region: The region number of the route to move to
          *
          * @note If the @p route or @p region have not been unlocked, no move will happen
          */
@@ -154,7 +154,7 @@ class AutomationUtils
         /**
          * @brief Checks if the player is allowed to move to the given @p region
          *
-         * @param region: The region number to move to
+         * @param {number} region: The region number to move to
          *
          * @returns True if the player can mov to the region, False otherwise
          */
@@ -406,9 +406,9 @@ class AutomationUtils
         /**
          * @brief Computes the maximum number of click needed to defeat a pokemon with the given @p pokemonHp
          *
-         * @param pokemonHp: The HP of the pokemon to defeat
-         * @param playerClickAttack: The current player click attack
-         * @param totalAtkPerSecond: The players total attack per seconds (click + pokemon)
+         * @param {number} pokemonHp: The HP of the pokemon to defeat
+         * @param {number} playerClickAttack: The current player click attack
+         * @param {number} totalAtkPerSecond: The players total attack per seconds (click + pokemon)
          *
          * @returns The number of game ticks needed to defeat the pokemon
          */
@@ -499,19 +499,52 @@ class AutomationUtils
 
     /**
      * @brief Adds a pokeclicker notification using the given @p message
-     *        The notification is a blue one, without sound and with the "Automation" ttitle
+     *        The notification is a blue one, without sound and with the "Automation" title
      *
-     * @param message: The notification message
+     * @param {string} message: The notification message
+     * @param {string} module: [optional] The automation module name
      */
-    static __sendNotif(message)
+    static __sendNotif(message, module = null)
     {
         if (localStorage.getItem("automationNotificationsEnabled") == "true")
         {
+            let titleStr = "Automation";
+            if (module !== null)
+            {
+                titleStr += " > " + module;
+            }
+
             Notifier.notify({
-                                title: "Automation",
+                                title: titleStr,
                                 message: message,
                                 type: NotificationConstants.NotificationOption.primary,
                                 timeout: 3000,
+                            });
+        }
+    }
+
+    /**
+     * @brief Adds a pokeclicker warning notification using the given @p message
+     *        The notification is a yellow one, without sound and with the "Automation" title
+     *
+     * @param {string} message: The warning notification message
+     * @param {string} module: [optional] The automation module name
+     */
+    static __sendWarningNotif(message, module = null)
+    {
+        if (localStorage.getItem("automationNotificationsEnabled") == "true")
+        {
+            let titleStr = "Automation";
+            if (module !== null)
+            {
+                titleStr += " > " + module;
+            }
+
+            Notifier.notify({
+                                title: titleStr,
+                                message: message,
+                                type: NotificationConstants.NotificationOption.warning,
+                                timeout: 10000,
                             });
         }
     }
@@ -546,8 +579,8 @@ class AutomationUtils
      *   - Their length is the same
      *   - Their content is the same and at the same index
      *
-     * @param a: The first array
-     * @param b: The second array
+     * @param {Array} a: The first array
+     * @param {Array} b: The second array
      *
      * @returns True if the arrays are equals, False otherwise
      */

--- a/src/lib/Utils.js
+++ b/src/lib/Utils.js
@@ -12,9 +12,78 @@ class AutomationUtils
     }
 
     /**
+     * @class The OakItem inner-class
+     */
+    static OakItem = class AutomationOakItemUtils
+    {
+        /**
+         * @class The Setup class lists the different setup to use based on the current objectives
+         */
+        static Setup = class AutomationOakItemUtilsSetup
+        {
+            /**
+             * @brief The most efficient setup to catch pokemons
+             */
+            static PokemonCatch = [
+                                    OakItemType.Magic_Ball,
+                                    OakItemType.Shiny_Charm,
+                                    OakItemType.Poison_Barb,
+                                    OakItemType.Exp_Share
+                                ];
+            /**
+             * @brief The most efficient setup to increase the pokemon power and make money
+             */
+            static PokemonExp = [
+                                    OakItemType.Poison_Barb,
+                                    OakItemType.Amulet_Coin,
+                                    OakItemType.Blaze_Cassette,
+                                    OakItemType.Exp_Share
+                                ];
+        }
+
+        /**
+         * @brief Updates the Oak item loadout with the provided @p loadoutCandidates
+         *
+         * The @p loadoutCandidates contains three items but the user might have less slots unlocked.
+         *
+         * @param loadoutCandidates: The wanted loadout composition
+         */
+        static __equipLoadout(loadoutCandidates)
+        {
+            let possibleEquippedItem = 0;
+            let expectedLoadout = loadoutCandidates.filter(
+                (item) =>
+                {
+                    // Skip any forbidden item
+                    if (item === Automation.Quest.__forbiddenItem)
+                    {
+                        return false;
+                    }
+
+                    if (App.game.oakItems.itemList[item].isUnlocked())
+                    {
+                        if (possibleEquippedItem < App.game.oakItems.maxActiveCount())
+                        {
+                            possibleEquippedItem++;
+                            return true;
+                        }
+                    }
+                    return false;
+                });
+
+            App.game.oakItems.deactivateAll();
+            expectedLoadout.forEach(
+                (item) =>
+                {
+                    App.game.oakItems.activate(item);
+                });
+        }
+    }
+
+    /**
      * @class The Route inner-class
      */
-    static Route = class AutomationRouteUils
+    static Route = class AutomationRouteUtils
     {
         // Map of Map [ region => [ route => maxHp ]]
         static __routeMaxHealthMap = new Map();


### PR DESCRIPTION
Mutualize the Oak loadout management to Utils.OakItem

Mutualize route farming selection to the Utils.Route class
Improve the dungeon token and pokemon type farming route selection methods, by considering the pokemon attack in addition to the click attack (which is more relevant in end-game)

Add the module to the alert title, add the possibility to send warning alerts