### PR TITLE
Quest: Disable 'AutoQuests' mode by default

### DIFF
--- a/src/lib/Quest.js
+++ b/src/lib/Quest.js
@@ -14,7 +14,7 @@ class AutomationQuest
     /**
      * @brief Builds the menu, and retores previous running state if needed
      *
-     * The 'Use/buy Small Restore' functionality is disabled by default (if never set in a previous session)
+     * The 'Use/buy Small Restore' and 'AutoQuests' functionalities are disabled by default (if never set in a previous session)
      */
     static start()
     {
@@ -22,6 +22,12 @@ class AutomationQuest
         if (localStorage.getItem("autoUseSmallRestoreEnabled") === null)
         {
             localStorage.setItem("autoUseSmallRestoreEnabled", false);
+        }
+
+        // Disable Auto quest mode by default
+        if (localStorage.getItem("autoQuestEnabled") === null)
+        {
+            localStorage.setItem("autoQuestEnabled", false);
         }
 
         // Add the related button to the automation menu


### PR DESCRIPTION
A player loading the mode for the first time might be pretty disturbed
otherwise, as most menu would be greyed, the player would be moved 
to places....

This is not a suitable default setting, so it's now turned off by default