### PR TITLE
Mine: Fix the algorithm for larger underground

### DIFF
--- a/src/lib/Underground.js
+++ b/src/lib/Underground.js
@@ -276,7 +276,7 @@ class AutomationUnderground
     {
         let itemsState = new Map();
 
-        [...Array(Underground.sizeY).keys()].forEach(
+        [...Array(App.game.underground.getSizeY()).keys()].forEach(
             (row) =>
             {
                 [...Array(Underground.sizeX).keys()].forEach(


### PR DESCRIPTION
If the player buy the 'Larger underground' upgrade, the underground layout gains a row.

This is not reflected on the static property (which reflects the default row number).

The algorithm would be stuck in such case since it would never consider the last row.

The getSizeY method, which gives the number of rows based on the unlocked upgrades is now used.