### PR TITLE
Mine: Fixup crash when the the Larger Underground is unlocked

### DIFF
--- a/src/lib/Underground.js
+++ b/src/lib/Underground.js
@@ -281,10 +281,10 @@ class AutomationUnderground
     {
         let itemsState = new Map();
 
-        [...Array(App.game.underground.getSizeY()).keys()].forEach(
+        [...Array(Mine.rewardGrid.length).keys()].forEach(
             (row) =>
             {
-                [...Array(Underground.sizeX).keys()].forEach(
+                [...Array(Mine.rewardGrid[row].length).keys()].forEach(
                     (column) =>
                     {
                         let content = Mine.rewardGrid[row][column];


### PR DESCRIPTION
The size of the underground only increases on the next mine layout refresh.

The size of the current mine layout is now used instead of the underground attribut that define the size unlocked by the player.