### PR TITLE
Dungeon: Fixup player rushing to boss in some rare cases

### DIFF
--- a/src/lib/Dungeon.js
+++ b/src/lib/Dungeon.js
@@ -352,7 +352,9 @@ class AutomationDungeon
 
                             if (tile.type() === GameConstants.DungeonTile.boss)
                             {
-                                this.__isCompleted = true;
+                                // Only tag the dungeon as completed if it's not the first move or any tile is visited apart from the entrance
+                                this.__isCompleted = (!this.__isFirstMove)
+                                                  || DungeonRunner.map.board().some((row) => row.some((tile) => tile.isVisited && (tile.type() !== GameConstants.DungeonTile.entrance)));
                                 this.__bossPosition = currentLocation;
                             }
                         }


### PR DESCRIPTION
If the player has the flashlight (after defeating the dungeon more than 200 times), the tiles nearby the player are visible.
When entering a dungeon, if the boss is on a tile directly adjacent to the entrance, the script would rush for it immediately, since it's visible.

In case the player never moved, it's not the intended behavior.
The dungeon is now only tagged as completed if either:
- It's not the first moved
- Or:
  - The boss tile is visible or visited
  - The player visited at least a tile (apart from the entrance)
  
Fixes #31 