### PR TITLE
Focus.Quests: Fixup oak item not being selected

### DIFF
--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -753,7 +753,7 @@ class AutomationFocusQuests
 
         // Always equip UseOakItemQuest items 1st
         let useOakItemQuests = currentQuests.filter((quest) => quest instanceof UseOakItemQuest)
-        if (useOakItemQuests == 1)
+        if (useOakItemQuests.length == 1)
         {
             optimumItems.push(useOakItemQuests[0].item);
         }


### PR DESCRIPTION
The list was compared to 1 instead of the length of the list

Fixup #33