### PR TITLE
Focus.Achievements: Bypass the player's stop on pokedex option

### DIFF
--- a/src/lib/Dungeon.js
+++ b/src/lib/Dungeon.js
@@ -10,7 +10,6 @@ class AutomationDungeon
     static __bossPosition = null;
     static __chestPositions = [];
     static __previousTown = null;
-    static __stopRequested = false;
     static __isFirstMove = true;
     static __playerActionOccured = false;
 
@@ -18,6 +17,13 @@ class AutomationDungeon
                           FeatureEnabled: "Dungeon-FightEnabled",
                           StopOnPokedex: "Dungeon-FightStopOnPokedex"
                       };
+
+    static InternalMode = {
+                              None: 0,
+                              StopAfterThisRun: 1,
+                          };
+
+    static __internalModeRequested = this.InternalMode.None;
 
     /**
      * @brief Builds the menu
@@ -190,7 +196,7 @@ class AutomationDungeon
             // Reset button status if either:
             //    - it was requested by another module
             //    - the pokedex is full for this dungeon, and it has been ask for
-            if (this.__stopRequested
+            if ((this.__internalModeRequested == this.InternalMode.StopAfterThisRun)
                 || this.__playerActionOccured
                 || ((Automation.Utils.LocalStorage.getValue(this.Settings.StopOnPokedex) === "true")
                     && DungeonRunner.dungeonCompleted(player.town().dungeon, this.__isShinyCatchStopMode)))
@@ -201,7 +207,7 @@ class AutomationDungeon
                 }
 
                 Automation.Menu.__forceAutomationState(this.Settings.FeatureEnabled, false);
-                this.__stopRequested = false;
+                this.__internalModeRequested = this.InternalMode.None;
             }
             else
             {
@@ -458,13 +464,13 @@ class AutomationDungeon
     /**
      * @brief Adds the given @p position to the check list, if not already added.
      */
-     static __addChestPosition(position)
-     {
-         if (!this.__chestPositions.some((pos) => (pos.x == position.x) && (pos.y == position.y)))
-         {
-             this.__chestPositions.push(position);
-         }
-     }
+    static __addChestPosition(position)
+    {
+        if (!this.__chestPositions.some((pos) => (pos.x == position.x) && (pos.y == position.y)))
+        {
+            this.__chestPositions.push(position);
+        }
+    }
 
     /**
      * @brief Resets the internal data for the next run

--- a/src/lib/Dungeon.js
+++ b/src/lib/Dungeon.js
@@ -21,6 +21,7 @@ class AutomationDungeon
     static InternalMode = {
                               None: 0,
                               StopAfterThisRun: 1,
+                              ByPassUserSettings: 2
                           };
 
     static __internalModeRequested = this.InternalMode.None;
@@ -196,10 +197,11 @@ class AutomationDungeon
             // Reset button status if either:
             //    - it was requested by another module
             //    - the pokedex is full for this dungeon, and it has been ask for
-            if ((this.__internalModeRequested == this.InternalMode.StopAfterThisRun)
-                || this.__playerActionOccured
-                || ((Automation.Utils.LocalStorage.getValue(this.Settings.StopOnPokedex) === "true")
-                    && DungeonRunner.dungeonCompleted(player.town().dungeon, this.__isShinyCatchStopMode)))
+            if ((this.__internalModeRequested != this.InternalMode.ByPassUserSettings)
+                && ((this.__internalModeRequested == this.InternalMode.StopAfterThisRun)
+                    || this.__playerActionOccured
+                    || ((Automation.Utils.LocalStorage.getValue(this.Settings.StopOnPokedex) === "true")
+                        && DungeonRunner.dungeonCompleted(player.town().dungeon, this.__isShinyCatchStopMode))))
             {
                 if (this.__playerActionOccured)
                 {
@@ -427,7 +429,8 @@ class AutomationDungeon
             }
 
             // The 'stop on pokedex' feature might be enable and the pokedex already completed
-            if ((Automation.Utils.LocalStorage.getValue(this.Settings.StopOnPokedex) == "true")
+            if ((this.__internalModeRequested != this.InternalMode.ByPassUserSettings)
+                && (Automation.Utils.LocalStorage.getValue(this.Settings.StopOnPokedex) == "true")
                 && DungeonRunner.dungeonCompleted(player.town().dungeon, this.__isShinyCatchStopMode))
             {
                 disableNeeded = true;

--- a/src/lib/Focus.js
+++ b/src/lib/Focus.js
@@ -536,7 +536,7 @@ class AutomationFocus
         // Ask the dungeon auto-fight to stop, if the feature is enabled
         if (Automation.Utils.LocalStorage.getValue(Automation.Dungeon.Settings.FeatureEnabled) === "true")
         {
-            Automation.Dungeon.__stopRequested = true;
+            Automation.Dungeon.__internalModeRequested = Automation.Dungeon.InternalMode.StopAfterThisRun;
             return false;
         }
 

--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -52,7 +52,7 @@ class AutomationFocusAchievements
 
         if (Automation.Utils.__isInInstanceState())
         {
-            Automation.Dungeon.__stopRequested = true;
+            Automation.Dungeon.__internalModeRequested = Automation.Dungeon.InternalMode.StopAfterThisRun;
         }
         Automation.Menu.__forceAutomationState(Automation.Gym.Settings.FeatureEnabled, false);
         App.game.pokeballs.alreadyCaughtSelection = GameConstants.Pokeball.None;

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -103,7 +103,7 @@ class AutomationFocusQuests
 
         // Reset demands
         Automation.Farm.__forcePlantBerriesAsked = false;
-        Automation.Dungeon.__stopRequested = false;
+        Automation.Dungeon.__internalModeRequested = Automation.Dungeon.InternalMode.None;
 
         // Reset other modes status
         Automation.Click.__toggleAutoClick();
@@ -199,10 +199,10 @@ class AutomationFocusQuests
         // Already fighting, nothing to do for now
         if (Automation.Utils.__isInInstanceState())
         {
-            Automation.Dungeon.__stopRequested = true;
+            Automation.Dungeon.__internalModeRequested = Automation.Dungeon.InternalMode.StopAfterThisRun;
             return;
         }
-        Automation.Dungeon.__stopRequested = false;
+        Automation.Dungeon.__internalModeRequested = Automation.Dungeon.InternalMode.None;
 
         let currentQuests = App.game.quests.currentQuests();
         if (currentQuests.length == 0)

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -368,8 +368,8 @@ class AutomationFocusQuests
             return;
         }
 
-        // Disable pokedex stop
-        Automation.Menu.__forceAutomationState("stopDungeonAtPokedexCompletion", false);
+        // Bypass user settings like the stop on pokedex one
+        Automation.Dungeon.__internalModeRequested = Automation.Dungeon.InternalMode.ByPassUserSettings;
 
         // Enable auto dungeon fight
         Automation.Menu.__forceAutomationState(Automation.Dungeon.Settings.FeatureEnabled, true);


### PR DESCRIPTION
If the player enabled the 'stop on pokedex' option and a quest or an achievement needed to complete a dungeon in which all pokemon were caught, the button wass disabled and the dungeon would never start.

The automation can now request to bypass the user settings for dungeon

Fixes #30