### PR TITLE
Focus.Gems: Use gyms in priority to farm gems

### DIFF
--- a/src/ComponentLoader.js
+++ b/src/ComponentLoader.js
@@ -26,6 +26,7 @@ class AutomationComponentLoader
         // From the least dependant, to the most dependent
         this.__addScript("src/lib/Focus/Achievements.js");
         this.__addScript("src/lib/Focus/Quests.js");
+        this.__addScript("src/lib/Utils/Gym.js");
         this.__addScript("src/lib/Utils/LocalStorage.js");
         this.__addScript("src/lib/Utils/OakItem.js");
         this.__addScript("src/lib/Utils/Route.js");

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -21,7 +21,7 @@ class AutomationFocusQuests
             {
                 id: "Quests",
                 name: "Quests",
-                tooltip: "Automatically add and complete quests"
+                tooltip: "Automatically adds and completes quests"
                        + Automation.Menu.__tooltipSeparator()
                        + "This mode fully automates quest completion\n"
                        + "It automatically equips Oak items and balls\n"

--- a/src/lib/Utils.js
+++ b/src/lib/Utils.js
@@ -4,6 +4,7 @@
 class AutomationUtils
 {
     // Aliases on the other classes
+    static Gym = AutomationUtilsGym;
     static LocalStorage = AutomationUtilsLocalStorage;
     static OakItem = AutomationUtilsOakItem;
     static Route = AutomationUtilsRoute;
@@ -15,6 +16,7 @@ class AutomationUtils
      */
     static initialize(initStep)
     {
+        this.Gym.initialize(initStep);
         this.Route.initialize(initStep);
     }
 

--- a/src/lib/Utils/Gym.js
+++ b/src/lib/Utils/Gym.js
@@ -1,0 +1,146 @@
+/**
+ * @class The AutomationUtilsGym regroups helpers related to pokeclicker gyms
+ */
+class AutomationUtilsGym
+{
+    /**
+     * @brief Initializes the class members
+     *
+     * @param initStep: The current automation init step
+     */
+    static initialize(initStep)
+    {
+        // Only consider the Finalize init step
+        if (initStep != Automation.InitSteps.Finalize) return;
+
+        this.__internal__buildGymGemTypeMap();
+    }
+
+    /**
+     * @brief Finds the best available gym to farm the given @p pokemonType gems/pokemons
+     *
+     * The best gym is the one that will give the most gems per game tick
+     *
+     * @param pokemonType: The pokemon type to look for
+     *
+     * @returns Null if no gym could be found, or a struct { bestGymName, bestGymTown }, where:
+     *          @c bestGymName is the best gym name
+     *          @c bestGymTown is the best gym town name
+     */
+    static findBestGymForFarmingType(pokemonType)
+    {
+        let bestGymName = null;
+        let bestGymTown = null;
+        let bestGymRate = 0;
+
+        let playerClickAttack = App.game.party.calculateClickAttack();
+        let playerWorstPokemonAttack = Automation.Utils.Route.__getPlayerWorstPokemonAttack();
+        let totalAtkPerSecond = (20 * playerClickAttack) + playerWorstPokemonAttack;
+
+        this.__internal__gymGemTypeMap.get(pokemonType).forEach(
+            (gymData) =>
+            {
+                let gym = GymList[gymData.gymName];
+
+                // Skip any gym that we can't access
+                if (!gym.isUnlocked()
+                    || !Automation.Utils.Route.__canMoveToRegion(gymData.region))
+                {
+                    return;
+                }
+
+                let currentGymGemPerTick = 0;
+                gym.pokemons.forEach(
+                    (pokemon) =>
+                    {
+                        let pokemonData = pokemonMap[pokemon.name];
+                        if (!pokemonData.type.includes(pokemonType))
+                        {
+                            return;
+                        }
+
+                        let currentPokemonTickToDefeat = Automation.Utils.Route.__getGameTickCountNeededToDefeatPokemon(pokemon.maxHealth, playerClickAttack, totalAtkPerSecond);
+                        currentGymGemPerTick += (GameConstants.GYM_GEMS / currentPokemonTickToDefeat);
+                    });
+
+                // TODO (26/06/2022): Be more precise, all pokemons do not have the same health
+                currentGymGemPerTick /= gym.pokemons.length;
+
+                if (currentGymGemPerTick > bestGymRate)
+                {
+                    bestGymName = gymData.gymName;
+                    bestGymTown = gymData.gymTown;
+                    bestGymRate = currentGymGemPerTick;
+                }
+            });
+
+        return (bestGymName !== null) ? { Name: bestGymName, Town: bestGymTown } : null;
+    }
+
+    /******************************************************************\
+    |***    Internal data, should never be used by other classes    ***|
+    \******************************************************************/
+
+    static __internal__gymGemTypeMap = new Map();
+
+    /**
+     * @brief Builds the [ gemType => list(gyms)] map of list of gyms for each pokemon type
+     *
+     * The resulting map is stored as a member of this class @c __internal__gymGemTypeMap for further use
+     */
+    static __internal__buildGymGemTypeMap()
+    {
+        // Initialize the map for each gem types
+        [...Array(Gems.nTypes).keys()].forEach(
+            (gemType) =>
+            {
+                this.__internal__gymGemTypeMap.set(gemType, []);
+            }, this);
+
+        Object.keys(GymList).forEach(
+            (gymName) =>
+            {
+                let gym = GymList[gymName];
+
+                gym.pokemons.forEach(
+                    (pokemon) =>
+                    {
+                        let pokemonData = pokemonMap[pokemon.name];
+
+                        pokemonData.type.forEach(
+                            (type) =>
+                            {
+                                let gemTypeData = this.__internal__gymGemTypeMap.get(type);
+
+                                if ((gemTypeData.length == 0) || gemTypeData[gemTypeData.length - 1].gymName != gymName)
+                                {
+                                    let gymTown = gym.town;
+                                    // If a ligue champion is the target, the gymTown points to the champion instead of the town
+                                    if (!TownList[gymTown])
+                                    {
+                                        // If this happens, then it's a work in progress in pokeclicker code-base
+                                        if (gym.parent == undefined)
+                                        {
+                                            return;
+                                        }
+
+                                        gymTown = gym.parent.name;
+                                    }
+
+                                    gemTypeData.push({
+                                                         gymName: gymName,
+                                                         gymTown: gymTown,
+                                                         region: TownList[gymTown].region,
+                                                         pokemonMathingType: 1,
+                                                         totalPokemons: gym.pokemons.length
+                                                     });
+                                }
+                                else
+                                {
+                                    gemTypeData[gemTypeData.length - 1].pokemonMathingType += 1;
+                                }
+                            }, this);
+                    }, this);
+            }, this);
+    }
+}


### PR DESCRIPTION
Gyms give way more gems per kill.
If no gym is available for a given gem type, the route will be considered as before.

Fixes #22