### PR TITLE
Dungeon: Don't disable the button if the player is still in the dungeon

### DIFF
--- a/src/lib/Dungeon.js
+++ b/src/lib/Dungeon.js
@@ -415,7 +415,9 @@ class AutomationDungeon
                               || ((App.game.gameState === GameConstants.GameState.town)
                                   && (player.town() instanceof DungeonTown)));
 
-        if (!dungeonDiv.hidden)
+        // Don't disable the button if the player is still in the dungeon
+        if (!dungeonDiv.hidden
+            && (App.game.gameState !== GameConstants.GameState.dungeon))
         {
             // Disable the AutoFight button if the requirements are not met
             let disableNeeded = false;


### PR DESCRIPTION
If the player is still in the dungeon, he won't be able to turn the feature off if needed.

The button is now disabled only if the player is not within a dungeon instance

Fixes #41