### PR TITLE
Focus.Achievements: Fixup the achievements filtering method

### DIFF
--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -257,7 +257,8 @@ class AutomationFocusAchievements
                     }
 
                     return (Automation.Utils.Route.__canMoveToRegion(achievement.region)
-                            && MapHelper.accessToTown(townName));
+                            && MapHelper.accessToTown(townName)
+                            && GymList[townName].isUnlocked());
                 }
 
                 // Consider ClearDungeon achievements, if the player can move to the target dungeon
@@ -281,14 +282,17 @@ class AutomationFocusAchievements
                     if (a.region > b.region) return 1;
 
                     // Then route kill
+                    if ((a.property instanceof RouteKillRequirement) && (b.property instanceof RouteKillRequirement)) return 0;
                     if (a.property instanceof RouteKillRequirement) return -1;
                     if (b.property instanceof RouteKillRequirement) return 1;
 
                     // Then Gym clear
+                    if ((a.property instanceof ClearGymRequirement) && (b.property instanceof ClearGymRequirement)) return 0;
                     if (a.property instanceof ClearGymRequirement) return -1;
                     if (b.property instanceof ClearGymRequirement) return 1;
 
                     // Finally Dungeon clear
+                    if ((a.property instanceof ClearDungeonRequirement) && (b.property instanceof ClearDungeonRequirement)) return 0;
                     if (a.property instanceof ClearDungeonRequirement) return -1;
                     if (b.property instanceof ClearDungeonRequirement) return 1;
                 }


### PR DESCRIPTION
The gym can be listed because the town was unlocked, but still be locked.
The gym unlocked state is now checked in the achievements filter.

---

On Chrome, the initial order was not preserved after the reorder call.
This was due to not handling equals elements properly, which is the only way to preserve the order.

Fixes #56 