### PR TITLE
Loader: Don't load and run before the game is fully instantiated

### DIFF
--- a/src/ComponentLoader.js
+++ b/src/ComponentLoader.js
@@ -108,9 +108,8 @@ class AutomationComponentLoader
     }
 
     /**
-     * @brief Sets a loading watcher.
-     *        Once all scripts are properly loaded, the main class is loaded.
-     *        Once done, it runs the automation.
+     * @brief Sets a loading watcher which prevent loading the automation before the game components are fully up and running.
+     *        Once all scripts are properly loaded, it runs the automation.
      */
     static __setupAutomationRunner()
     {
@@ -119,8 +118,9 @@ class AutomationComponentLoader
         let watcher = setInterval(function ()
             {
                 let isLoadingCompleted = Object.keys(this.__loadingProgressTable).every(key => this.__loadingProgressTable[key]);
+                let isGameStarted = (App && App.game && App.game.worker && (App.game.worker instanceof Worker));
 
-                if (!isLoadingCompleted)
+                if (!isLoadingCompleted || !isGameStarted)
                 {
                     return;
                 }


### PR DESCRIPTION
Running the game on a low-end environment (a raspberry pi for instance) can take a significant amount of time before it's up and running.

This could cause the menu to request game components that are not yet existing or instantiated.

The loader now makes sure the game is properly loaded before loading the automation.