### PR TITLE
Farm: Fix the harvesting method while doing quests

### DIFF
--- a/src/lib/Farm.js
+++ b/src/lib/Farm.js
@@ -260,6 +260,7 @@ class AutomationFarm
                 }
 
                 if ((Automation.Utils.LocalStorage.getValue(this.Settings.FocusOnUnlocks) === "false")
+                    || this.ForcePlantBerriesAsked
                     || (this.__internal__currentStrategy === null)
                     || (this.__internal__currentStrategy.harvestAsSoonAsPossible === true)
                     || ((plot.berryData.growthTime[4] - plot.age) < 15))


### PR DESCRIPTION
While the `Focus on quest` feature is enabled, the script will switch to Cheri berries to avoid occupying the farm with long riping ones.
It also asks the Farming automation to harvest berries as fast as possible.

However, this parameter was not considered by the harvest method.
It's now properly done.