### PR TITLE
Utils.Route: Don't move the player not necessary

### DIFF
--- a/src/lib/Dungeon.js
+++ b/src/lib/Dungeon.js
@@ -74,7 +74,6 @@ class AutomationDungeon
     static __internal__isCompleted = false;
     static __internal__bossPosition = null;
     static __internal__chestPositions = [];
-    static __internal__previousTown = null;
     static __internal__isFirstMove = true;
     static __internal__playerActionOccured = false;
 
@@ -196,8 +195,6 @@ class AutomationDungeon
             && App.game.keyItems.hasKeyItem(KeyItemType.Dungeon_ticket)
             && (App.game.wallet.currencies[GameConstants.Currency.dungeonToken]() >= player.town().dungeon.tokenCost))
         {
-            this.__internal__previousTown = player.town().name;
-
             // Reset button status if either:
             //    - it was requested by another module
             //    - the pokedex is full for this dungeon, and it has been ask for
@@ -323,7 +320,6 @@ class AutomationDungeon
         // Else hide the menu and turn off the feature, if we're not in the dungeon anymore
         else
         {
-            this.__internal__previousTown = null;
             this.__internal__playerActionOccured = false;
             this.__internal__resetSavedStates();
             Automation.Menu.forceAutomationState(this.Settings.FeatureEnabled, false);

--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -171,7 +171,7 @@ class AutomationFocusAchievements
         }
 
         // Move to the associated gym if needed
-        if ((player.route() != 0) || (townToGoTo !== player.town().name))
+        if (!Automation.Utils.Route.isPlayerInTown(townToGoTo))
         {
             Automation.Utils.Route.moveToTown(townToGoTo);
         }
@@ -211,7 +211,7 @@ class AutomationFocusAchievements
         }
 
         // Move to dungeon if needed
-        if ((player.route() != 0) || targetedDungeonName !== player.town().name)
+        if (!Automation.Utils.Route.isPlayerInTown(targetedDungeonName))
         {
             Automation.Utils.Route.moveToTown(targetedDungeonName);
 

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -381,7 +381,7 @@ class AutomationFocusQuests
         this.__internal__selectBallToCatch(GameConstants.Pokeball.None);
 
         // Move to dungeon if needed
-        if ((player.route() != 0) || quest.dungeon !== player.town().name)
+        if (!Automation.Utils.Route.isPlayerInTown(quest.dungeon))
         {
             Automation.Utils.Route.moveToTown(quest.dungeon);
 
@@ -416,7 +416,7 @@ class AutomationFocusQuests
         }
 
         // Move to the associated gym if needed
-        if ((player.route() != 0) || (townToGoTo !== player.town().name))
+        if (!Automation.Utils.Route.isPlayerInTown(townToGoTo))
         {
             Automation.Utils.Route.moveToTown(townToGoTo);
         }

--- a/src/lib/Utils/Route.js
+++ b/src/lib/Utils/Route.js
@@ -45,6 +45,12 @@ class AutomationUtilsRoute
      */
     static moveToTown(townName)
     {
+        // If the player is already in the right town, there's nothing to do
+        if (this.isPlayerInTown(townName))
+        {
+            return;
+        }
+
         let town = TownList[townName];
 
         // Don't move if the game would not allow it
@@ -63,6 +69,19 @@ class AutomationUtilsRoute
         }
 
         MapHelper.moveToTown(townName);
+    }
+
+    /**
+     * @brief Checks if the player is in the provided @p townName
+     *
+     * @param {string} townName: The name of the town to check
+     *
+     * @returns True if the player is in the town, false otherwise
+     */
+    static isPlayerInTown(townName)
+    {
+        // player.town() points to the last visited town, so we need to check if the current route is 0 as well
+        return (player.route() == 0) && (player.town().name == townName);
     }
 
     /**
@@ -138,7 +157,7 @@ class AutomationUtilsRoute
                 (route) =>
                 {
                     // Skip any route that we can't access
-                    if (!Automation.Utils.Route.canMoveToRegion(route.region))
+                    if (!this.canMoveToRegion(route.region))
                     {
                         return true;
                     }


### PR DESCRIPTION
If the player was already in the right town, he would be moved anyway.
This broke gym automation if the player could not kill all pokemon fast enough, since moving in such case would reset the gym.

The player is not moved anymore if already in the right town.

Fixes #67 