### PR TITLE
Shop: Add a new Shop auto buy feature

### DIFF
--- a/src/Automation.js
+++ b/src/Automation.js
@@ -12,6 +12,7 @@ class Automation
     static Hatchery = AutomationHatchery;
     static Items = AutomationItems;
     static Menu = AutomationMenu;
+    static Shop = AutomationShop;
     static Trivia = AutomationTrivia;
     static Underground = AutomationUnderground;
     static Utils = AutomationUtils;
@@ -52,6 +53,7 @@ class Automation
                     this.Hatchery.initialize(initStep);
                     this.Underground.initialize(initStep);
                     this.Farm.initialize(initStep);
+                    this.Shop.initialize(initStep);
                     this.Items.initialize(initStep);
 
                     // 'Trivia' panel

--- a/src/ComponentLoader.js
+++ b/src/ComponentLoader.js
@@ -40,6 +40,7 @@ class AutomationComponentLoader
         this.__addScript("src/lib/Hatchery.js");
         this.__addScript("src/lib/Items.js");
         this.__addScript("src/lib/Menu.js");
+        this.__addScript("src/lib/Shop.js");
         this.__addScript("src/lib/Trivia.js");
         this.__addScript("src/lib/Underground.js");
         this.__addScript("src/lib/Utils.js");

--- a/src/lib/Click.js
+++ b/src/lib/Click.js
@@ -35,7 +35,7 @@ class AutomationClick
      * If the feature was disabled and it's toggled to enabled, the auto attack loop will be started.
      *
      * @param enable: [Optional] If a boolean is passed, it will be used to set the right state.
-     *                Otherwise, the cookie stored value will be used
+     *                Otherwise, the local storage value will be used
      */
     static toggleAutoClick(enable)
     {

--- a/src/lib/Dungeon.js
+++ b/src/lib/Dungeon.js
@@ -142,7 +142,7 @@ class AutomationDungeon
      * If the feature was disabled and it's toggled to enabled, the loop will be started.
      *
      * @param enable: [Optional] If a boolean is passed, it will be used to set the right state.
-     *                Otherwise, the cookie stored value will be used
+     *                Otherwise, the local storage value will be used
      */
     static __internal__toggleDungeonFight(enable)
     {

--- a/src/lib/Farm.js
+++ b/src/lib/Farm.js
@@ -41,7 +41,7 @@ class AutomationFarm
      * If the feature was disabled and it's toggled to enabled, the loop will be started.
      *
      * @param enable: [Optional] If a boolean is passed, it will be used to set the right state.
-     *                Otherwise, the cookie stored value will be used
+     *                Otherwise, the local storage value will be used
      */
     static toggleAutoFarming(enable)
     {
@@ -103,7 +103,7 @@ class AutomationFarm
     static __internal__currentStrategy = null;
 
     /**
-     * @brief Builds the menu, and retores previous running state if needed
+     * @brief Builds the menu, and restores the previous running state if needed
      */
     static __internal__buildMenu()
     {

--- a/src/lib/Farm.js
+++ b/src/lib/Farm.js
@@ -136,7 +136,10 @@ class AutomationFarm
         farmingSettingPanel.appendChild(titleDiv);
 
         let unlockTooltip = "Takes the necessary actions to unlock new slots and berries";
-        Automation.Menu.addToggleButton("Focus on unlocking plots and new berries", this.Settings.FocusOnUnlocks, unlockTooltip, farmingSettingPanel);
+        Automation.Menu.addLabeledAdvancedSettingsToggleButton("Focus on unlocking plots and new berries",
+                                                               this.Settings.FocusOnUnlocks,
+                                                               unlockTooltip,
+                                                               farmingSettingPanel);
     }
 
     /**

--- a/src/lib/Focus.js
+++ b/src/lib/Focus.js
@@ -22,6 +22,9 @@ class AutomationFocus
         // Only consider the BuildMenu init step
         if (initStep == Automation.InitSteps.BuildMenu)
         {
+            // Disable 'Focus on' by default
+            Automation.Utils.LocalStorage.setDefaultValue(this.Settings.FeatureEnabled, false);
+
             this.__internal__buildFunctionalitiesList();
             this.__internal__buildMenu();
         }
@@ -144,15 +147,12 @@ class AutomationFocus
     static __internal__lastFocusData = null;
 
     /**
-     * @brief Builds the menu, and retores previous running state if needed
+     * @brief Builds the menu, and restores the previous running state if needed
      *
      * The 'Focus on' functionality is disabled by default (if never set in a previous session)
      */
     static __internal__buildMenu()
     {
-        // Disable 'Focus on' by default
-        Automation.Utils.LocalStorage.setDefaultValue(this.Settings.FeatureEnabled, false);
-
         // Add the related buttons to the automation menu
         let focusContainer = document.createElement("div");
         focusContainer.style.textAlign = "center";
@@ -205,7 +205,7 @@ class AutomationFocus
      * If the feature was disabled and it's toggled to enabled, the loop will be started.
      *
      * @param enable: [Optional] If a boolean is passed, it will be used to set the right state.
-     *                Otherwise, the cookie stored value will be used
+     *                Otherwise, the local storage value will be used
      */
     static __internal__toggleFocus(enable)
     {

--- a/src/lib/Gym.js
+++ b/src/lib/Gym.js
@@ -55,7 +55,7 @@
      * If the feature was disabled and it's toggled to enabled, the loop will be started.
      *
      * @param enable: [Optional] If a boolean is passed, it will be used to set the right state.
-     *                Otherwise, the cookie stored value will be used
+     *                Otherwise, the local storage value will be used
      */
     static __internal__toggleGymFight(enable)
     {

--- a/src/lib/Hatchery.js
+++ b/src/lib/Hatchery.js
@@ -117,16 +117,19 @@ class AutomationHatchery
         let shinyTooltip = "Only add shinies to the hatchery if no other pokemon is available"
                          + Automation.Menu.TooltipSeparator
                          + "This is useful to farm shinies you don't have yet";
-        Automation.Menu.addToggleButton("Consider shiny pokemons last", this.Settings.NotShinyFirst, shinyTooltip, hatcherySettingPanel);
+        Automation.Menu.addLabeledAdvancedSettingsToggleButton("Consider shiny pokemons last",
+                                                               this.Settings.NotShinyFirst,
+                                                               shinyTooltip,
+                                                               hatcherySettingPanel);
         let fossilTooltip = "Add fossils to the hatchery as well"
                           + Automation.Menu.TooltipSeparator
                           + "Only fossils for which pokemon are not currently held are added";
-        Automation.Menu.addToggleButton("Hatch Fossils", this.Settings.UseFossils, fossilTooltip, hatcherySettingPanel);
+        Automation.Menu.addLabeledAdvancedSettingsToggleButton("Hatch Fossils", this.Settings.UseFossils, fossilTooltip, hatcherySettingPanel);
         let eggTooltip = "Add eggs to the hatchery as well"
                        + Automation.Menu.TooltipSeparator
                        + "Only eggs for which some pokemon are not currently held are added\n"
                        + "Only one egg of a given type is used at the same time";
-        Automation.Menu.addToggleButton("Hatch Eggs", this.Settings.UseEggs, eggTooltip, hatcherySettingPanel);
+        Automation.Menu.addLabeledAdvancedSettingsToggleButton("Hatch Eggs", this.Settings.UseEggs, eggTooltip, hatcherySettingPanel);
     }
 
     /**

--- a/src/lib/Hatchery.js
+++ b/src/lib/Hatchery.js
@@ -43,7 +43,7 @@ class AutomationHatchery
      * If the feature was disabled and it's toggled to enabled, the loop will be started.
      *
      * @param enable: [Optional] If a boolean is passed, it will be used to set the right state.
-     *                Otherwise, the cookie stored value will be used
+     *                Otherwise, the local storage value will be used
      */
     static toggleAutoHatchery(enable)
     {
@@ -82,6 +82,9 @@ class AutomationHatchery
     static __internal__hatcheryContainer = null;
     static __internal__autoHatcheryLoop = null;
 
+    /**
+     * @brief Builds the menu, and restores the previous running state if needed
+     */
     static __internal__buildMenu()
     {
         // Add the related buttons to the automation menu

--- a/src/lib/Items.js
+++ b/src/lib/Items.js
@@ -51,6 +51,9 @@ class AutomationItems
     static __internal__autoOakUpgradeLoop = null;
     static __internal__autoGemUpgradeLoop = null;
 
+    /**
+     * @brief Builds the menu, and restores the previous running state if needed
+     */
     static __internal__buildMenu()
     {
         // Add the related button to the automation menu
@@ -138,7 +141,7 @@ class AutomationItems
      * If the feature was disabled and it's toggled to enabled, the loop will be started.
      *
      * @param enable: [Optional] If a boolean is passed, it will be used to set the right state.
-     *                Otherwise, the cookie stored value will be used
+     *                Otherwise, the local storage value will be used
      */
     static __internal__toggleAutoOakUpgrade(enable)
     {
@@ -172,7 +175,7 @@ class AutomationItems
      * If the feature was disabled and it's toggled to enabled, the loop will be started.
      *
      * @param enable: [Optional] If a boolean is passed, it will be used to set the right state.
-     *                Otherwise, the cookie stored value will be used
+     *                Otherwise, the local storage value will be used
      */
     static __internal__toggleAutoGemUpgrade(enable)
     {

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -349,7 +349,7 @@ class AutomationMenu
     }
 
     /**
-     * @brief Creates a title
+     * @brief Creates a title element
      *
      * @param {string} titleText: The text to display
      *
@@ -374,6 +374,40 @@ class AutomationMenu
         titleDiv.appendChild(titleSpan);
 
         return titleDiv;
+    }
+
+    /**
+     * @brief Creates an editable text field element
+     *
+     * @param {number} charLimit: The max char number that the user can enter (set to -1 for no limit)
+     * @param {string} acceptedRegex: The axepted input regex (leave empty to accept any input)
+     *
+     * @returns The created element's container (It's the caller's responsibility to add it to the DOM at some point)
+     */
+    static createTextInputElement(charLimit = -1, acceptedRegex = "")
+    {
+        // Add the input
+        let inputElem = document.createElement("div");
+        inputElem.contentEditable = true;
+        inputElem.spellcheck = false;
+        inputElem.classList.add("automation-setting-input");
+
+        // Filter input based on the given parameters
+        inputElem.onkeydown = function(event)
+        {
+            let isValidKey = (acceptedRegex === "") || (event.key.match(acceptedRegex) != null);
+
+            return (event.key === "Backspace")
+                   || (event.key === "Delete")
+                   || (event.key === "ArrowLeft")
+                   || (event.key === "ArrowRight")
+                   || (isValidKey && ((charLimit == -1) || (this.innerText.length < charLimit)));
+        };
+
+        // Disable drag and drop
+        inputElem.ondrop = function(event) { event.preventDefault(); event.dataTransfer.dropEffect = 'none'; return false; };
+
+        return inputElem;
     }
 
     /**
@@ -707,7 +741,7 @@ class AutomationMenu
             }
             .automation-setting-menu-container[automation-visible]
             {
-                max-width: 500px;
+                max-width: 650px;
                 max-height: 500px;
 
                 transition-property:        max-width, max-height;
@@ -716,7 +750,7 @@ class AutomationMenu
                 transition-delay:                  0s,      500ms;
 
                 /* Delay the overflow change after the entire animation */
-                animation: 4s automation-delay-overflow forwards;
+                animation: 6s automation-delay-overflow forwards;
             }
             @keyframes automation-delay-overflow
             {
@@ -838,6 +872,29 @@ class AutomationMenu
                 transform: rotate(-20deg);
                 right: 2px;
                 top: 6px;
+            }
+            .automation-setting-input
+            {
+                display: inline-block;
+                border-bottom: solid 1px #CCCDD9;
+                border-radius: 5px;
+                padding: 0px 5px;
+                margin: 0px 5px;
+                min-width: 20px;
+                user-select: text !important;
+                background-color: #3c5071;
+                transition: color 1s;
+            }
+            .automation-setting-input.invalid
+            {
+                color: #FFABAB;
+                transition: color 1s;
+            }
+            .automation-setting-input:focus
+            {
+                outline: none;
+                border-radius: 5px;
+                background-color: #455d77;
             }`;
         document.head.append(style);
     }

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -929,13 +929,13 @@ class AutomationMenu
             .automation-setting-input
             {
                 display: inline-block;
+                min-width: 20px;
+                user-select: text !important;
+                background-color: #3c5071;
                 border-bottom: solid 1px #CCCDD9;
                 border-radius: 5px;
                 padding: 0px 5px;
                 margin: 0px 5px;
-                min-width: 20px;
-                user-select: text !important;
-                background-color: #3c5071;
                 transition: color 1s;
             }
             .automation-setting-input.invalid

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -164,7 +164,35 @@ class AutomationMenu
     }
 
     /**
-     * @brief Adds a toggle button element
+     * @brief Creates a simple toggle element bound to the local storage associated to the @p id
+     *
+     * @param {string} id: The button's id (that will be used for the corresponding local storage item id as well)
+     *
+     * @returns The button element
+     */
+    static addLocalStorageBoundToggleButton(id)
+    {
+        let buttonElem = this.createToggleButtonElement(id);
+
+        // Set the current state
+        let isFeatureEnabled = (Automation.Utils.LocalStorage.getValue(id) === "true");
+        buttonElem.setAttribute("checked", isFeatureEnabled ? "true" : "false");
+
+        // Register the onclick event callback
+        buttonElem.onclick = function()
+            {
+                let wasChecked = buttonElem.getAttribute("checked") == "true";
+                buttonElem.setAttribute("checked", wasChecked ? "false" : "true");
+                Automation.Utils.LocalStorage.setValue(id, !wasChecked);
+            };
+
+        return buttonElem;
+    }
+
+    /**
+     * @brief Adds a label-prefixed toggle button element bound to the @p id local storage key.
+     *        Such toggle button is designed for advanced settings panel
+     *        @see addSettingPanel
      *
      * @param {string}  label: The text label to place before the toggle button
      * @param {string}  id: The button's id (that will be used for the corresponding local storage item id as well)
@@ -173,7 +201,7 @@ class AutomationMenu
      *
      * @returns The button element
      */
-    static addToggleButton(label, id, tooltip = "", containingDiv = this.AutomationButtonsDiv)
+    static addLabeledAdvancedSettingsToggleButton(label, id, tooltip = "", containingDiv = this.AutomationButtonsDiv)
     {
         // Enable automation by default, if not already set in local storage
         Automation.Utils.LocalStorage.setDefaultValue(id, true);
@@ -191,15 +219,7 @@ class AutomationMenu
         buttonLabel.style.paddingRight = "7px";
         buttonContainer.appendChild(buttonLabel);
 
-        let buttonElem = this.createToggleButtonElement(id);
-        let isFeatureEnabled = (Automation.Utils.LocalStorage.getValue(id) === "true");
-        buttonElem.setAttribute("checked", isFeatureEnabled ? "true" : "false");
-        buttonElem.onclick = function()
-            {
-                let wasChecked = buttonElem.getAttribute("checked") == "true";
-                buttonElem.setAttribute("checked", wasChecked ? "false" : "true");
-                Automation.Utils.LocalStorage.setValue(id, !wasChecked);
-            };
+        let buttonElem = this.addLocalStorageBoundToggleButton(id);
 
         if (tooltip != "")
         {

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -349,6 +349,39 @@ class AutomationMenu
     }
 
     /**
+     * @brief Creates an animated checkmark element, hidden
+     *        Call @see showCheckmark() to reveal it
+     *
+     * @returns The created animated checkmark element (It's the caller's responsibility to add it to the DOM at some point)
+     */
+    static createAnimatedCheckMarkElement()
+    {
+        let checkmarkContainer = document.createElement("div");
+        checkmarkContainer.classList.add("automation-checkmark-container");
+
+        let checkmarkElem = document.createElement("div");
+        checkmarkElem.classList.add("automation-checkmark");
+        checkmarkContainer.appendChild(checkmarkElem);
+
+        return checkmarkContainer;
+    }
+
+    /**
+     * @brief Shows the animated checkmark
+     *
+     * @param {Element} checkmarkContainer: The element created using @see createAnimatedCheckMarkElement()
+     * @param {number} resetTimer: The timeout in milliseconds upon which the checkmark will be hidden again
+     *                             Don't use a value under 400ms, since it's the animation duration
+     */
+    static showCheckmark(checkmarkContainer, resetTimer = 2000)
+    {
+        let checkmarkElem = checkmarkContainer.children[0];
+        checkmarkElem.classList.add("shown");
+
+        setTimeout(function() { checkmarkElem.classList.remove("shown"); }, resetTimer);
+    }
+
+    /**
      * @brief Creates a title element
      *
      * @param {string} titleText: The text to display
@@ -895,6 +928,48 @@ class AutomationMenu
                 outline: none;
                 border-radius: 5px;
                 background-color: #455d77;
+            }
+            .automation-checkmark-container
+            {
+                display: inline-block;
+                margin-left: 4px;
+                height: 14px;
+                width: 9px;
+                transform: rotate(45deg);
+                padding-right: 4px;
+                padding-bottom: 4px;
+            }
+            .automation-checkmark
+            {
+                display: inline-block;
+                box-sizing: content-box;
+                margin-left: 4px;
+                height: 0px;
+                width: 0px;
+                border-bottom: 4px solid #78b13f;
+                border-right: 0px solid #78b13f;
+            }
+            .automation-checkmark.shown
+            {
+                animation: 400ms automation-checkmark-show forwards;
+                animation-iteration-count: 1;
+            }
+            @keyframes automation-checkmark-show
+            {
+                50%
+                {
+                    height: 0px;
+                    width: 5px;
+                    border-bottom: 4px solid #78b13f;
+                    border-right: 4px solid #78b13f;
+                }
+                100%
+                {
+                    height: 10px;
+                    width: 5px;
+                    border-bottom: 4px solid #78b13f;
+                    border-right: 4px solid #78b13f;
+                }
             }`;
         document.head.append(style);
     }

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -235,7 +235,7 @@ class AutomationMenu
 
     /**
      * @brief Toggles the button elem between on and off based on its current state
-     *        The cookie value will be updated accordingly
+     *        The local storage value will be updated accordingly
      *
      * @note If the button has been disabled, this function has no effect
      *

--- a/src/lib/Shop.js
+++ b/src/lib/Shop.js
@@ -1,0 +1,263 @@
+/**
+ * @class AutomationShop provides functionality to automatically buy Poké Mart shop items
+ */
+class AutomationShop
+{
+    static Settings = {
+                          FeatureEnabled: "Shop-Enabled"
+                      };
+
+    /**
+     * @brief Builds the menu, and retores previous running state if needed
+     *
+     * @param initStep: The current automation init step
+     */
+    static initialize(initStep)
+    {
+        if (initStep === Automation.InitSteps.BuildMenu)
+        {
+            // Disable AutoBuy by default
+            Automation.Utils.LocalStorage.setDefaultValue(this.Settings.FeatureEnabled, false);
+
+            this.__internal__buildMenu();
+        }
+        else if (initStep === Automation.InitSteps.Finalize)
+        {
+            // Restore previous session state
+            this.__internal__toggleAutoBuy();
+        }
+    }
+
+    /*********************************************************************\
+    |***    Internal members, should never be used by other classes    ***|
+    \*********************************************************************/
+
+    static __internal__shoppingContainer = null;
+    static __internal__shopLoop = null;
+    static __internal__activeTimouts = new Map();
+
+    /**
+     * @brief Builds the menu, and restores the previous running state if needed
+     */
+    static __internal__buildMenu()
+    {
+        // Add the related buttons to the automation menu
+        this.__internal__shoppingContainer = document.createElement("div");
+        Automation.Menu.AutomationButtonsDiv.appendChild(this.__internal__shoppingContainer);
+
+        Automation.Menu.addSeparator(this.__internal__shoppingContainer);
+
+        // Only display the menu when the Poké Mart is unlocked
+        if (!TownList["Cinnabar Island"].isUnlocked())
+        {
+            this.__internal__shoppingContainer.hidden = true;
+            this.__internal__setShoppingUnlockWatcher();
+        }
+
+        let autoShopTooltip = "Automatically buys the configured items (see advanced settings)"
+                            + Automation.Menu.TooltipSeparator
+                            + "⚠️ This can be cost-heavy";
+        let autoShopButton =
+            Automation.Menu.addAutomationButton("Auto Shop", this.Settings.FeatureEnabled, autoShopTooltip, this.__internal__shoppingContainer);
+        autoShopButton.addEventListener("click", this.__internal__toggleAutoBuy.bind(this), false);
+
+        // Build advanced settings panel
+        let shoppingSettingPanel = Automation.Menu.addSettingPanel(autoShopButton.parentElement.parentElement);
+
+        let titleDiv = Automation.Menu.createTitleElement("Auto shop advanced settings");
+        titleDiv.style.marginBottom = "10px";
+        shoppingSettingPanel.appendChild(titleDiv);
+
+        // Add the min pokedolar limit input
+        let minPokedollarsInputContainer = document.createElement("div");
+        minPokedollarsInputContainer.style.textAlign = "left";
+        minPokedollarsInputContainer.style.marginBottom = "10px";
+
+        let minPokedollarsText = document.createTextNode("Stop buying if the player has less than");
+        minPokedollarsInputContainer.appendChild(minPokedollarsText);
+
+        let minPokedollarsInputElem = Automation.Menu.createTextInputElement(10, "[0-9]");
+        minPokedollarsInputElem.innerHTML = "10000"; // TODO get the saved setting value
+        minPokedollarsInputContainer.appendChild(minPokedollarsInputElem);
+
+        let minPokedollarsImage = document.createElement("img");
+        minPokedollarsImage.src = "assets/images/currency/money.svg";
+        minPokedollarsImage.style.height = "25px";
+        minPokedollarsInputContainer.appendChild(minPokedollarsImage);
+
+        shoppingSettingPanel.appendChild(minPokedollarsInputContainer);
+
+        this.__internal__buildShopItemList(shoppingSettingPanel);
+    }
+
+    /**
+     * @brief Watches for the in-game functionality to be unlocked.
+     *        Once unlocked, the menu will be displayed to the user
+     */
+    static __internal__setShoppingUnlockWatcher()
+    {
+        let watcher = setInterval(function()
+            {
+                if (TownList["Cinnabar Island"].isUnlocked())
+                {
+                    clearInterval(watcher);
+                    this.__internal__shoppingContainer.hidden = false;
+                    this.__internal__toggleAutoBuy();
+                }
+            }.bind(this), 10000); // Check every 10 seconds
+    }
+
+    /**
+     * @brief Toggles the 'Auto Shop' feature
+     *
+     * If the feature was enabled and it's toggled to disabled, the loop will be stopped.
+     * If the feature was disabled and it's toggled to enabled, the loop will be started.
+     *
+     * @param enable: [Optional] If a boolean is passed, it will be used to set the right state.
+     *                Otherwise, the local storage value will be used
+     */
+    static __internal__toggleAutoBuy(enable)
+    {
+        if (!TownList["Cinnabar Island"].isUnlocked())
+        {
+            return;
+        }
+
+        if ((enable !== true) && (enable !== false))
+        {
+            enable = (Automation.Utils.LocalStorage.getValue(this.Settings.FeatureEnabled) === "true");
+        }
+
+        if (enable)
+        {
+            if (this.__internal__shopLoop === null)
+            {
+                this.__internal__shopLoop = setInterval(this.__internal__shop.bind(this), 10000); // Runs every 10s
+            }
+        }
+        else
+        {
+            clearInterval(this.__internal__shopLoop);
+            this.__internal__shopLoop = null;
+        }
+    }
+
+    /**
+     * @brief Adds the shop item list and adds it to the advanced settings
+     *
+     * @param {Element} parentDiv: The div to add the list to
+     */
+    static __internal__buildShopItemList(parentDiv)
+    {
+        let table = document.createElement("table");
+        table.style.textAlign = "left";
+
+        pokeMartShop.items.forEach(
+            (item) =>
+            {
+                let tableRow = document.createElement("tr");
+                table.appendChild(tableRow);
+                let tableCell = document.createElement("td");
+                tableRow.appendChild(tableCell);
+
+                let firstLineDiv = document.createElement("div");
+
+                // Buy count
+                let label = document.createTextNode("Buy");
+                firstLineDiv.appendChild(label);
+
+                let buyCount = Automation.Menu.createTextInputElement(4, "[0-9]");
+                buyCount.innerHTML = "10"; // TODO get the saved setting value
+                buyCount.style.marginRight = "3px";
+                firstLineDiv.appendChild(buyCount);
+
+                let itemImage = document.createElement("img");
+                if (item.imageDirectory !== undefined)
+                {
+                    itemImage.src = `assets/images/items/${item.imageDirectory}/${item.name}.png`;
+                }
+                else
+                {
+                    itemImage.src = `assets/images/items/${item.name}.png`;
+                }
+                itemImage.style.height = "25px";
+                firstLineDiv.appendChild(itemImage);
+
+                // Until count
+                label = document.createTextNode("until the player has");
+                firstLineDiv.appendChild(label);
+
+                let untilCount = Automation.Menu.createTextInputElement(10, "[0-9]");
+                untilCount.innerHTML = "10000"; // TODO get the saved setting value
+                firstLineDiv.appendChild(untilCount);
+
+                // Max price
+                label = document.createTextNode("at max base price");
+                firstLineDiv.appendChild(label);
+
+                let maxPrice = Automation.Menu.createTextInputElement(10, "[0-9]");
+                maxPrice.innerHTML = item.basePrice; // TODO get the saved setting value
+                firstLineDiv.appendChild(maxPrice);
+
+                let pokedollarsImage = document.createElement("img");
+                pokedollarsImage.src = "assets/images/currency/money.svg";
+                pokedollarsImage.style.height = "25px";
+                firstLineDiv.appendChild(pokedollarsImage);
+
+                tableCell.appendChild(firstLineDiv);
+
+                parentDiv.appendChild(table);
+
+                // Set oninput callbacks
+                maxPrice.oninput = function()
+                    {
+                        if (maxPrice.innerText < item.basePrice)
+                        {
+                            maxPrice.classList.add("invalid");
+                            // Let the time to the user to edit the value before setting back the minimum possible value
+                            let timeout = setTimeout(function()
+                                {
+                                    // Only update the value if it's still under the minimum possible
+                                    if (maxPrice.innerText < item.basePrice)
+                                    {
+                                        maxPrice.innerText = item.basePrice;
+                                        maxPrice.classList.remove("invalid");
+
+                                        // Move the cursor at the end of the input if still focused
+                                        var range = document.createRange();
+
+                                        if (maxPrice === document.activeElement)
+                                        {
+                                            var set = window.getSelection();
+                                            range.setStart(maxPrice.childNodes[0], maxPrice.innerText.length);
+                                            range.collapse(true);
+                                            set.removeAllRanges();
+                                            set.addRange(range);
+                                        }
+                                    }
+                                    this.__internal__activeTimouts.delete(item.name);
+                                }.bind(this), 1000);
+
+                            if (this.__internal__activeTimouts.has(item.name))
+                            {
+                                clearTimeout(this.__internal__activeTimouts.get(item.name));
+                                this.__internal__activeTimouts.delete(item.name);
+                            }
+                            this.__internal__activeTimouts.set(item.name, timeout);
+                        }
+                        else
+                        {
+                            maxPrice.classList.remove("invalid");
+                        }
+                    }.bind(this);
+            });
+    }
+
+    /**
+     * @brief The Shopping loop
+     */
+    static __internal__shop()
+    {
+        // TODO: buy the items
+    }
+}

--- a/src/lib/Underground.js
+++ b/src/lib/Underground.js
@@ -52,7 +52,7 @@ class AutomationUnderground
      * If the feature was disabled and it's toggled to enabled, the loop will be started.
      *
      * @param enable: [Optional] If a boolean is passed, it will be used to set the right state.
-     *                Otherwise, the cookie stored value will be used
+     *                Otherwise, the local storage value will be used
      */
     static toggleAutoMining(enable)
     {

--- a/src/lib/Utils.js
+++ b/src/lib/Utils.js
@@ -114,4 +114,18 @@ class AutomationUtils
             && (a.length === b.length)
             && a.every((val, index) => val === b[index]);
     }
+
+    /**
+     * @brief Converts the string representation of a number to its integer equivalent
+     *
+     * @param {string} str: The string to parse
+     * @param {number} defaultValue: The default value (in case the string was not representing an int)
+     *
+     * @returns The int value if the string could be parsed, the default value otherwise
+     */
+    static tryParseInt(str, defaultValue = 0)
+    {
+        let result = parseInt(str);
+        return isNaN(result) ? defaultValue : result;
+    }
 }


### PR DESCRIPTION
The shop settings are available in its advance settings panel:
![image](https://user-images.githubusercontent.com/11090416/177648235-96560a7e-a698-4c9f-8e42-2e466baa1bc3.png)

The green checkmark is displayed to notice the user that the changes have been saved for the current setting row.
It will be done after 3s without any changes in said row.

If a value under the minimum possible base price is entered, the value will turn red and be reset to the minium value after 1s without further modification :
![image](https://user-images.githubusercontent.com/11090416/177648595-5465edeb-19f5-49d2-b16a-ab477a2febe9.png)

The shop automation will run every 10 seconds and buy according to the user settings.
If anything was bought, a notification is sent with the amount spent:
![image](https://user-images.githubusercontent.com/11090416/177648157-6769b9b4-14a5-4a5b-8a64-665b1db4727f.png)


closes #52 
fixes #45