### PR TITLE
Focus.Gems: Consider both gym and route

### DIFF
--- a/src/lib/Focus.js
+++ b/src/lib/Focus.js
@@ -271,9 +271,9 @@ class AutomationFocus
                                         id: "Gold",
                                         name: "Money",
                                         tooltip: "Automatically moves to the best gym for money"
-                                                + Automation.Menu.TooltipSeparator
-                                                + "Gyms gives way more money than routes\n"
-                                                + "The best gym is the one that gives the most money per game tick",
+                                               + Automation.Menu.TooltipSeparator
+                                               + "Gyms gives way more money than routes\n"
+                                               + "The best gym is the one that gives the most money per game tick",
                                         run: function (){ this.__internal__goToBestGymForMoney(); }.bind(this),
                                         stop: function (){ Automation.Menu.forceAutomationState(Automation.Gym.Settings.FeatureEnabled, false); },
                                         refreshRateAsMs: 10000 // Refresh every 10s
@@ -330,11 +330,10 @@ class AutomationFocus
                         id: gemTypeName + "Gems",
                         name: gemTypeName + " Gems",
                         tooltip: "Moves to the best gym or route to earn " + gemTypeName + " gems"
-                            + Automation.Menu.TooltipSeparator
-                            + "The best location is the one that will give the most\n"
-                            + gemTypeName + " gems per game tick.\n"
-                            + "Gyms are considered in priority, if none is found\n"
-                            + "the routes will be considered.",
+                               + Automation.Menu.TooltipSeparator
+                               + "The best location is the one that will give the most\n"
+                               + gemTypeName + " gems per game tick.\n"
+                               + "Both gyms and routes are considered, the best one will be used.",
                         run: function (){ this.__internal__goToBestGymOrRouteForGem(gemType); }.bind(this),
                         stop: function (){ Automation.Menu.forceAutomationState(Automation.Gym.Settings.FeatureEnabled, false); },
                         refreshRateAsMs: 10000 // Refresh every 10s
@@ -507,19 +506,17 @@ class AutomationFocus
         }
 
         let bestGym = Automation.Utils.Gym.findBestGymForFarmingType(gemType);
-        if (bestGym !== null)
+        let bestRoute = Automation.Utils.Route.findBestRouteForFarmingType(gemType);
+
+        // Compare with a 1/1000 precision
+        if ((bestGym !== null) && (Math.ceil(bestGym.Rate * 1000) >= Math.ceil(bestRoute.Rate * 1000)))
         {
             Automation.Utils.Route.moveToTown(bestGym.Town);
             this.__enableAutoGymFight(bestGym.Name);
-
-            return;
         }
-
-        // Fallback to routes if no gym could be found
-        let { bestRoute, bestRouteRegion } = Automation.Utils.Route.findBestRouteForFarmingType(gemType);
-        if ((player.route() !== bestRoute) || (player.region !== bestRouteRegion))
+        else
         {
-            Automation.Utils.Route.moveToRoute(bestRoute, bestRouteRegion);
+            Automation.Utils.Route.moveToRoute(bestRoute.Route, bestRoute.Region);
         }
     }
 }

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -346,15 +346,15 @@ class AutomationFocusQuests
      */
     static __internal__workOnCapturePokemonTypesQuest(quest)
     {
-        let { bestRoute, bestRouteRegion } = Automation.Utils.Route.findBestRouteForFarmingType(quest.type);
+        let bestRoute = Automation.Utils.Route.findBestRouteForFarmingType(quest.type);
 
         // Add a pokeball to the Caught type and set the PokemonCatch setup
         let hasBalls = this.__internal__selectBallToCatch(GameConstants.Pokeball.Ultraball);
         this.__internal__equipOptimizedLoadout(Automation.Utils.OakItem.Setup.PokemonCatch);
 
-        if (hasBalls && ((player.route() !== bestRoute) || (player.region !== bestRouteRegion)))
+        if (hasBalls)
         {
-            Automation.Utils.Route.moveToRoute(bestRoute, bestRouteRegion);
+            Automation.Utils.Route.moveToRoute(bestRoute.Route, bestRoute.Region);
         }
     }
 
@@ -446,11 +446,7 @@ class AutomationFocusQuests
         this.__internal__selectBallToCatch(GameConstants.Pokeball.None);
         this.__internal__equipOptimizedLoadout(Automation.Utils.OakItem.Setup.PokemonExp);
 
-        if ((player.region != quest.region)
-            || (player.route() != quest.route))
-        {
-            Automation.Utils.Route.moveToRoute(quest.route, quest.region);
-        }
+        Automation.Utils.Route.moveToRoute(quest.route, quest.region);
     }
 
     /**
@@ -465,8 +461,8 @@ class AutomationFocusQuests
         this.__internal__selectBallToCatch(GameConstants.Pokeball.None);
         this.__internal__equipOptimizedLoadout(Automation.Utils.OakItem.Setup.PokemonExp);
 
-        let { bestRoute, bestRouteRegion } = Automation.Utils.Route.findBestRouteForFarmingType(quest.type);
-        Automation.Utils.Route.moveToRoute(bestRoute, bestRouteRegion);
+        let bestRoute = Automation.Utils.Route.findBestRouteForFarmingType(quest.type);
+        Automation.Utils.Route.moveToRoute(bestRoute.Route, bestRoute.Region);
     }
 
     /**

--- a/src/lib/Utils/Gym.js
+++ b/src/lib/Utils/Gym.js
@@ -23,9 +23,10 @@ class AutomationUtilsGym
      *
      * @param pokemonType: The pokemon type to look for
      *
-     * @returns Null if no gym could be found, or a struct { bestGymName, bestGymTown }, where:
-     *          @c bestGymName is the best gym name
-     *          @c bestGymTown is the best gym town name
+     * @returns Null if no gym could be found, or a struct { Name, Town, Rate }, where:
+     *          @c Name is the best gym name
+     *          @c Town is the best gym town name
+     *          @c Rate is the gem rate
      */
     static findBestGymForFarmingType(pokemonType)
     {
@@ -67,7 +68,8 @@ class AutomationUtilsGym
                 // TODO (26/06/2022): Be more precise, all pokemons do not have the same health
                 currentGymGemPerTick /= gym.pokemons.length;
 
-                if (currentGymGemPerTick > bestGymRate)
+                // Compare with a 1/1000 precision
+                if (Math.ceil(currentGymGemPerTick * 1000) >= Math.ceil(bestGymRate * 1000))
                 {
                     bestGymName = gymData.gymName;
                     bestGymTown = gymData.gymTown;
@@ -75,7 +77,7 @@ class AutomationUtilsGym
                 }
             });
 
-        return (bestGymName !== null) ? { Name: bestGymName, Town: bestGymTown } : null;
+        return (bestGymName !== null) ? { Name: bestGymName, Town: bestGymTown, Rate: bestGymRate } : null;
     }
 
     /**


### PR DESCRIPTION
In some cases, farming routes can be more efficient than farming gyms.
Both rates are now computed and the best one is chosen.

---

The player can't get any gems until the Gem_case key item was unlocked.
The focus topic is now hidden until the in-game functionality has been unlocked.

Fixes #47