### PR TITLE
Hatchery: Add Pokérus speading strategy

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,6 +5,6 @@ Pokeclicker-automation aims at automating some recurring tasks that can be a bit
 This script collection does not aim at cheating.
 It will never perform actions that the game would not allow.
 
-Last known compatible pokeclicker version: 0.9.8
+Last known compatible pokeclicker version: 0.9.9
 
 For more details, please refer to the [wiki](../../wiki)

--- a/src/lib/Utils/LocalStorage.js
+++ b/src/lib/Utils/LocalStorage.js
@@ -42,6 +42,16 @@ class AutomationUtilsLocalStorage
         }
     }
 
+    /**
+     * @brief Unsets the value associated to @p key from the local storage
+     *
+     * @param {string} key: The key to get the value of
+     */
+    static unsetValue(key)
+    {
+        return localStorage.removeItem(this.__internal__getSaveSpecificKey(key));
+    }
+
     /*********************************************************************\
     |***    Internal members, should never be used by other classes    ***|
     \*********************************************************************/


### PR DESCRIPTION
This option will add contagious Pokémon if none are present in the hatchery.
It will then add Pokérus-free ones matching the contagious pokémon type to spread the pokerus to them.

Once every pokemon have been infected, it will fallback to the default strategy.

This option is togglable in the advanced settings and is on by default.
Since the Pokérus is an end-game unlock, the option is disabled until the player reached this point.

Fixes #63