### PR TITLE
Coding style: Replace foreach usages

### DIFF
--- a/src/ComponentLoader.js
+++ b/src/ComponentLoader.js
@@ -131,14 +131,13 @@ class AutomationComponentLoader
                 {
                     currentLoadingOrder += 1;
 
-                    this.__loadingList.forEach(
-                        (scriptData) =>
+                    for (const scriptData of this.__loadingList)
+                    {
+                        if (scriptData.order === currentLoadingOrder)
                         {
-                            if (scriptData.order === currentLoadingOrder)
-                            {
-                                this.__loadScript(scriptData.filePath);
-                            }
-                        });
+                            this.__loadScript(scriptData.filePath);
+                        }
+                    }
 
                     return;
                 }

--- a/src/lib/Dungeon.js
+++ b/src/lib/Dungeon.js
@@ -403,52 +403,48 @@ class AutomationDungeon
     {
         let startingTile = null;
 
-        DungeonRunner.map.board().forEach(
-            (row, rowIndex) =>
+        for (const [rowIndex, row] of DungeonRunner.map.board().entries())
+        {
+            for (const [columnIndex, tile] of row.entries())
             {
-                row.forEach(
-                    (tile, columnIndex) =>
+                // Ignore not visible tiles
+                if (!tile.isVisible) continue;
+
+                let currentLocation = { x: columnIndex, y: rowIndex };
+
+                if (DungeonRunner.map.hasAccessToTile(currentLocation))
+                {
+                    // Store chest positions
+                    if (tile.type() === GameConstants.DungeonTile.chest)
                     {
-                        // Ignore not visible tiles
-                        if (!tile.isVisible) return;
+                        this.__internal__addChestPosition(currentLocation);
+                    }
 
-                        let currentLocation = { x: columnIndex, y: rowIndex };
+                    if (tile.type() === GameConstants.DungeonTile.boss)
+                    {
+                        // Only tag the dungeon as completed if it's not the first move or any tile is visited apart from the entrance
+                        this.__internal__isCompleted = (!this.__internal__isFirstMove) || DungeonRunner.map.board().some(
+                            (row) => row.some((tile) => tile.isVisited && (tile.type() !== GameConstants.DungeonTile.entrance)));
+                        this.__internal__bossPosition = currentLocation;
+                    }
+                }
 
-                        if (DungeonRunner.map.hasAccessToTile(currentLocation))
-                        {
-                            // Store chest positions
-                            if (tile.type() === GameConstants.DungeonTile.chest)
-                            {
-                                this.__internal__addChestPosition(currentLocation);
-                            }
+                // For the next part, ignore not visited tiles
+                if (!tile.isVisited) continue;
 
-                            if (tile.type() === GameConstants.DungeonTile.boss)
-                            {
-                                // Only tag the dungeon as completed if it's not the first move or any tile is visited apart from the entrance
-                                this.__internal__isCompleted =
-                                    (!this.__internal__isFirstMove)
-                                    || DungeonRunner.map.board().some(
-                                           (row) => row.some((tile) => tile.isVisited && (tile.type() !== GameConstants.DungeonTile.entrance)));
-                                this.__internal__bossPosition = currentLocation;
-                            }
-                        }
+                if ((rowIndex === (DungeonRunner.map.size - 1))
+                    && (startingTile === null))
+                {
+                    startingTile = currentLocation;
+                }
 
-                        // For the next part, ignore not visited tiles
-                        if (!tile.isVisited) return;
-
-                        if ((rowIndex === (DungeonRunner.map.size - 1))
-                            && (startingTile === null))
-                        {
-                            startingTile = currentLocation;
-                        }
-
-                        if ((tile.type() !== GameConstants.DungeonTile.entrance)
-                            && this.__internal__isFirstMove)
-                        {
-                            this.__internal__playerActionOccured = true;
-                        }
-                    });
-            });
+                if ((tile.type() !== GameConstants.DungeonTile.entrance)
+                    && this.__internal__isFirstMove)
+                {
+                    this.__internal__playerActionOccured = true;
+                }
+            }
+        }
 
         if (!this.__internal__isFirstMove)
         {

--- a/src/lib/Farm.js
+++ b/src/lib/Farm.js
@@ -203,7 +203,11 @@ class AutomationFarm
             customOakLoadout.unshift(this.__internal__currentStrategy.oakItemToEquip.oakItemToEquip);
 
             App.game.oakItems.deactivateAll();
-            customOakLoadout.forEach((item) => { App.game.oakItems.activate(item); });
+
+            for (const item of customOakLoadout)
+            {
+                App.game.oakItems.activate(item);
+            }
         }
     }
 
@@ -222,14 +226,13 @@ class AutomationFarm
      */
     static __internal__tryToUnlockNewSpots()
     {
-        App.game.farming.plotList.forEach(
-            (plot, index) =>
+        for (const [index, plot] of App.game.farming.plotList.entries())
+        {
+            if (!plot.isUnlocked)
             {
-                if (!plot.isUnlocked)
-                {
-                    FarmController.plotClick(index);
-                }
-            });
+                FarmController.plotClick(index);
+            }
+        }
     }
 
     /**
@@ -245,34 +248,33 @@ class AutomationFarm
         this.__internal__plantedBerryCount = 0;
 
         // Mutations can only occur while the berry is fully ripe, so we need to collect them the later possible
-        App.game.farming.plotList.forEach(
-            (plot, index) =>
+        for (const [index, plot] of App.game.farming.plotList.entries())
+        {
+            if (plot.isEmpty())
             {
-                if (plot.isEmpty())
+                if (plot.isUnlocked)
                 {
-                    if (plot.isUnlocked)
-                    {
-                        this.__internal__freeSlotCount++;
-                    }
-                    return;
-                }
-
-                if (plot.stage() != PlotStage.Berry)
-                {
-                    return;
-                }
-
-                if ((Automation.Utils.LocalStorage.getValue(this.Settings.FocusOnUnlocks) === "false")
-                    || this.ForcePlantBerriesAsked
-                    || (this.__internal__currentStrategy === null)
-                    || (this.__internal__currentStrategy.harvestAsSoonAsPossible === true)
-                    || ((plot.berryData.growthTime[4] - plot.age) < 15))
-                {
-                    App.game.farming.harvest(index);
-                    this.__internal__harvestCount++;
                     this.__internal__freeSlotCount++;
                 }
-            }, this);
+                continue;
+            }
+
+            if (plot.stage() != PlotStage.Berry)
+            {
+                continue;
+            }
+
+            if ((Automation.Utils.LocalStorage.getValue(this.Settings.FocusOnUnlocks) === "false")
+                || this.ForcePlantBerriesAsked
+                || (this.__internal__currentStrategy === null)
+                || (this.__internal__currentStrategy.harvestAsSoonAsPossible === true)
+                || ((plot.berryData.growthTime[4] - plot.age) < 15))
+            {
+                App.game.farming.harvest(index);
+                this.__internal__harvestCount++;
+                this.__internal__freeSlotCount++;
+            }
+        }
     }
 
     /**
@@ -311,14 +313,13 @@ class AutomationFarm
         //  |o| | | |o|
         //  |o|o|o|o|o|
         //  |o|o|o|o|o|
-        App.game.farming.plotList.forEach(
-            (_, index) =>
+        for (const index of App.game.farming.plotList.keys())
+        {
+            if (![ 6, 8, 11, 12, 13 ].includes(index))
             {
-                if (![ 6, 8, 11, 12, 13 ].includes(index))
-                {
-                    Automation.Farm.__internal__tryPlantBerryAtIndex(index, berryType);
-                }
-            });
+                Automation.Farm.__internal__tryPlantBerryAtIndex(index, berryType);
+            }
+        }
     }
 
     /**
@@ -334,14 +335,13 @@ class AutomationFarm
         //  |o|o| | |o|
         //  |o|o|o|o|o|
         //  |o|o|o|o|o|
-        App.game.farming.plotList.forEach(
-            (_, index) =>
+        for (const index of App.game.farming.plotList.keys())
+        {
+            if (![ 12, 13 ].includes(index))
             {
-                if (![ 12, 13 ].includes(index))
-                {
-                    Automation.Farm.__internal__tryPlantBerryAtIndex(index, berryType);
-                }
-            });
+                Automation.Farm.__internal__tryPlantBerryAtIndex(index, berryType);
+            }
+        }
     }
 
     /**
@@ -360,8 +360,8 @@ class AutomationFarm
             //  | | | | | |
             //  |1| | |1| |
             //  | |2| | |2|
-            [ 0, 3, 15, 18 ].forEach((index) => this.__internal__tryPlantBerryAtIndex(index, berry1Type), this);
-            [ 6, 9, 21, 24 ].forEach((index) => this.__internal__tryPlantBerryAtIndex(index, berry2Type), this);
+            this.__internal__tryPlantBerryAtIndexes(berry1Type, [ 0, 3, 15, 18 ]);
+            this.__internal__tryPlantBerryAtIndexes(berry2Type, [ 6, 9, 21, 24 ]);
         }
         else if (App.game.farming.plotList[2].isUnlocked)
         {
@@ -375,8 +375,8 @@ class AutomationFarm
                 //  |1| |2| |1|
                 //  |x| | | |x|
                 //  |x|x|1|x|x|
+                this.__internal__tryPlantBerryAtIndexes(berry1Type, [ 2, 10, 14, 22 ]);
                 this.__internal__tryPlantBerryAtIndex(12, berry2Type);
-                [ 2, 10, 14, 22 ].forEach((index) => this.__internal__tryPlantBerryAtIndex(index, berry1Type), this);
             }
             else
             {
@@ -386,7 +386,7 @@ class AutomationFarm
                 //  |x| |2| |x|
                 //  |x| |1| |x|
                 //  |x|x|x|x|x|
-                [ 2, 17 ].forEach((index) => this.__internal__tryPlantBerryAtIndex(index, berry1Type), this);
+                this.__internal__tryPlantBerryAtIndexes(berry1Type, [ 2, 17 ]);
                 this.__internal__tryPlantBerryAtIndex(12, berry2Type);
             }
         }
@@ -398,8 +398,8 @@ class AutomationFarm
             //  |x|2| |2|x|
             //  |x| |1| |x|
             //  |x|x|x|x|x|
-            [ 7, 17 ].forEach((index) => this.__internal__tryPlantBerryAtIndex(index, berry1Type), this);
-            [ 11, 13 ].forEach((index) => this.__internal__tryPlantBerryAtIndex(index, berry2Type), this);
+            this.__internal__tryPlantBerryAtIndexes(berry1Type, [ 7, 17 ]);
+            this.__internal__tryPlantBerryAtIndexes(berry2Type, [ 11, 13 ]);
         }
     }
 
@@ -418,9 +418,9 @@ class AutomationFarm
         //  | | | | | |
         //  | |1| | |1|
         //  |2|3| |2|3|
-        [ 1, 4, 16, 19 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, berry1Type));
-        [ 5, 8, 20, 23 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, berry2Type));
-        [ 6, 9, 21, 24 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, berry3Type));
+        this.__internal__tryPlantBerryAtIndexes(berry1Type, [ 1, 4, 16, 19 ]);
+        this.__internal__tryPlantBerryAtIndexes(berry2Type, [ 5, 8, 20, 23 ]);
+        this.__internal__tryPlantBerryAtIndexes(berry3Type, [ 6, 9, 21, 24 ]);
     }
 
     /**
@@ -433,10 +433,16 @@ class AutomationFarm
      */
     static __internal__plantFourBerriesForMutation(berry1Type, berry2Type, berry3Type, berry4Type)
     {
-        [ 0, 4, 17 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, berry1Type));
-        [ 2, 15, 19 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, berry2Type));
-        [ 5, 9, 22 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, berry3Type));
-        [ 7, 20, 24 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, berry4Type));
+        // This represents the following strategy
+        //  |1| |2| |1|
+        //  |3| |4| |3|
+        //  | | | | | |
+        //  |2| |1| |2|
+        //  |4| |3| |4|
+        this.__internal__tryPlantBerryAtIndexes(berry1Type, [ 0, 4, 17 ]);
+        this.__internal__tryPlantBerryAtIndexes(berry2Type, [ 2, 15, 19 ]);
+        this.__internal__tryPlantBerryAtIndexes(berry3Type, [ 5, 9, 22 ]);
+        this.__internal__tryPlantBerryAtIndexes(berry4Type, [ 7, 20, 24 ]);
     }
 
     /**
@@ -453,12 +459,11 @@ class AutomationFarm
         //  |o|o|o|o|o|
         //  |o|o|o|o|o|
         //  |o|x|o|o|x|
-        App.game.farming.plotList.forEach(
-            (plot, index) =>
-            {
-                let berryType = [ 6, 9, 21, 24 ].includes(index) ? triggerBerryType : mutatedBerryType;
-                Automation.Farm.__internal__tryPlantBerryAtIndex(index, berryType);
-            });
+        for (const index of App.game.farming.plotList.keys())
+        {
+            let berryType = [ 6, 9, 21, 24 ].includes(index) ? triggerBerryType : mutatedBerryType;
+            Automation.Farm.__internal__tryPlantBerryAtIndex(index, berryType);
+        }
     }
 
     /**
@@ -480,6 +485,22 @@ class AutomationFarm
         {
             App.game.farming.plant(index, berryType, true);
             this.__internal__plantedBerryCount++;
+        }
+    }
+
+    /**
+     * @brief Tries to plant the given @p berryType in the selected @p indexes
+     *
+     * @see __internal__tryPlantBerryAtIndex
+     *
+     * @param indexes: The list of indexes of the spot to plant the berry in
+     * @param berryType: The type of the berry to plant
+     */
+    static __internal__tryPlantBerryAtIndexes(berryType, indexes)
+    {
+        for (const index of indexes)
+        {
+            this.__internal__tryPlantBerryAtIndex(index, berryType);
         }
     }
 
@@ -603,7 +624,7 @@ class AutomationFarm
             BerryType.Figy,
             function()
             {
-                [ 2, 3, 6, 10, 14, 16, 18, 19, 22 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Cheri));
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Cheri, [ 2, 3, 6, 10, 14, 16, 18, 19, 22 ]);
             });
 
         // Unlock the slot requiring Figy
@@ -614,7 +635,7 @@ class AutomationFarm
             BerryType.Wiki,
             function()
             {
-                [ 2, 3, 6, 10, 12, 14, 19, 21, 22 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Chesto));
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Chesto, [ 2, 3, 6, 10, 12, 14, 19, 21, 22 ]);
             });
 
         // Unlock the slot requiring Wiki
@@ -625,7 +646,7 @@ class AutomationFarm
             BerryType.Mago,
             function()
             {
-                [ 2, 3, 5, 10, 12, 14, 19, 21, 22 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Pecha));
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Pecha, [ 2, 3, 5, 10, 12, 14, 19, 21, 22 ]);
             });
 
         // Unlock the slot requiring Mago
@@ -636,7 +657,7 @@ class AutomationFarm
             BerryType.Aguav,
             function()
             {
-                [ 2, 3, 5, 10, 12, 14, 19, 21, 22 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Rawst));
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Rawst, [ 2, 3, 5, 10, 12, 14, 19, 21, 22 ]);
             });
 
         // Unlock the slot requiring Aguav
@@ -647,7 +668,7 @@ class AutomationFarm
             BerryType.Iapapa,
             function()
             {
-                [ 2, 3, 5, 10, 12, 14, 19, 21, 22 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Aspear));
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Aspear, [ 2, 3, 5, 10, 12, 14, 19, 21, 22 ]);
             });
 
         // Unlock the slot requiring Iapapa
@@ -680,8 +701,8 @@ class AutomationFarm
             BerryType.Pomeg,
             function()
             {
-                [ 5, 8, 16, 19 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Iapapa));
-                [ 6, 9, 22 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Mago));
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Iapapa, [ 5, 8, 16, 19 ]);
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Mago, [ 6, 9, 22 ]);
             });
 
         // Unlock the slot requiring Pomeg
@@ -692,8 +713,8 @@ class AutomationFarm
             BerryType.Kelpsy,
             function()
             {
-                [ 6, 8, 21, 23 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Persim));
-                [ 7, 10, 14, 22 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Chesto));
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Persim, [ 6, 8, 21, 23 ]);
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Chesto, [ 7, 10, 14, 22 ]);
             });
 
         // Unlock the slot requiring Kelpsy
@@ -704,8 +725,8 @@ class AutomationFarm
             BerryType.Qualot,
             function()
             {
-                [ 0, 8, 15, 18 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Pinap));
-                [ 6, 9, 19, 21 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Mago));
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Pinap, [ 0, 8, 15, 18 ]);
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Mago, [ 6, 9, 19, 21 ]);
             });
 
         // Unlock the slot requiring Qualot
@@ -716,9 +737,9 @@ class AutomationFarm
             BerryType.Hondew,
             function()
             {
-                [ 1, 8, 15, 23 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Figy));
-                [ 3, 5, 17, 19 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Wiki));
-                [ 6, 9, 22 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Aguav));
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Figy, [ 1, 8, 15, 23 ]);
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Wiki, [ 3, 5, 17, 19 ]);
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Aguav, [ 6, 9, 22 ]);
             });
 
         // Unlock the slot requiring Hondew
@@ -729,8 +750,8 @@ class AutomationFarm
             BerryType.Grepa,
             function()
             {
-                [ 0, 3, 15, 18 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Aguav));
-                [ 6, 9, 21, 24 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Figy));
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Aguav, [ 0, 3, 15, 18 ]);
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Figy, [ 6, 9, 21, 24 ]);
             });
 
         // Unlock the slot requiring Grepa
@@ -768,7 +789,7 @@ class AutomationFarm
             BerryType.Nomel,
             function()
             {
-                [ 6, 9, 21, 24 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Pinap));
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Pinap, [ 6, 9, 21, 24 ]);
             });
 
         // #31 Unlock at least one Spelon berry through mutation
@@ -776,7 +797,7 @@ class AutomationFarm
             BerryType.Spelon,
             function()
             {
-                App.game.farming.plotList.forEach((_, index) => { Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Tamato); });
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Tamato, App.game.farming.plotList.keys());
             });
 
         // #32 Unlock at least one Pamtre berry through mutation
@@ -784,7 +805,7 @@ class AutomationFarm
             BerryType.Pamtre,
             function()
             {
-                App.game.farming.plotList.forEach((_, index) => { Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Cornn); });
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Cornn, App.game.farming.plotList.keys());
             },
             null,
             OakItemType.Cell_Battery);
@@ -794,7 +815,7 @@ class AutomationFarm
             BerryType.Watmel,
             function()
             {
-                App.game.farming.plotList.forEach((_, index) => { Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Magost); });
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Magost, App.game.farming.plotList.keys());
             });
 
         // #34 Unlock at least one Durin berry through mutation
@@ -802,7 +823,7 @@ class AutomationFarm
             BerryType.Durin,
             function()
             {
-                App.game.farming.plotList.forEach((_, index) => { Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Rabuta); });
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Rabuta, App.game.farming.plotList.keys());
             });
 
         // #35 Unlock at least one Belue berry through mutation
@@ -810,7 +831,7 @@ class AutomationFarm
             BerryType.Belue,
             function()
             {
-                App.game.farming.plotList.forEach((_, index) => { Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Nomel); });
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Nomel, App.game.farming.plotList.keys());
             });
 
         /**********************************\
@@ -877,7 +898,7 @@ class AutomationFarm
             BerryType.Yache,
             function()
             {
-                [ 0, 2, 4, 10, 12, 14, 20, 22, 24 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Passho));
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Passho, [ 0, 2, 4, 10, 12, 14, 20, 22, 24 ]);
             });
 
         // #45 Unlock at least one Payapa berry through mutation
@@ -895,14 +916,13 @@ class AutomationFarm
             BerryType.Tanga,
             function()
             {
-                App.game.farming.plotList.forEach(
-                    (_, index) =>
+                for (const index of App.game.farming.plotList.keys())
+                {
+                    if (![ 6, 9, 21, 24 ].includes(index))
                     {
-                        if (![ 6, 9, 21, 24 ].includes(index))
-                        {
-                            Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Rindo);
-                        }
-                    });
+                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Rindo);
+                    }
+                }
             });
 
         // #48 Unlock at least one Kasib berry through mutation
@@ -910,7 +930,7 @@ class AutomationFarm
             BerryType.Kasib,
             function()
             {
-                App.game.farming.plotList.forEach((plot, index) => { Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Cheri); });
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Cheri, App.game.farming.plotList.keys());
             });
 
         // #49 Unlock at least one Haban berry through mutation
@@ -944,7 +964,7 @@ class AutomationFarm
             BerryType.Shuca,
             function()
             {
-                App.game.farming.plotList.forEach((_, index) => { Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Watmel); });
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Watmel, App.game.farming.plotList.keys());
             },
             OakItemType.Sprinklotad);
 
@@ -953,7 +973,7 @@ class AutomationFarm
             BerryType.Charti,
             function()
             {
-                App.game.farming.plotList.forEach((_, index) => { Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Cornn); });
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Cornn, App.game.farming.plotList.keys());
             },
             OakItemType.Cell_Battery);
 
@@ -962,9 +982,8 @@ class AutomationFarm
             BerryType.Babiri,
             function()
             {
-                [ 0, 1, 2, 3, 4, 7, 17, 20, 21, 22, 23, 24 ].forEach(
-                    (index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Shuca));
-                [ 5, 9, 10, 11, 12, 13, 14, 15, 19 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Charti));
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Shuca, [ 0, 1, 2, 3, 4, 7, 17, 20, 21, 22, 23, 24 ]);
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Charti, [ 5, 9, 10, 11, 12, 13, 14, 15, 19 ]);
             });
 
         // #41 Unlock at least one Chople berry through mutation (moved this far to avoid any problem, since it uses Oak items)
@@ -972,7 +991,7 @@ class AutomationFarm
             BerryType.Chople,
             function()
             {
-                App.game.farming.plotList.forEach((_, index) => { Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Spelon); });
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Spelon, App.game.farming.plotList.keys());
             },
             OakItemType.Blaze_Cassette);
 
@@ -1011,12 +1030,12 @@ class AutomationFarm
                 // Nothing planted, plant the first batch
                 if (App.game.farming.plotList[6].isEmpty())
                 {
-                    [ 6, 8, 16, 18 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Chople));
+                    Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Chople, [ 6, 8, 16, 18 ]);
                 }
                 // First batch ripped, plant the rest
                 else if (App.game.farming.plotList[6].age > App.game.farming.plotList[6].berryData.growthTime[3])
                 {
-                    App.game.farming.plotList.forEach((_, index) => { Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Chople); });
+                    Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Chople, App.game.farming.plotList.keys());
                 }
             });
     }
@@ -1134,14 +1153,13 @@ class AutomationFarm
         this.__internal__addUnlockMutationStrategy(BerryType.Starf,
                                                    function()
                                                    {
-                                                       App.game.farming.plotList.forEach(
-                                                           (_, index) =>
+                                                       for (const index of App.game.farming.plotList.keys())
+                                                       {
+                                                           if (![ 11, 12, 13 ].includes(index))
                                                            {
-                                                               if (![ 11, 12, 13 ].includes(index))
-                                                               {
-                                                                   Automation.Farm.__internal__tryPlantBerryAtIndex(index, berryType);
-                                                               }
-                                                           });
+                                                               Automation.Farm.__internal__tryPlantBerryAtIndex(index, berryType);
+                                                           }
+                                                       }
                                                    },
                                                    null,
                                                    null,
@@ -1177,14 +1195,17 @@ class AutomationFarm
                 action: function()
                     {
                         // Always harvest the middle on as soon as possible
-                        [ 7, 17 ].forEach((index) => FarmController.plotClick(index));
+                        for (const index of [ 7, 17 ])
+                        {
+                            FarmController.plotClick(index);
+                        }
 
                         // Plant the needed berries
-                        [ 1, 21 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Oran));
-                        [ 2, 22 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Leppa));
-                        [ 3, 23 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Aspear));
-                        [ 6, 16 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Sitrus));
-                        [ 8, 18 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Rawst));
+                        Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Oran, [ 1, 21 ]);
+                        Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Leppa, [ 2, 22 ]);
+                        Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Aspear, [ 3, 23 ]);
+                        Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Sitrus, [ 6, 16 ]);
+                        Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Rawst, [ 8, 18 ]);
                         Automation.Farm.__internal__tryPlantBerryAtIndex(11, BerryType.Pecha);
                         Automation.Farm.__internal__tryPlantBerryAtIndex(12, BerryType.Cheri);
                         Automation.Farm.__internal__tryPlantBerryAtIndex(13, BerryType.Chesto);
@@ -1200,7 +1221,7 @@ class AutomationFarm
             BerryType.Kebia,
             function()
             {
-                App.game.farming.plotList.forEach((plot, index) => { Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Pamtre); });
+                Automation.Farm.__internal__tryPlantBerryAtIndexes(BerryType.Pamtre, App.game.farming.plotList.keys());
             },
             OakItemType.Rocky_Helmet);
     }
@@ -1223,14 +1244,13 @@ class AutomationFarm
                         {
                             let neededBerries = EnigmaMutation.getReqs();
                             // North berry
-                            [ 1, 13 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, neededBerries[0]));
+                            Automation.Farm.__internal__tryPlantBerryAtIndexes(neededBerries[0], [ 1, 13 ]);
                             // West berry
-                            [ 5, 17 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, neededBerries[1]));
+                            Automation.Farm.__internal__tryPlantBerryAtIndexes(neededBerries[1], [ 5, 17 ]);
                             // East berry
-                            [ 7, 19 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, neededBerries[2]));
+                            Automation.Farm.__internal__tryPlantBerryAtIndexes(neededBerries[2], [ 7, 19 ]);
                             // South berry
-                            [ 11, 23 ].forEach((index) => Automation.Farm.__internal__tryPlantBerryAtIndex(index, neededBerries[3]));
-
+                            Automation.Farm.__internal__tryPlantBerryAtIndexes(neededBerries[3], [ 11, 23 ]);
                         }
             });
     }
@@ -1326,31 +1346,33 @@ class AutomationFarm
                 action: function()
                 {
                     let plotIndex = 0;
-                    berriesToGather.every(
-                        (berryType) =>
+                    for (const berryType of berriesToGather)
+                    {
+                        let neededAmount = (berriesMinAmount - App.game.farming.berryList[berryType]());
+                        let berryHarvestAmount = App.game.farming.berryData[berryType].harvestAmount;
+
+                        let alreadyPlantedCount = this.__internal__getPlantedBerriesCount(berryType);
+                        neededAmount -= (alreadyPlantedCount * berryHarvestAmount);
+
+                        while ((neededAmount > 0) && (plotIndex <= 24))
                         {
-                            let neededAmount = (berriesMinAmount - App.game.farming.berryList[berryType]());
-                            let berryHarvestAmount = App.game.farming.berryData[berryType].harvestAmount;
-
-                            let alreadyPlantedCount = this.__internal__getPlantedBerriesCount(berryType);
-                            neededAmount -= (alreadyPlantedCount * berryHarvestAmount);
-
-                            while ((neededAmount > 0) && (plotIndex <= 24))
+                            if (App.game.farming.plotList[plotIndex].isUnlocked
+                                && App.game.farming.plotList[plotIndex].isEmpty()
+                                && App.game.farming.hasBerry(berryType))
                             {
-                                if (App.game.farming.plotList[plotIndex].isUnlocked
-                                    && App.game.farming.plotList[plotIndex].isEmpty()
-                                    && App.game.farming.hasBerry(berryType))
-                                {
-                                    App.game.farming.plant(plotIndex, berryType, true);
+                                App.game.farming.plant(plotIndex, berryType, true);
 
-                                    // Subtract the harvest amount (-1 for the planted berry)
-                                    neededAmount -= (berryHarvestAmount - 1);
-                                }
-                                plotIndex++;
+                                // Subtract the harvest amount (-1 for the planted berry)
+                                neededAmount -= (berryHarvestAmount - 1);
                             }
+                            plotIndex++;
+                        }
 
-                            return (plotIndex <= 24);
-                        }, this);
+                        if (plotIndex > 24)
+                        {
+                            break;
+                        }
+                    }
 
                     // If no more berries are needed, plant Cheris on the remaining plots
                     FarmController.selectedBerry(BerryType.Cheri);
@@ -1366,17 +1388,14 @@ class AutomationFarm
     {
         this.__internal__currentStrategy = null;
 
-        this.__internal__unlockStrategySelection.every(
-            (strategy) =>
+        for (const strategy of this.__internal__unlockStrategySelection)
+        {
+            if (strategy.isNeeded())
             {
-                if (!strategy.isNeeded())
-                {
-                    return true;
-                }
-
                 this.__internal__currentStrategy = strategy;
-                return false;
-            }, this);
+                break;
+            }
+        }
 
         // If no strategy can be found, turn off the feature and disable the button
         if (this.__internal__currentStrategy === null)

--- a/src/lib/Gym.js
+++ b/src/lib/Gym.js
@@ -185,42 +185,40 @@
             selectElem.innerHTML = "";
 
             let selectedItemSet = false;
-            gymList.forEach(
-                (gym) =>
+            for (const gym of gymList)
+            {
+                let opt = document.createElement("option");
+                opt.value = gym.town;
+                opt.id = gym.town;
+                opt.innerHTML = gym.leaderName;
+
+                // Don't show the option if it's not been unlocked yet
+                if (!gym.isUnlocked())
                 {
-                    let opt = document.createElement("option");
-                    opt.value = gym.town;
-                    opt.id = gym.town;
-                    opt.innerHTML = gym.leaderName;
+                    opt.style.display = "none";
+                }
+                else if (!selectedItemSet)
+                {
+                    opt.selected = true;
+                    selectedItemSet = true;
+                }
 
-                    // Don't show the option if it's not been unlocked yet
-                    if (!gym.isUnlocked())
-                    {
-                        opt.style.display = "none";
-                    }
-                    else if (!selectedItemSet)
-                    {
-                        opt.selected = true;
-                        selectedItemSet = true;
-                    }
-
-                    selectElem.options.add(opt);
-                });
+                selectElem.options.add(opt);
+            }
         }
         else
         {
-            gymList.forEach(
-                (gym) =>
+            for (const gym of gymList)
+            {
+                if (gym.isUnlocked())
                 {
-                    if (gym.isUnlocked())
+                    let opt = selectElem.options.namedItem(gym.town);
+                    if (opt.style.display === "none")
                     {
-                        let opt = selectElem.options.namedItem(gym.town);
-                        if (opt.style.display === "none")
-                        {
-                            opt.style.display = "block";
-                        }
+                        opt.style.display = "block";
                     }
-                });
+                }
+            }
         }
 
         if (unlockedGymCount === 0)

--- a/src/lib/Hatchery.js
+++ b/src/lib/Hatchery.js
@@ -214,7 +214,10 @@ class AutomationHatchery
     static __internal__hatcheryLoop()
     {
         // Attempt to hatch each egg. If the egg is at 100% it will succeed
-        [3, 2, 1, 0].forEach((index) => App.game.breeding.hatchPokemonEgg(index));
+        for (const index of [3, 2, 1, 0])
+        {
+            App.game.breeding.hatchPokemonEgg(index);
+        }
 
         // Try to use eggs first, if enabled
         if (Automation.Utils.LocalStorage.getValue(this.Settings.UseEggs) === "true")
@@ -273,29 +276,28 @@ class AutomationHatchery
     {
         let eggList = Object.keys(GameConstants.EggItemType).filter((eggType) => isNaN(eggType) && player._itemList[eggType]());
 
-        eggList.forEach(
-            (eggTypeName) =>
+        for (const eggTypeName of eggList)
+        {
+            let eggType = ItemList[eggTypeName];
+            let pokemonType = PokemonType[eggTypeName.split('_')[0]];
+            // Use an egg only if:
+            //   - a slot is available
+            //   - the player has one
+            //   - a new pokemon can be caught that way
+            //   - the item actually can be used
+            //   - no other egg of that type is breeding
+            if (App.game.breeding.hasFreeEggSlot()
+                && player.itemList[eggType.name]()
+                && !eggType.getCaughtStatus()
+                && eggType.checkCanUse()
+                && ![3, 2, 1, 0].some((index) => !App.game.breeding.eggList[index]().isNone()
+                                                && ((App.game.breeding.eggList[index]().pokemonType1 === pokemonType)
+                                                    || (App.game.breeding.eggList[index]().pokemonType2 === pokemonType))))
             {
-                let eggType = ItemList[eggTypeName];
-                let pokemonType = PokemonType[eggTypeName.split('_')[0]];
-                // Use an egg only if:
-                //   - a slot is available
-                //   - the player has one
-                //   - a new pokemon can be caught that way
-                //   - the item actually can be used
-                //   - no other egg of that type is breeding
-                if (App.game.breeding.hasFreeEggSlot()
-                    && player.itemList[eggType.name]()
-                    && !eggType.getCaughtStatus()
-                    && eggType.checkCanUse()
-                    && ![3, 2, 1, 0].some((index) => !App.game.breeding.eggList[index]().isNone()
-                                                  && ((App.game.breeding.eggList[index]().pokemonType1 === pokemonType)
-                                                      || (App.game.breeding.eggList[index]().pokemonType2 === pokemonType))))
-                {
-                    eggType.use();
-                    Automation.Utils.sendNotif("Added a " + eggType.displayName + " to the Hatchery!", "Hatchery");
-                }
-            }, this);
+                eggType.use();
+                Automation.Utils.sendNotif("Added a " + eggType.displayName + " to the Hatchery!", "Hatchery");
+            }
+        }
     }
 
     /**
@@ -461,15 +463,13 @@ class AutomationHatchery
         let contagiousPokemonTypes = new Set();
 
         // Build the list of possible contagious types
-        contagiousPokemons.forEach(
-            (pokemon) =>
+        for (const pokemon of contagiousPokemons)
+        {
+            for (const type of pokemonMap[pokemon.id].type)
             {
-                pokemonMap[pokemon.id].type.forEach(
-                    type =>
-                    {
-                        contagiousPokemonTypes.add(type);
-                    });
-            });
+                contagiousPokemonTypes.add(type);
+            }
+        }
 
         // Pick the next best contagious pokémon candidate
         let bestPokemonMatchingAContagiousType = targetPokemons.find(
@@ -505,7 +505,10 @@ class AutomationHatchery
             {
                 pokemonToBreed.push(bestCandidate);
                 let hatchingContagiousTypes = new Set();
-                pokemonMap[bestCandidate.id].type.forEach(type => hatchingContagiousTypes.add(type));
+                for (const type of pokemonMap[bestCandidate.id].type)
+                {
+                    hatchingContagiousTypes.add(type);
+                }
                 pokemonToBreed = this.__internal__addBestPokemonWithTypes(hatchingContagiousTypes, targetPokemons, pokemonToBreed, availableEggSlot);
             }
         }

--- a/src/lib/Hatchery.js
+++ b/src/lib/Hatchery.js
@@ -411,7 +411,8 @@ class AutomationHatchery
         // Both Contagious and Cured pokemon spread the Pokérus
         let contagiousPokemons = sortedPokemonCandidates.filter(pokemon => (pokemon?.pokerus === GameConstants.Pokerus.Contagious)
                                                                         || (pokemon?.pokerus === GameConstants.Pokerus.Cured));
-        let availableEggSlot = App.game.breeding.eggList.reduce((count, egg) => count + (egg().isNone() ? 1 : 0), 0);
+        let availableEggSlot = App.game.breeding.eggList.reduce((count, egg) => count + (egg().isNone() ? 1 : 0), 0)
+                             - (App.game.breeding.eggList.length - App.game.breeding.eggSlots);
 
         let hatchingContagiousTypes = new Set();
 

--- a/src/lib/Items.js
+++ b/src/lib/Items.js
@@ -222,22 +222,19 @@ class AutomationItems
             return;
         }
 
-        App.game.oakItems.itemList.forEach(
-            (item) =>
+        for (const item of App.game.oakItems.itemList)
+        {
+            if (!item.isUnlocked() || item.isMaxLevel() || !item.hasEnoughExp())
             {
-                if (!item.isUnlocked()
-                    || item.isMaxLevel()
-                    || !item.hasEnoughExp())
-                {
-                    return;
-                }
+                continue;
+            }
 
-                let itemCost = item.calculateCost();
-                if (itemCost.amount < App.game.wallet.currencies[itemCost.currency]())
-                {
-                    item.buy();
-                }
-            });
+            let itemCost = item.calculateCost();
+            if (itemCost.amount < App.game.wallet.currencies[itemCost.currency]())
+            {
+                item.buy();
+            }
+        }
     }
 
     /**
@@ -250,20 +247,18 @@ class AutomationItems
     static __internal__gemUpgradeLoop()
     {
         // Iterate over gem types
-        [...Array(Gems.nTypes).keys()].forEach(
-            (type) =>
+        for (const type of Array(Gems.nTypes).keys())
+        {
+            // Iterate over affinity (backward)
+            for (const affinity of Array(Gems.nEffects).keys())
             {
-                // Iterate over affinity (backward)
-                [...Array(Gems.nEffects).keys()].reverse().forEach(
-                    (affinity) =>
-                    {
-                        if (App.game.gems.isValidUpgrade(type, affinity)
-                            && !App.game.gems.hasMaxUpgrade(type, affinity)
-                            && App.game.gems.canBuyGemUpgrade(type, affinity))
-                        {
-                            App.game.gems.buyGemUpgrade(type, affinity);
-                        }
-                    })
-            });
+                if (App.game.gems.isValidUpgrade(type, affinity)
+                    && !App.game.gems.hasMaxUpgrade(type, affinity)
+                    && App.game.gems.canBuyGemUpgrade(type, affinity))
+                {
+                    App.game.gems.buyGemUpgrade(type, affinity);
+                }
+            }
+        }
     }
 }

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -515,7 +515,10 @@ class AutomationMenu
                     arrowDiv.classList.add("right");
 
                     // Hide all other settings panels
-                    Array.from(allSettingsPanels).forEach((el) => { el.setAttribute("automation-visible", "false"); });
+                    for (const el of Array.from(allSettingsPanels))
+                    {
+                        el.setAttribute("automation-visible", "false");
+                    }
                     placeholderDiv.removeAttribute("automation-visible");
                 }
                 else
@@ -524,7 +527,10 @@ class AutomationMenu
                     arrowDiv.classList.remove("right");
 
                     // Show all settings panels
-                    Array.from(allSettingsPanels).forEach((el) => { el.removeAttribute("automation-visible"); });
+                    for (const el of Array.from(allSettingsPanels))
+                    {
+                        el.removeAttribute("automation-visible");
+                    }
                 }
             };
 

--- a/src/lib/Shop.js
+++ b/src/lib/Shop.js
@@ -184,147 +184,146 @@ class AutomationShop
         let table = document.createElement("table");
         table.style.textAlign = "left";
 
-        pokeMartShop.items.forEach(
-            (item) =>
+        for (const item of pokeMartShop.items)
+        {
+            let tableRow = document.createElement("tr");
+            table.appendChild(tableRow);
+            let tableFirstCell = document.createElement("td");
+            tableFirstCell.style.paddingLeft = "7px";
+            tableRow.appendChild(tableFirstCell);
+
+            // Add the toggle button
+            let buttonElem = Automation.Menu.addLocalStorageBoundToggleButton(this.__internal__advancedSettings.ItemEnabled(item.name));
+            tableFirstCell.appendChild(buttonElem);
+
+            // Buy count
+            let tableBuyLabelCell = document.createElement("td");
+            tableBuyLabelCell.style.paddingLeft = "4px";
+            tableBuyLabelCell.style.paddingRight = "4px";
+            tableRow.appendChild(tableBuyLabelCell);
+
+            let label = document.createTextNode("Buy");
+            tableBuyLabelCell.appendChild(label);
+
+            let tableBuyCountCell = document.createElement("td");
+            tableRow.appendChild(tableBuyCountCell);
+            let buyCount = Automation.Menu.createTextInputElement(4, "[0-9]");
+            buyCount.innerHTML = Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.BuyAmount(item.name));
+            buyCount.style.width = "100%"; // Make it take the whole cell space
+            buyCount.style.margin = "0px";
+            buyCount.style.textAlign = "right";
+            tableBuyCountCell.appendChild(buyCount);
+
+            let tableTargetLabelCell = document.createElement("td");
+            tableTargetLabelCell.style.paddingRight = "4px";
+            tableRow.appendChild(tableTargetLabelCell);
+            let itemImage = document.createElement("img");
+            if (item.imageDirectory !== undefined)
             {
-                let tableRow = document.createElement("tr");
-                table.appendChild(tableRow);
-                let tableFirstCell = document.createElement("td");
-                tableFirstCell.style.paddingLeft = "7px";
-                tableRow.appendChild(tableFirstCell);
+                itemImage.src = `assets/images/items/${item.imageDirectory}/${item.name}.png`;
+            }
+            else
+            {
+                itemImage.src = `assets/images/items/${item.name}.png`;
+            }
+            itemImage.style.height = "25px";
+            tableTargetLabelCell.appendChild(itemImage);
 
-                // Add the toggle button
-                let buttonElem = Automation.Menu.addLocalStorageBoundToggleButton(this.__internal__advancedSettings.ItemEnabled(item.name));
-                tableFirstCell.appendChild(buttonElem);
+            // Until count
+            label = document.createTextNode("until the player has");
+            tableTargetLabelCell.appendChild(label);
 
-                // Buy count
-                let tableBuyLabelCell = document.createElement("td");
-                tableBuyLabelCell.style.paddingLeft = "4px";
-                tableBuyLabelCell.style.paddingRight = "4px";
-                tableRow.appendChild(tableBuyLabelCell);
+            let tableUntilCountCell = document.createElement("td");
+            tableRow.appendChild(tableUntilCountCell);
+            let untilCount = Automation.Menu.createTextInputElement(10, "[0-9]");
+            untilCount.innerHTML = Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.TargetAmount(item.name));
+            untilCount.style.width = "100%"; // Make it take the whole cell space
+            untilCount.style.margin = "0px";
+            untilCount.style.textAlign = "right";
+            tableUntilCountCell.appendChild(untilCount);
 
-                let label = document.createTextNode("Buy");
-                tableBuyLabelCell.appendChild(label);
+            // Max price
+            let tableMaxPriceLabelCell = document.createElement("td");
+            tableMaxPriceLabelCell.style.paddingLeft = "4px";
+            tableMaxPriceLabelCell.style.paddingRight = "4px";
+            tableRow.appendChild(tableMaxPriceLabelCell);
+            label = document.createTextNode("at max base price");
+            tableMaxPriceLabelCell.appendChild(label);
 
-                let tableBuyCountCell = document.createElement("td");
-                tableRow.appendChild(tableBuyCountCell);
-                let buyCount = Automation.Menu.createTextInputElement(4, "[0-9]");
-                buyCount.innerHTML = Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.BuyAmount(item.name));
-                buyCount.style.width = "100%"; // Make it take the whole cell space
-                buyCount.style.margin = "0px";
-                buyCount.style.textAlign = "right";
-                tableBuyCountCell.appendChild(buyCount);
+            let tableMaxPriceCell = document.createElement("td");
+            tableRow.appendChild(tableMaxPriceCell);
+            let maxPrice = Automation.Menu.createTextInputElement(10, "[0-9]");
+            maxPrice.style.width = "100%"; // Make it take the whole cell space
+            maxPrice.style.margin = "0px";
+            maxPrice.style.textAlign = "right";
+            maxPrice.innerHTML = Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.MaxBuyUnitPrice(item.name));
+            tableMaxPriceCell.appendChild(maxPrice);
 
-                let tableTargetLabelCell = document.createElement("td");
-                tableTargetLabelCell.style.paddingRight = "4px";
-                tableRow.appendChild(tableTargetLabelCell);
-                let itemImage = document.createElement("img");
-                if (item.imageDirectory !== undefined)
+            let tableLastCell = document.createElement("td");
+            tableRow.appendChild(tableLastCell);
+            let pokedollarsImage = document.createElement("img");
+            pokedollarsImage.src = "assets/images/currency/money.svg";
+            pokedollarsImage.style.height = "25px";
+            tableLastCell.appendChild(pokedollarsImage);
+
+            // The save status checkmark
+            let checkmark = Automation.Menu.createAnimatedCheckMarkElement();
+            tableLastCell.appendChild(checkmark);
+
+            parentDiv.appendChild(table);
+
+            // Set all oninput callbacks
+            buyCount.oninput = function()
                 {
-                    itemImage.src = `assets/images/items/${item.imageDirectory}/${item.name}.png`;
-                }
-                else
+                    this.__internal_setSaveItemChangesTimeout(item.name, checkmark, buyCount, untilCount, maxPrice);
+                }.bind(this);
+            untilCount.oninput = function()
                 {
-                    itemImage.src = `assets/images/items/${item.name}.png`;
-                }
-                itemImage.style.height = "25px";
-                tableTargetLabelCell.appendChild(itemImage);
-
-                // Until count
-                label = document.createTextNode("until the player has");
-                tableTargetLabelCell.appendChild(label);
-
-                let tableUntilCountCell = document.createElement("td");
-                tableRow.appendChild(tableUntilCountCell);
-                let untilCount = Automation.Menu.createTextInputElement(10, "[0-9]");
-                untilCount.innerHTML = Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.TargetAmount(item.name));
-                untilCount.style.width = "100%"; // Make it take the whole cell space
-                untilCount.style.margin = "0px";
-                untilCount.style.textAlign = "right";
-                tableUntilCountCell.appendChild(untilCount);
-
-                // Max price
-                let tableMaxPriceLabelCell = document.createElement("td");
-                tableMaxPriceLabelCell.style.paddingLeft = "4px";
-                tableMaxPriceLabelCell.style.paddingRight = "4px";
-                tableRow.appendChild(tableMaxPriceLabelCell);
-                label = document.createTextNode("at max base price");
-                tableMaxPriceLabelCell.appendChild(label);
-
-                let tableMaxPriceCell = document.createElement("td");
-                tableRow.appendChild(tableMaxPriceCell);
-                let maxPrice = Automation.Menu.createTextInputElement(10, "[0-9]");
-                maxPrice.style.width = "100%"; // Make it take the whole cell space
-                maxPrice.style.margin = "0px";
-                maxPrice.style.textAlign = "right";
-                maxPrice.innerHTML = Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.MaxBuyUnitPrice(item.name));
-                tableMaxPriceCell.appendChild(maxPrice);
-
-                let tableLastCell = document.createElement("td");
-                tableRow.appendChild(tableLastCell);
-                let pokedollarsImage = document.createElement("img");
-                pokedollarsImage.src = "assets/images/currency/money.svg";
-                pokedollarsImage.style.height = "25px";
-                tableLastCell.appendChild(pokedollarsImage);
-
-                // The save status checkmark
-                let checkmark = Automation.Menu.createAnimatedCheckMarkElement();
-                tableLastCell.appendChild(checkmark);
-
-                parentDiv.appendChild(table);
-
-                // Set all oninput callbacks
-                buyCount.oninput = function()
+                    this.__internal_setSaveItemChangesTimeout(item.name, checkmark, buyCount, untilCount, maxPrice);
+                }.bind(this);
+            maxPrice.oninput = function()
+                {
+                    if (maxPrice.innerText < item.basePrice)
                     {
-                        this.__internal_setSaveItemChangesTimeout(item.name, checkmark, buyCount, untilCount, maxPrice);
-                    }.bind(this);
-                untilCount.oninput = function()
-                    {
-                        this.__internal_setSaveItemChangesTimeout(item.name, checkmark, buyCount, untilCount, maxPrice);
-                    }.bind(this);
-                maxPrice.oninput = function()
-                    {
-                        if (maxPrice.innerText < item.basePrice)
-                        {
-                            maxPrice.classList.add("invalid");
-                            // Let the time to the user to edit the value before setting back the minimum possible value
-                            let timeout = setTimeout(function()
-                                {
-                                    // Only update the value if it's still under the minimum possible
-                                    if (maxPrice.innerText < item.basePrice)
-                                    {
-                                        maxPrice.innerText = item.basePrice;
-                                        maxPrice.classList.remove("invalid");
-
-                                        // Move the cursor at the end of the input if still focused
-                                        var range = document.createRange();
-
-                                        if (maxPrice === document.activeElement)
-                                        {
-                                            var set = window.getSelection();
-                                            range.setStart(maxPrice.childNodes[0], maxPrice.innerText.length);
-                                            range.collapse(true);
-                                            set.removeAllRanges();
-                                            set.addRange(range);
-                                        }
-                                    }
-                                    this.__internal__activeTimeouts.delete(item.name);
-                                }.bind(this), 1000);
-
-                            if (this.__internal__activeTimeouts.has(item.name))
+                        maxPrice.classList.add("invalid");
+                        // Let the time to the user to edit the value before setting back the minimum possible value
+                        let timeout = setTimeout(function()
                             {
-                                clearTimeout(this.__internal__activeTimeouts.get(item.name));
+                                // Only update the value if it's still under the minimum possible
+                                if (maxPrice.innerText < item.basePrice)
+                                {
+                                    maxPrice.innerText = item.basePrice;
+                                    maxPrice.classList.remove("invalid");
+
+                                    // Move the cursor at the end of the input if still focused
+                                    var range = document.createRange();
+
+                                    if (maxPrice === document.activeElement)
+                                    {
+                                        var set = window.getSelection();
+                                        range.setStart(maxPrice.childNodes[0], maxPrice.innerText.length);
+                                        range.collapse(true);
+                                        set.removeAllRanges();
+                                        set.addRange(range);
+                                    }
+                                }
                                 this.__internal__activeTimeouts.delete(item.name);
-                            }
-                            this.__internal__activeTimeouts.set(item.name, timeout);
-                        }
-                        else
+                            }.bind(this), 1000);
+
+                        if (this.__internal__activeTimeouts.has(item.name))
                         {
-                            maxPrice.classList.remove("invalid");
+                            clearTimeout(this.__internal__activeTimeouts.get(item.name));
+                            this.__internal__activeTimeouts.delete(item.name);
                         }
-                        this.__internal_setSaveItemChangesTimeout(item.name, checkmark, buyCount, untilCount, maxPrice);
-                    }.bind(this);
-            }, this);
+                        this.__internal__activeTimeouts.set(item.name, timeout);
+                    }
+                    else
+                    {
+                        maxPrice.classList.remove("invalid");
+                    }
+                    this.__internal_setSaveItemChangesTimeout(item.name, checkmark, buyCount, untilCount, maxPrice);
+                }.bind(this);
+        }
     }
 
     /**
@@ -374,21 +373,20 @@ class AutomationShop
         Automation.Utils.LocalStorage.setDefaultValue(this.__internal__advancedSettings.MinPlayerCurrency, 1000000);
 
         // Set default value for all buyable items
-        pokeMartShop.items.forEach(
-            (item) =>
-            {
-                // Disable all items by default
-                Automation.Utils.LocalStorage.setDefaultValue(this.__internal__advancedSettings.ItemEnabled(item.name), false);
+        for (const item of pokeMartShop.items)
+        {
+            // Disable all items by default
+            Automation.Utils.LocalStorage.setDefaultValue(this.__internal__advancedSettings.ItemEnabled(item.name), false);
 
-                // By 10 items at a time by default
-                Automation.Utils.LocalStorage.setDefaultValue(this.__internal__advancedSettings.BuyAmount(item.name), 10);
+            // By 10 items at a time by default
+            Automation.Utils.LocalStorage.setDefaultValue(this.__internal__advancedSettings.BuyAmount(item.name), 10);
 
-                // Stop buying at a stock of 10'000 by default
-                Automation.Utils.LocalStorage.setDefaultValue(this.__internal__advancedSettings.TargetAmount(item.name), 10000);
+            // Stop buying at a stock of 10'000 by default
+            Automation.Utils.LocalStorage.setDefaultValue(this.__internal__advancedSettings.TargetAmount(item.name), 10000);
 
-                // Buy at the cheapest possible by default
-                Automation.Utils.LocalStorage.setDefaultValue(this.__internal__advancedSettings.MaxBuyUnitPrice(item.name), item.basePrice);
-            }, this);
+            // Buy at the cheapest possible by default
+            Automation.Utils.LocalStorage.setDefaultValue(this.__internal__advancedSettings.MaxBuyUnitPrice(item.name), item.basePrice);
+        }
     }
 
     /**
@@ -400,49 +398,48 @@ class AutomationShop
 
         let totalSpent = 0;
 
-        pokeMartShop.items.forEach(
-            (item) =>
+        for (const item of pokeMartShop.items)
+        {
+            // Skip any disabled item
+            if (Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.ItemEnabled(item.name)) !== "true")
             {
-                // Skip any disabled item
-                if (Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.ItemEnabled(item.name)) !== "true")
-                {
-                    return;
-                }
+                continue;
+            }
 
-                let itemData = ItemList[item.name];
-                let targetAmount = parseInt(Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.TargetAmount(item.name)));
+            let itemData = ItemList[item.name];
+            let targetAmount = parseInt(Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.TargetAmount(item.name)));
 
-                // Don't buy if the target quantity has been reached
-                if (this.__internal__getItemQuantity(item.name) > targetAmount)
-                {
-                    return;
-                }
+            // Don't buy if the target quantity has been reached
+            if (this.__internal__getItemQuantity(item.name) > targetAmount)
+            {
+                continue;
+            }
 
-                let buyAmount = parseInt(Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.BuyAmount(item.name)));
+            let buyAmount = parseInt(Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.BuyAmount(item.name)));
 
-                // Don't buy if it would bring the player under the set threshold
-                let totalPrice = itemData.totalPrice(buyAmount);
-                if (App.game.wallet.currencies[GameConstants.Currency.money]() < (minPlayerCurrency + totalPrice))
-                {
-                    return;
-                }
+            // Don't buy if it would bring the player under the set threshold
+            let totalPrice = itemData.totalPrice(buyAmount);
+            if (App.game.wallet.currencies[GameConstants.Currency.money]() < (minPlayerCurrency + totalPrice))
+            {
+                continue;
+            }
 
-                let maxUnitPrice = parseInt(Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.MaxBuyUnitPrice(item.name)));
+            let maxUnitPrice = parseInt(Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.MaxBuyUnitPrice(item.name)));
 
-                // Don't buy if the base price is over the set desired max price
-                if (itemData.totalPrice(1) > maxUnitPrice)
-                {
-                    return;
-                }
+            // Don't buy if the base price is over the set desired max price
+            if (itemData.totalPrice(1) > maxUnitPrice)
+            {
+                continue;
+            }
 
-                // Buy the item
-                itemData.buy(buyAmount);
-                totalSpent += totalPrice;
-            }, this);
+            // Buy the item
+            itemData.buy(buyAmount);
+            totalSpent += totalPrice;
+        }
 
         if (totalSpent > 0)
         {
-            let pokedollarsImage = `<img src="assets/images/currency/money.svg" height="25px">`;
+            let pokedollarsImage = '<img src="assets/images/currency/money.svg" height="25px">';
             Automation.Utils.sendNotif(`Bought some items for a total of ${totalSpent.toLocaleString('en-US')} ${pokedollarsImage}`, "Shop");
         }
     }

--- a/src/lib/Trivia.js
+++ b/src/lib/Trivia.js
@@ -208,29 +208,28 @@ class AutomationTrivia
 
             let selectedItemSet = false;
             // Build the new drop-down list
-            filteredList.forEach(
-                ([townName, town]) =>
+            for (const [townName, town] of filteredList)
+            {
+                const type = (town instanceof DungeonTown) ? "&nbsp;⚔&nbsp;" : "🏫";
+
+                let opt = document.createElement("option");
+                opt.value = townName;
+                opt.id = townName;
+                opt.innerHTML = type + ' ' + townName;
+
+                // Don't show the option if it's not been unlocked yet
+                if (!town.isUnlocked())
                 {
-                    const type = (town instanceof DungeonTown) ? "&nbsp;⚔&nbsp;" : "🏫";
+                    opt.style.display = "none";
+                }
+                else if (!selectedItemSet)
+                {
+                    opt.selected = true;
+                    selectedItemSet = true;
+                }
 
-                    let opt = document.createElement("option");
-                    opt.value = townName;
-                    opt.id = townName;
-                    opt.innerHTML = type + ' ' + townName;
-
-                    // Don't show the option if it's not been unlocked yet
-                    if (!town.isUnlocked())
-                    {
-                        opt.style.display = "none";
-                    }
-                    else if (!selectedItemSet)
-                    {
-                        opt.selected = true;
-                        selectedItemSet = true;
-                    }
-
-                    gotoList.options.add(opt);
-                });
+                gotoList.options.add(opt);
+            }
 
             this.__internal__previousRegion = player.region;
 
@@ -238,18 +237,17 @@ class AutomationTrivia
         }
         else if (this.__internal__currentLocationListSize != unlockedTownCount)
         {
-            filteredList.forEach(
-                ([townName, town]) =>
+            for (const [townName, town] of filteredList)
+            {
+                if (town.isUnlocked())
                 {
-                    if (town.isUnlocked())
+                    let opt = gotoList.options.namedItem(townName);
+                    if (opt.style.display === "none")
                     {
-                        let opt = gotoList.options.namedItem(townName);
-                        if (opt.style.display === "none")
-                        {
-                            opt.style.display = "block";
-                        }
+                        opt.style.display = "block";
                     }
-                });
+                }
+            }
         }
     }
 
@@ -320,18 +318,17 @@ class AutomationTrivia
 
             // Update the tooltip
             let tooltip = "The following pokemons are roaming this route:\n";
-            roamers.forEach(
-                (pokemon, index) =>
+            for (const [ index, pokemon ] of roamers.entries())
+            {
+                if (index !== 0)
                 {
-                    if (index !== 0)
-                    {
-                        let isLast = (index === (roamers.length - 1));
-                        tooltip += (isLast ? "" : ",")
-                                 + (((index % 3) === 0) ? "\n" : " ")
-                                 + (isLast ? "and " : "");
-                    }
-                    tooltip += pokemon.pokemon.name + " (#" + pokemon.pokemon.id + ")";
-                });
+                    let isLast = (index === (roamers.length - 1));
+                    tooltip += (isLast ? "" : ",")
+                                + (((index % 3) === 0) ? "\n" : " ")
+                                + (isLast ? "and " : "");
+                }
+                tooltip += pokemon.pokemon.name + " (#" + pokemon.pokemon.id + ")";
+            }
             textElem.setAttribute("automation-tooltip-text", tooltip);
 
             document.getElementById("roamingRouteTriviaContainer").hidden = false;
@@ -370,9 +367,11 @@ class AutomationTrivia
             let contentDiv = document.getElementById("availableEvolutionTriviaContent");
             contentDiv.innerHTML = "";
 
-            evoStones.forEach(
-                (stone) => contentDiv.innerHTML += '<img style="max-width: 28px;" src="assets/images/items/evolution/' + stone + '.png"'
-                                                 + ' onclick="javascript: Automation.Trivia.__internal__goToStoneMenu(\'' + stone + '\');">');
+            for (const stone of evoStones)
+            {
+                 contentDiv.innerHTML += `<img style="max-width: 28px;" src="assets/images/items/evolution/${stone}.png"`
+                                       + ` onclick="javascript: Automation.Trivia.__internal__goToStoneMenu('${stone}');">`;
+            }
 
             this.__internal__lastEvoStone = evoStones;
         }
@@ -416,9 +415,13 @@ class AutomationTrivia
     {
         var hasCandidate = false;
 
-        PokemonHelper.getPokemonsWithEvolution(GameConstants.StoneType[stone]).forEach(
-            (pokemon) => (PartyController.getStoneEvolutionsCaughtStatus(pokemon.id, GameConstants.StoneType[stone]).forEach(
-                              (status) => hasCandidate |= status == 0)));
+        for (const pokemon of PokemonHelper.getPokemonsWithEvolution(GameConstants.StoneType[stone]))
+        {
+            for (const status of PartyController.getStoneEvolutionsCaughtStatus(pokemon.id, GameConstants.StoneType[stone]))
+            {
+                hasCandidate |= (status == 0);
+            }
+        }
 
         return hasCandidate;
     }

--- a/src/lib/Utils/OakItem.js
+++ b/src/lib/Utils/OakItem.js
@@ -73,10 +73,9 @@ class AutomationUtilsOakItem
             }, this);
 
         App.game.oakItems.deactivateAll();
-        expectedLoadout.forEach(
-            (item) =>
-            {
-                App.game.oakItems.activate(item);
-            });
+        for (const item of expectedLoadout)
+        {
+            App.game.oakItems.activate(item);
+        }
     }
 }


### PR DESCRIPTION
For-of loops are way more readable and don't have tricky edge cases.

As for regular loops break and continue keyword works.
Some hacky use of every() were replaced with for-of loops.

---

A performance issue of the `moveToHighestDungeonTokenIncomeRoute` was addressed as well.

This method generated huge spikes in the profiler:
![image](https://user-images.githubusercontent.com/11090416/180617532-6f5725b1-1d8c-4bb7-bbd6-8fc508a55faa.png)

The callgraph shows that most of the time was spent accros 2 methods:
![image](https://user-images.githubusercontent.com/11090416/180617948-a5e703ab-eda6-40c7-a00d-ae542b9714f5.png)

The `calcBonus` method is a pokeclicker method. The call always returns the same value.
To avoid performing such computation each time, the data is computed for all routes at the start of the automation and stored in a map.

This reduced the spike considerably:
![image](https://user-images.githubusercontent.com/11090416/180617775-53f5dda5-3d28-45ce-82c9-e9163c28bbb0.png)

The `calcBonus` is not involved anymore:
![image](https://user-images.githubusercontent.com/11090416/180617828-17d2b870-bac3-4ea2-9996-ea5e207f9657.png)

The `getPlayerWorstPokemonAttack` might be worth optimizing though.
The responsible call is `App.game.party.calculatePokemonAttack`