### PR TITLE
Farm/Focus: Allow player to disable oak item loadout modification

### DIFF
--- a/src/lib/Farm.js
+++ b/src/lib/Farm.js
@@ -177,8 +177,8 @@ class AutomationFarm
         if ((Automation.Utils.LocalStorage.getValue(this.Settings.FocusOnUnlocks) === "true")
             && !this.ForcePlantBerriesAsked)
         {
-            this.__internal__equipOakItemIfNeeded();
             this.__internal__removeOakItemIfNeeded();
+            this.__internal__equipOakItemIfNeeded();
             this.__internal__currentStrategy.action();
         }
         else
@@ -195,19 +195,18 @@ class AutomationFarm
         }
 
         // Equip the right oak item if not already equipped
-        let customOakLoadout = App.game.oakItems.itemList.filter((item) => item.isActive);
+        let currentLoadout = App.game.oakItems.itemList.filter((item) => item.isActive);
 
-        if (!customOakLoadout.includes(this.__internal__currentStrategy.oakItemToEquip.oakItemToEquip))
+        if (!currentLoadout.some(item => (item.name == this.__internal__currentStrategy.oakItemToEquip)))
         {
-            // Prepend the item if it's not part of the current loadout
-            customOakLoadout.unshift(this.__internal__currentStrategy.oakItemToEquip.oakItemToEquip);
-
-            App.game.oakItems.deactivateAll();
-
-            for (const item of customOakLoadout)
+            // Remove the last item of the current loadout if needed
+            if (currentLoadout.length === App.game.oakItems.maxActiveCount())
             {
-                App.game.oakItems.activate(item);
+                App.game.oakItems.deactivate(currentLoadout.reverse()[0].name);
             }
+
+            // Equip the needed item
+            App.game.oakItems.activate(this.__internal__currentStrategy.oakItemToEquip);
         }
     }
 

--- a/src/lib/Focus.js
+++ b/src/lib/Focus.js
@@ -9,7 +9,8 @@ class AutomationFocus
 
     static Settings = {
                           FeatureEnabled: "Focus-Enabled",
-                          FocusedTopic: "Focus-SelectedTopic"
+                          FocusedTopic: "Focus-SelectedTopic",
+                          OakItemLoadoutUpdate: "Focus-OakItemLoadoutUpdate"
                       };
 
     /**
@@ -94,7 +95,7 @@ class AutomationFocus
         }
 
         // Equip the Oak item catch loadout
-        Automation.Utils.OakItem.equipLoadout(Automation.Utils.OakItem.Setup.PokemonCatch);
+        this.__internal__equipLoadout(Automation.Utils.OakItem.Setup.PokemonCatch);
 
         // Equip an "Already caught" pokeball
         App.game.pokeballs.alreadyCaughtSelection = GameConstants.Pokeball.Ultraball;
@@ -192,8 +193,34 @@ class AutomationFocus
         // Toggle the 'Focus on' loop on click
         focusButton.addEventListener("click", this.__internal__toggleFocus.bind(this), false);
 
-        // Add the quests-specific menu
-        this.Quests.__buildSpecificMenu(focusContainer);
+        // Build advanced settings
+        this.__internal__buildAdvancedSettings(focusContainer);
+    }
+
+    /**
+     * @brief Builds the 'Focus on' feature advanced settings panel
+     *
+     * @param {Element} parent: The parent div to add the settings to
+     */
+    static __internal__buildAdvancedSettings(parent)
+    {
+        // Build advanced settings panel
+        let focusSettingPanel = Automation.Menu.addSettingPanel(parent);
+        focusSettingPanel.style.textAlign = "right";
+
+        let titleDiv = Automation.Menu.createTitleElement("'Focus on' advanced settings");
+        titleDiv.style.marginBottom = "10px";
+        focusSettingPanel.appendChild(titleDiv);
+
+        // OakItem loadout setting
+        let disableOakItemTooltip = "Modifies the oak item loadout automatically";
+        Automation.Menu.addLabeledAdvancedSettingsToggleButton("Optimize oak item loadout",
+                                                               this.Settings.OakItemLoadoutUpdate,
+                                                               disableOakItemTooltip,
+                                                               focusSettingPanel);
+
+        // Add the quests-specific settings
+        this.Quests.__addAdvancedSettings(focusSettingPanel);
     }
 
     /**
@@ -455,7 +482,7 @@ class AutomationFocus
         }
 
         // Equip the most effective Oak item loadout for XP farming
-        Automation.Utils.OakItem.equipLoadout(Automation.Utils.OakItem.Setup.PokemonExp);
+        this.__internal__equipLoadout(Automation.Utils.OakItem.Setup.PokemonExp);
 
         Automation.Utils.Route.moveToBestRouteForExp();
     }
@@ -479,7 +506,7 @@ class AutomationFocus
         }
 
         // Equip the 'money' Oak loadout
-        Automation.Utils.OakItem.equipLoadout(Automation.Utils.OakItem.Setup.Money);
+        this.__internal__equipLoadout(Automation.Utils.OakItem.Setup.Money);
 
         // Fallback to the exp route if no gym can be found
         if (this.__internal__lastFocusData.bestGymTown === null)
@@ -517,6 +544,23 @@ class AutomationFocus
         else
         {
             Automation.Utils.Route.moveToRoute(bestRoute.Route, bestRoute.Region);
+        }
+    }
+
+    /**
+     * @brief Updates the Oak item loadout with the provided @p loadoutCandidates
+     *
+     * @note The loadout will only be modified if the OakItemLoadoutUpdate is enabled
+     *
+     * @see Automation.Utils.OakItem.equipLoadout()
+     *
+     * @param {Array} loadoutCandidates: The wanted loadout composition
+     */
+    static __internal__equipLoadout(loadoutCandidates)
+    {
+        if (Automation.Utils.LocalStorage.getValue(this.Settings.OakItemLoadoutUpdate) === "true")
+        {
+            Automation.Utils.OakItem.equipLoadout(loadoutCandidates);
         }
     }
 }

--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -146,7 +146,7 @@ class AutomationFocusAchievements
     static __internal__workOnRouteKillRequirement()
     {
         // Equip the Oak item Exp loadout
-        Automation.Utils.OakItem.equipLoadout(Automation.Utils.OakItem.Setup.PokemonExp);
+        Automation.Focus.__internal__equipLoadout(Automation.Utils.OakItem.Setup.PokemonExp);
 
         // Move to the selected route
         Automation.Utils.Route.moveToRoute(this.__internal__currentAchievement.property.route, this.__internal__currentAchievement.property.region);

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -42,13 +42,13 @@ class AutomationFocusQuests
     }
 
     /**
-     * @brief Builds the menu
+     * @brief Adds the Quest-specific advanced settings
      *
-     * The 'Use/buy Small Restore' functionality is disabled by default (if never set in a previous session)
+     * The 'Use/buy Small Restore' setting is disabled by default (if never set in a previous session)
      *
-     * @param parent: The div container to insert the menu to
+     * @param parent: The div container to insert the settings to
      */
-    static __buildSpecificMenu(parent)
+    static __addAdvancedSettings(parent)
     {
         // Disable use/buy small restore mode by default
         Automation.Utils.LocalStorage.setDefaultValue(this.Settings.UseSmallRestore, false);
@@ -57,11 +57,13 @@ class AutomationFocusQuests
                                 + Automation.Menu.TooltipSeparator
                                 + "This will only be used when a mining quest is active.\n"
                                 + "⚠️ This can be cost-heavy during early game";
-        let smallRestoreLabel = 'Use/buy<img src="assets/images/items/SmallRestore.png" height="26px">:';
-        let buttonContainer =
-            Automation.Menu.addAutomationButton(smallRestoreLabel, this.Settings.UseSmallRestore, smallRestoreTooltip, parent).parentElement;
-        buttonContainer.style.textAlign = "right";
-        buttonContainer.style.merginTop = "2px";
+        let smallRestoreLabel = 'Automatically buy and use<img src="assets/images/items/SmallRestore.png"'
+                              // Set the width smaller than the actual image one, and set it to preserve the image ratio to shrink the image margins
+                              + ' style="height: 26px; width: 19px; object-fit: cover; object-position: left top;">';
+        Automation.Menu.addLabeledAdvancedSettingsToggleButton(smallRestoreLabel,
+                                                               this.Settings.UseSmallRestore,
+                                                               smallRestoreTooltip,
+                                                               parent);
     }
 
     /*********************************************************************\
@@ -571,7 +573,7 @@ class AutomationFocusQuests
             {
                 // No more balls, go farm to buy some
                 App.game.pokeballs.alreadyCaughtSelection = GameConstants.Pokeball.None;
-                Automation.Utils.OakItem.equipLoadout(Automation.Utils.OakItem.Setup.Money);
+                Automation.Focus.__internal__equipLoadout(Automation.Utils.OakItem.Setup.Money);
 
                 let bestGym = Automation.Utils.Gym.findBestGymForMoney();
 
@@ -768,6 +770,6 @@ class AutomationFocusQuests
             }
         }
 
-        Automation.Utils.OakItem.equipLoadout(resultLoadout);
+        Automation.Focus.__internal__equipLoadout(resultLoadout);
     }
 }

--- a/src/lib/Utils/Route.js
+++ b/src/lib/Utils/Route.js
@@ -130,7 +130,7 @@ class AutomationUtilsRoute
 
         // We need to find a new road if:
         //    - The highest region changed
-        //    - The player attack decreased (this can happen if the rocky helmet item was unequiped)
+        //    - The player attack decreased (this can happen if the rocky helmet item was unequipped)
         //    - We are currently on the highest route of the map
         //    - The next best route is still over-powered
         let needsNewRoad = (this.__internal__lastHighestRegion !== player.highestRegion())


### PR DESCRIPTION
The new option is available through both Farm and Focus advanced settings.
The associated option only toggles the oak item management for the set feature.

Indeed, some player might want to keep one or the other feature's auto-equip.

Fixes #91 

---

Farm: Fixup oak item loadout being messed-up

The loadout was always reset because the item id was compared to the item object, which was obviously always different.

The custom loadout was a mix of items and item id.
Thus, only the needed item was equipped back because the `activate()` method takes the item's id as param, not the item object.

Only the last item of the current loadout is removed now, only if there is no room for the needed item.