### PR TITLE
Focus: Add pokeball advanced settings

### DIFF
--- a/src/lib/Focus.js
+++ b/src/lib/Focus.js
@@ -230,16 +230,28 @@ class AutomationFocus
         |*   Balls settings   *|
         \**********************/
 
-        // Pokeball to use for catching
-        this.__internal__pokeballToUseSelectElem = this.__internal__addPokeballList(
-            "focusPokeballToUseSelection", focusSettingPanel, this.Settings.BallToUseToCatch, "Pokeball to use for catching :");
+        let disclaimer = Automation.Menu.TooltipSeparator + "⚠️ Equipping higher pokéballs can be cost-heavy during early game";
 
-        // Default Pokeball for caught pokémons value
+        // Pokeball to use for catching
+        let pokeballToUseTooltip = "Defines which pokeball will be equipped to catch\n"
+                                 + "already caught pokémon, when needed"
+                                 + disclaimer;
+        this.__internal__pokeballToUseSelectElem = this.__internal__addPokeballList(
+            "focusPokeballToUseSelection", focusSettingPanel, this.Settings.BallToUseToCatch, "Pokeball to use for catching :", pokeballToUseTooltip);
+
+        // Default Pokeball for caught pokémons
+        let defaultCaughtPokeballTooltip = "Defines which pokeball will be equipped to catch\n"
+                                         + "already caught pokémon, when no catching is needed"
+                                         + Automation.Menu.TooltipSeparator
+                                         + "This setting will not be taken into account while focusing on quests.\n"
+                                         + "In this case no pokéball will be equipped to complete quests faster"
+                                         + disclaimer;
         this.__internal__defaultCaughtPokeballSelectElem =
             this.__internal__addPokeballList("focusDefaultCaughtBallSelection",
                                              focusSettingPanel,
                                              this.Settings.DefaultCaughtBall,
                                              "Default value for caught pokémon pokéball :",
+                                             defaultCaughtPokeballTooltip,
                                              true);
 
         /**********************\
@@ -267,15 +279,18 @@ class AutomationFocus
      * @param {Element} parent: The element to add the list to
      * @param {string}  setting: The local storage setting id
      * @param {string}  textLabel: The text to display before the list
+     * @param {string}  tooltip: The tooltip text to display upon hovering the list or the label
      * @param {boolean} addNoneOption: If set to true the None pokeball option will be added at the beginning of the list
      *
      * @returns The created drop-down list element
      */
-    static __internal__addPokeballList(id, parent, setting, textLabel, addNoneOption = false)
+    static __internal__addPokeballList(id, parent, setting, textLabel, tooltip, addNoneOption = false)
     {
         let container = document.createElement("div");
         container.style.paddingLeft = "10px";
         container.style.paddingRight = "10px";
+        container.classList.add("hasAutomationTooltip");
+        container.setAttribute("automation-tooltip-text", tooltip);
         parent.appendChild(container);
 
         let label = document.createTextNode(textLabel);

--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -62,7 +62,7 @@ class AutomationFocusAchievements
                                                                                           : Automation.Dungeon.InternalModes.None;
 
         Automation.Menu.forceAutomationState(Automation.Gym.Settings.FeatureEnabled, false);
-        App.game.pokeballs.alreadyCaughtSelection = GameConstants.Pokeball.None;
+        App.game.pokeballs.alreadyCaughtSelection = Automation.Focus.__internal__defaultCaughtPokeballSelectElem.value;
     }
 
     /**
@@ -120,7 +120,7 @@ class AutomationFocusAchievements
     static __internal__workOnAchievement()
     {
         // Reset any equipped pokeball
-        App.game.pokeballs.alreadyCaughtSelection = GameConstants.Pokeball.None;
+        App.game.pokeballs.alreadyCaughtSelection = Automation.Focus.__internal__defaultCaughtPokeballSelectElem.value;
 
         if (this.__internal__currentAchievement.property instanceof RouteKillRequirement)
         {

--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -59,7 +59,7 @@ class AutomationFocusAchievements
         this.__internal__achievementLoop = null;
 
         Automation.Dungeon.AutomationRequestedMode = Automation.Utils.isInInstanceState() ? Automation.Dungeon.InternalModes.StopAfterThisRun
-                                                                                            : Automation.Dungeon.InternalModes.None;
+                                                                                          : Automation.Dungeon.InternalModes.None;
 
         Automation.Menu.forceAutomationState(Automation.Gym.Settings.FeatureEnabled, false);
         App.game.pokeballs.alreadyCaughtSelection = GameConstants.Pokeball.None;

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -133,8 +133,8 @@ class AutomationFocusQuests
         Automation.Menu.setButtonDisabledState(Automation.Farm.Settings.FocusOnUnlocks, false);
         Automation.Menu.setButtonDisabledState(Automation.Underground.Settings.FeatureEnabled, false);
 
-        // Remove the ball to catch
-        this.__internal__selectBallToCatch(GameConstants.Pokeball.None);
+        // Restore the ball to catch default value
+        this.__internal__selectBallToCatch(Automation.Focus.__internal__defaultCaughtPokeballSelectElem.value);
     }
 
     /**

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -9,7 +9,7 @@ class AutomationFocusQuests
     static Settings = { UseSmallRestore: "Focus-Quest-UseSmallRestore" };
 
     /******************************************************************************\
-    |***    Focus specific members, should only be used by focus sub-classes    ***|
+    |***    Focus-specific members, should only be used by focus sub-classes    ***|
     \******************************************************************************/
 
     /**
@@ -147,7 +147,7 @@ class AutomationFocusQuests
     static __internal__questLoop()
     {
         // Make sure to always have some balls to catch pokemons
-        this.__internal__tryBuyBallIfUnderThreshold(GameConstants.Pokeball.Ultraball, 10);
+        this.__internal__tryBuyBallIfUnderThreshold(Automation.Focus.__internal__pokeballToUseSelectElem.value, 10);
 
         // Disable best route if needed
         Automation.Menu.forceAutomationState("bestRouteClickEnabled", false);
@@ -244,7 +244,7 @@ class AutomationFocusQuests
         if ((quest instanceof CapturePokemonsQuest)
             || (quest instanceof GainTokensQuest))
         {
-            this.__internal__workOnUsePokeballQuest(GameConstants.Pokeball.Ultraball);
+            this.__internal__workOnUsePokeballQuest(Automation.Focus.__internal__pokeballToUseSelectElem.value);
         }
         else if (quest instanceof CapturePokemonTypesQuest)
         {
@@ -282,7 +282,7 @@ class AutomationFocusQuests
             if (currentQuests.some((quest) => quest instanceof CatchShiniesQuest))
             {
                 // Buy some ball to be prepared
-                this.__internal__tryBuyBallIfUnderThreshold(GameConstants.Pokeball.Ultraball, 10);
+                this.__internal__tryBuyBallIfUnderThreshold(Automation.Focus.__internal__pokeballToUseSelectElem.value, 10);
                 this.__internal__equipOptimizedLoadout(Automation.Utils.OakItem.Setup.PokemonCatch);
             }
             else if (currentQuests.some((quest) => quest instanceof GainMoneyQuest))
@@ -355,7 +355,7 @@ class AutomationFocusQuests
     static __internal__workOnCapturePokemonTypesQuest(quest)
     {
         // Add a pokeball to the Caught type and set the PokemonCatch setup
-        let hasBalls = this.__internal__selectBallToCatch(GameConstants.Pokeball.Ultraball);
+        let hasBalls = this.__internal__selectBallToCatch(Automation.Focus.__internal__pokeballToUseSelectElem.value);
         this.__internal__equipOptimizedLoadout(Automation.Utils.OakItem.Setup.PokemonCatch);
 
         if (hasBalls)
@@ -381,7 +381,7 @@ class AutomationFocusQuests
         // If we don't have enough tokens, go farm some
         if (TownList[quest.dungeon].dungeon.tokenCost > App.game.wallet.currencies[Currency.dungeonToken]())
         {
-            this.__internal__workOnUsePokeballQuest(GameConstants.Pokeball.Ultraball);
+            this.__internal__workOnUsePokeballQuest(Automation.Focus.__internal__pokeballToUseSelectElem.value);
             return;
         }
 
@@ -483,7 +483,7 @@ class AutomationFocusQuests
     {
         if (quest.item == OakItemType.Magic_Ball)
         {
-            this.__internal__workOnUsePokeballQuest(GameConstants.Pokeball.Ultraball);
+            this.__internal__workOnUsePokeballQuest(Automation.Focus.__internal__pokeballToUseSelectElem.value);
         }
         else
         {
@@ -529,7 +529,7 @@ class AutomationFocusQuests
      */
     static __internal__selectBallToCatch(ballTypeToUse, enforceType = false)
     {
-        if (ballTypeToUse === GameConstants.Pokeball.None)
+        if (ballTypeToUse == GameConstants.Pokeball.None)
         {
             App.game.pokeballs.alreadyCaughtSelection = ballTypeToUse;
             return;

--- a/src/lib/Shop.js
+++ b/src/lib/Shop.js
@@ -54,7 +54,7 @@ class AutomationShop
         Automation.Menu.addSeparator(this.__internal__shoppingContainer);
 
         // Only display the menu when the Poké Mart is unlocked
-        if (!TownList["Cinnabar Island"].isUnlocked())
+        if (!App.game.statistics.gymsDefeated[GameConstants.getGymIndex('Champion Lance')])
         {
             this.__internal__shoppingContainer.hidden = true;
             this.__internal__setShoppingUnlockWatcher();
@@ -130,7 +130,7 @@ class AutomationShop
     {
         let watcher = setInterval(function()
             {
-                if (TownList["Cinnabar Island"].isUnlocked())
+                if (App.game.statistics.gymsDefeated[GameConstants.getGymIndex('Champion Lance')])
                 {
                     clearInterval(watcher);
                     this.__internal__shoppingContainer.hidden = false;
@@ -150,7 +150,7 @@ class AutomationShop
      */
     static __internal__toggleAutoBuy(enable)
     {
-        if (!TownList["Cinnabar Island"].isUnlocked())
+        if (!App.game.statistics.gymsDefeated[GameConstants.getGymIndex('Champion Lance')])
         {
             return;
         }

--- a/src/lib/Trivia.js
+++ b/src/lib/Trivia.js
@@ -324,8 +324,8 @@ class AutomationTrivia
                 {
                     let isLast = (index === (roamers.length - 1));
                     tooltip += (isLast ? "" : ",")
-                                + (((index % 3) === 0) ? "\n" : " ")
-                                + (isLast ? "and " : "");
+                             + (((index % 3) === 0) ? "\n" : " ")
+                             + (isLast ? "and " : "");
                 }
                 tooltip += pokemon.pokemon.name + " (#" + pokemon.pokemon.id + ")";
             }


### PR DESCRIPTION
Add an option to define the ball to use to catch pokémons

The Ultraball was used by default, which might be a bit too expensive
early game.

An advanced option is now available to now choose which ball to use.
This will only affect selection when no particular ball is needed.

Fixes #93

---

Add an option to define the ball when no catching is needed

No ball was used by default, which might be ineffective when trying to
grind EVs while focusing on some topic.

An advanced option is now available to now choose which ball to use.
This will not affect the default value when focusing on quests.

Fixes #93 

---

Shop: Fixup feature being unlocked too early

The unlock condition was on "Cinnabar Island" city unlock.
However, the Poké Mart shortcut is only available upon beating
the league "Champion Lance".