### PR TITLE
Shop: Fixup shop always being visible

### DIFF
--- a/src/.vscode/settings.json
+++ b/src/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "files.trimTrailingWhitespace": true,
     "editor.rulers": [ 150 ],
     "workbench.colorCustomizations": {
         "editorRuler.foreground": "#0b80ce"

--- a/src/lib/Farm.js
+++ b/src/lib/Farm.js
@@ -1493,7 +1493,7 @@ class AutomationFarm
         }
 
         this.__internal__disableAutoUnlock("You need to catch " + this.__internal__currentStrategy.requiredPokemon
-                               + " (#" + neededPokemonId.toString() + ") for the next unlock");
+                                         + " (#" + neededPokemonId.toString() + ") for the next unlock");
 
         // Set a watcher to re-enable the feature once the pokemon has been caught
         let watcher = setInterval(function()
@@ -1527,7 +1527,7 @@ class AutomationFarm
             }
 
             this.__internal__disableAutoUnlock("You need to collect the four hints from the Kanto Berry Master\n"
-                                     + "for the next unlock. He's located in Cerulean City.");
+                                             + "for the next unlock. He's located in Cerulean City.");
         }
         else
         {

--- a/src/lib/Focus.js
+++ b/src/lib/Focus.js
@@ -374,6 +374,9 @@ class AutomationFocus
             {
                 if (this.__internal__activeFocus.stop !== undefined)
                 {
+                    // Reset any dungeon request that might have occured using __ensureNoInstanceIsInProgress
+                    Automation.Dungeon.AutomationRequestedMode = Automation.Dungeon.InternalModes.None;
+
                     this.__internal__activeFocus.stop();
                 }
                 this.__internal__activeFocus = null;

--- a/src/lib/Shop.js
+++ b/src/lib/Shop.js
@@ -54,7 +54,7 @@ class AutomationShop
         Automation.Menu.addSeparator(this.__internal__shoppingContainer);
 
         // Only display the menu when the Poké Mart is unlocked
-        if (!App.game.statistics.gymsDefeated[GameConstants.getGymIndex('Champion Lance')])
+        if (!App.game.statistics.gymsDefeated[GameConstants.getGymIndex('Champion Lance')]())
         {
             this.__internal__shoppingContainer.hidden = true;
             this.__internal__setShoppingUnlockWatcher();
@@ -130,7 +130,7 @@ class AutomationShop
     {
         let watcher = setInterval(function()
             {
-                if (App.game.statistics.gymsDefeated[GameConstants.getGymIndex('Champion Lance')])
+                if (App.game.statistics.gymsDefeated[GameConstants.getGymIndex('Champion Lance')]())
                 {
                     clearInterval(watcher);
                     this.__internal__shoppingContainer.hidden = false;
@@ -150,7 +150,7 @@ class AutomationShop
      */
     static __internal__toggleAutoBuy(enable)
     {
-        if (!App.game.statistics.gymsDefeated[GameConstants.getGymIndex('Champion Lance')])
+        if (!App.game.statistics.gymsDefeated[GameConstants.getGymIndex('Champion Lance')]())
         {
             return;
         }


### PR DESCRIPTION
The shop feature should only be visible once the Poké Mart has been unlocked.

The status checked is an observable, it needs to be called to
be accessed. This is now done properly.

This is a regression from #96

---

Fixup a case were the player would have the dungeon button disabled 
right away, and have to click it again to effectively enable the feature.