### PR TITLE
Hatchery: Allow the user to set region-related filters

### DIFF
--- a/src/lib/Dungeon.js
+++ b/src/lib/Dungeon.js
@@ -123,10 +123,10 @@ class AutomationDungeon
 
         // Add an on/off button to stop after pokedex completion
         let autoStopDungeonTooltip = "Automatically disables the dungeon loop\n"
-                                   + "once all pokemon are caught in this dungeon."
+                                   + "once all pokémon are caught in this dungeon."
                                    + Automation.Menu.TooltipSeparator
-                                   + "You can switch between pokemon and shiny completion\n"
-                                   + "by clicking on the pokeball image.";
+                                   + "You can switch between pokémon and shiny completion\n"
+                                   + "by clicking on the pokéball image.";
 
         let buttonLabel = 'Stop on <span id="automation-dungeon-pokedex-img"><img src="assets/images/pokeball/Pokeball.svg" height="17px"></span> :';
         Automation.Menu.addAutomationButton(buttonLabel, this.Settings.StopOnPokedex, autoStopDungeonTooltip, dungeonDiv);
@@ -507,7 +507,7 @@ class AutomationDungeon
                         disableReason += "shiny ";
                     }
 
-                    disableReason += "pokemons are already caught,\nand the option to stop in this case is enabled";
+                    disableReason += "pokémons are already caught,\nand the option to stop in this case is enabled";
                 }
 
                 // The player does not have enough dugeon token

--- a/src/lib/Hatchery.js
+++ b/src/lib/Hatchery.js
@@ -118,29 +118,49 @@ class AutomationHatchery
         titleDiv.style.marginBottom = "10px";
         hatcherySettingPanel.appendChild(titleDiv);
 
+        let fossilTooltip = "Add fossils to the hatchery as well"
+                          + Automation.Menu.TooltipSeparator
+                          + "Only fossils for which pokemon are not currently held are added";
+        Automation.Menu.addLabeledAdvancedSettingsToggleButton(
+            "Hatch Fossils that can breed an uncaught pokémon", this.Settings.UseFossils, fossilTooltip, hatcherySettingPanel);
+        let eggTooltip = "Add eggs to the hatchery as well"
+                       + Automation.Menu.TooltipSeparator
+                       + "Only eggs for which some pokemon are not currently held are added\n"
+                       + "Only one egg of a given type is used at the same time";
+        Automation.Menu.addLabeledAdvancedSettingsToggleButton(
+            "Hatch Eggs that can breed an uncaught pokémon", this.Settings.UseEggs, eggTooltip, hatcherySettingPanel);
+
+        this.__internal__buildSortingAdvancedSettingCategory(hatcherySettingPanel);
+
+        this.__internal__disablePokerusSpreadingIfNotUnlocked();
+    }
+
+    static __internal__buildSortingAdvancedSettingCategory(parentDiv)
+    {
+        let categoryContainer = Automation.Menu.createSettingCategory("Pokemon breeding order settings");
+        parentDiv.appendChild(categoryContainer);
+
+        // For now only Breeding efficiency is possible
+        let sortingOrder = document.createElement("div");
+        sortingOrder.style.paddingRight = "12px";
+        sortingOrder.textContent = "Sorting order: Breeding efficiency";
+        categoryContainer.appendChild(sortingOrder);
+
+        // Add the shiny setting
         let shinyTooltip = "Only add shinies to the hatchery if no other pokemon is available"
                          + Automation.Menu.TooltipSeparator
                          + "This is useful to farm shinies you don't have yet";
         Automation.Menu.addLabeledAdvancedSettingsToggleButton("Consider shiny pokemons last",
                                                                this.Settings.NotShinyFirst,
                                                                shinyTooltip,
-                                                               hatcherySettingPanel);
-        let fossilTooltip = "Add fossils to the hatchery as well"
-                          + Automation.Menu.TooltipSeparator
-                          + "Only fossils for which pokemon are not currently held are added";
-        Automation.Menu.addLabeledAdvancedSettingsToggleButton("Hatch Fossils", this.Settings.UseFossils, fossilTooltip, hatcherySettingPanel);
-        let eggTooltip = "Add eggs to the hatchery as well"
-                       + Automation.Menu.TooltipSeparator
-                       + "Only eggs for which some pokemon are not currently held are added\n"
-                       + "Only one egg of a given type is used at the same time";
-        Automation.Menu.addLabeledAdvancedSettingsToggleButton("Hatch Eggs", this.Settings.UseEggs, eggTooltip, hatcherySettingPanel);
+                                                               categoryContainer);
+
+        // Add the pokérus setting
         let pokerusTooltip = "Spread the Pokérus in priority"
                            + Automation.Menu.TooltipSeparator
                            + "This will try to infect as many pokemon as possible with the Pokérus";
         Automation.Menu.addLabeledAdvancedSettingsToggleButton(
-            "Focus on spreading the Pokérus", this.Settings.SpreadPokerus, pokerusTooltip, hatcherySettingPanel);
-
-        this.__internal__disablePokerusSpreadingIfNotUnlocked();
+            "Focus on spreading the Pokérus", this.Settings.SpreadPokerus, pokerusTooltip, categoryContainer);
     }
 
     /**

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -387,6 +387,20 @@ class AutomationMenu
     }
 
     /**
+     * @brief Creates a boxed category with the given @p title
+     *
+     * @returns The created div element
+     */
+    static createSettingCategory(title)
+    {
+        let categoryContainer = document.createElement("div");
+        categoryContainer.classList.add("automation-setting-category");
+        categoryContainer.setAttribute("automation-setting-category-title", title);
+
+        return categoryContainer;
+    }
+
+    /**
      * @brief Shows the animated checkmark
      *
      * @param {Element} checkmarkContainer: The element created using @see createAnimatedCheckMarkElement()
@@ -970,6 +984,28 @@ class AutomationMenu
                 outline: none;
                 border-radius: 5px;
                 background-color: #455d77;
+            }
+            .automation-setting-category
+            {
+                position: relative;
+                border: solid 1px #999999;
+                padding: 10px;
+                padding-right: 0px;
+                margin-top: 20px;
+                margin-bottom: 5px;
+                height: fit-content;
+                border-radius: 5px;
+            }
+            .automation-setting-category::after
+            {
+                content: attr(automation-setting-category-title);
+                position: absolute;
+                background-color: #2b3548;
+                color: #84b0f5;
+                width: fit-content;
+                padding: 0px 5px;
+                top: -13px;
+                right: 15px;
             }
             .automation-checkmark-container
             {

--- a/src/lib/Trivia.js
+++ b/src/lib/Trivia.js
@@ -317,7 +317,7 @@ class AutomationTrivia
             textElem.textContent = "Roamers: " + routeName.replace(/ /g, '\u00a0');
 
             // Update the tooltip
-            let tooltip = "The following pokemons are roaming this route:\n";
+            let tooltip = "The following pokémons are roaming this route:\n";
             for (const [ index, pokemon ] of roamers.entries())
             {
                 if (index !== 0)

--- a/tst/Hachery/AutoHatchery.test.in.js
+++ b/tst/Hachery/AutoHatchery.test.in.js
@@ -43,13 +43,13 @@ PokemonLoader.loadFossilsPokemons();
 |***    TEST-HELPERS    ***|
 \**************************/
 
-function addSomePokemonsToThePlayersParty()
+function addSomePokemonsToThePlayersParty(region = GameConstants.MAX_AVAILABLE_REGION)
 {
     let pokemons = [];
 
     for (const list of App.game.breeding.hatchList)
     {
-        pokemons = pokemons.concat(list.slice(0, 1).flat());
+        pokemons = pokemons.concat(list.slice(0, region + 1).flat());
     }
 
     // Simulate the player getting some pokemons
@@ -67,9 +67,9 @@ function expectBreedingPokemonOrderedByBreedingEfficiencyOnly()
     expect(App.game.breeding.__eggList[0].isNone()).toBe(false);
     expect(App.game.breeding.__eggList[1].pokemon).toEqual("Hitmonlee");
     expect(App.game.breeding.__eggList[1].isNone()).toBe(false);
-    expect(App.game.breeding.__eggList[2].pokemon).toEqual("Ponyta");
+    expect(App.game.breeding.__eggList[2].pokemon).toEqual("Qwilfish");
     expect(App.game.breeding.__eggList[2].isNone()).toBe(false);
-    expect(App.game.breeding.__eggList[3].pokemon).toEqual("Hitmonchan");
+    expect(App.game.breeding.__eggList[3].pokemon).toEqual("Ponyta");
     expect(App.game.breeding.__eggList[3].isNone()).toBe(false);
 }
 
@@ -104,6 +104,10 @@ beforeAll(() =>
         // Simulate NotShinyFirst setting being disabled by default (done in the Automation.InitSteps.BuildMenu)
         Automation.Utils.LocalStorage.setValue(Automation.Hatchery.Settings.NotShinyFirst, false);
         expect(Automation.Utils.LocalStorage.getValue(Automation.Hatchery.Settings.NotShinyFirst)).toBe("false");
+
+        // Simulate PrioritizedRegion setting being set to 'Any' by default (done in the Automation.InitSteps.BuildMenu)
+        Automation.Utils.LocalStorage.setValue(Automation.Hatchery.Settings.PrioritizedRegion, GameConstants.Region.none);
+        expect(Automation.Utils.LocalStorage.getValue(Automation.Hatchery.Settings.PrioritizedRegion)).toBe("-1");
     });
 
 beforeEach(() =>
@@ -248,7 +252,7 @@ describe(`${AutomationTestUtils.categoryPrefix}Party pokémon breeding:`, () =>
     // Test when the player has a lvl 100 pokemon in his party
     test("Breed lvl 100 pokémons", () =>
     {
-        addSomePokemonsToThePlayersParty();
+        addSomePokemonsToThePlayersParty(GameConstants.Region.johto);
 
         // Put the 1st one to lvl100
         App.game.party.caughtPokemon[0].level = 100;
@@ -263,7 +267,7 @@ describe(`${AutomationTestUtils.categoryPrefix}Party pokémon breeding:`, () =>
     // Test the breeding order
     test("Test breeding order", () =>
     {
-        addSomePokemonsToThePlayersParty();
+        addSomePokemonsToThePlayersParty(GameConstants.Region.johto);
 
         // Put the all pokemons to lvl100
         for (const pokemon of App.game.party.caughtPokemon)
@@ -280,7 +284,7 @@ describe(`${AutomationTestUtils.categoryPrefix}Party pokémon breeding:`, () =>
     // Test the breeding order with shinies
     test("Test breeding order with Shinies > NotShinyFirst setting disabled", () =>
     {
-        addSomePokemonsToThePlayersParty();
+        addSomePokemonsToThePlayersParty(GameConstants.Region.johto);
 
         // Put the all pokemons to lvl100
         for (const pokemon of App.game.party.caughtPokemon)
@@ -301,7 +305,7 @@ describe(`${AutomationTestUtils.categoryPrefix}Party pokémon breeding:`, () =>
     // Test the breeding order with shinies and the NotShinyFirst setting enabled
     test("Test breeding order with Shinies > NotShinyFirst setting enabled", () =>
     {
-        addSomePokemonsToThePlayersParty();
+        addSomePokemonsToThePlayersParty(GameConstants.Region.johto);
 
         // Put the all pokemons to lvl100
         for (const pokemon of App.game.party.caughtPokemon)
@@ -323,18 +327,18 @@ describe(`${AutomationTestUtils.categoryPrefix}Party pokémon breeding:`, () =>
         /** @note This order might change if new pokemon were to be added, or their value changed */
         expect(App.game.breeding.__eggList[0].pokemon).toEqual("Hitmonlee");
         expect(App.game.breeding.__eggList[0].isNone()).toBe(false);
-        expect(App.game.breeding.__eggList[1].pokemon).toEqual("Hitmonchan");
+        expect(App.game.breeding.__eggList[1].pokemon).toEqual("Qwilfish");
         expect(App.game.breeding.__eggList[1].isNone()).toBe(false);
-        expect(App.game.breeding.__eggList[2].pokemon).toEqual("Machop");
+        expect(App.game.breeding.__eggList[2].pokemon).toEqual("Hitmonchan");
         expect(App.game.breeding.__eggList[2].isNone()).toBe(false);
-        expect(App.game.breeding.__eggList[3].pokemon).toEqual("Mankey");
+        expect(App.game.breeding.__eggList[3].pokemon).toEqual("Machop");
         expect(App.game.breeding.__eggList[3].isNone()).toBe(false);
     });
 
     // Test the breeding order with infected and the SpreadPokerus setting disabled
     test("Test breeding order with pokérus > SpreadPokerus setting disabled", () =>
     {
-        addSomePokemonsToThePlayersParty();
+        addSomePokemonsToThePlayersParty(GameConstants.Region.johto);
 
         // Put the all pokemons to lvl100
         for (const pokemon of App.game.party.caughtPokemon)
@@ -357,7 +361,7 @@ describe(`${AutomationTestUtils.categoryPrefix}Party pokémon breeding:`, () =>
     // Test the breeding order with infected and the SpreadPokerus setting enabled
     test("Test breeding order with pokérus > SpreadPokerus setting enabled", () =>
     {
-        addSomePokemonsToThePlayersParty();
+        addSomePokemonsToThePlayersParty(GameConstants.Region.johto);
 
         // Put the all pokemons to lvl100
         for (const pokemon of App.game.party.caughtPokemon)
@@ -386,7 +390,7 @@ describe(`${AutomationTestUtils.categoryPrefix}Party pokémon breeding:`, () =>
     // Test the breeding order with pokérus when not enough pokémon share type with the infected one
     test("Test breeding order with pokérus when not enough pokémon share type with the infected one", () =>
     {
-        addSomePokemonsToThePlayersParty();
+        addSomePokemonsToThePlayersParty(GameConstants.Region.johto);
 
         // Put the all pokemons to lvl100
         for (const pokemon of App.game.party.caughtPokemon)
@@ -416,13 +420,13 @@ describe(`${AutomationTestUtils.categoryPrefix}Party pokémon breeding:`, () =>
         // Since no more pokémon are eligible to the pokérus spreading, the most efficient beeding pokémon should be added next
         expect(App.game.breeding.__eggList[2].pokemon).toEqual("Pikachu");
         expect(App.game.breeding.__eggList[2].isNone()).toBe(false);
-        expect(App.game.breeding.__eggList[3].pokemon).toEqual("Ponyta");
+        expect(App.game.breeding.__eggList[3].pokemon).toEqual("Qwilfish");
         expect(App.game.breeding.__eggList[3].isNone()).toBe(false);
 
         // Set the pokérus on Squirtle (Water type)
         App.game.party.getPokemon(pokemonMap["Squirtle"].id).pokerus = GameConstants.Pokerus.Contagious;
 
-        // Complete Pikachu and Ponyta steps
+        // Complete Pikachu and Qwilfish steps
         App.game.breeding.__eggList[2].__steps = App.game.breeding.__eggList[2].totalSteps;
         App.game.breeding.__eggList[3].__steps = App.game.breeding.__eggList[3].totalSteps;
 
@@ -437,7 +441,43 @@ describe(`${AutomationTestUtils.categoryPrefix}Party pokémon breeding:`, () =>
         expect(App.game.breeding.__eggList[1].isNone()).toBe(false);
         expect(App.game.breeding.__eggList[2].pokemon).toEqual("Squirtle");
         expect(App.game.breeding.__eggList[2].isNone()).toBe(false);
-        expect(App.game.breeding.__eggList[3].pokemon).toEqual("Psyduck");
+        expect(App.game.breeding.__eggList[3].pokemon).toEqual("Qwilfish");
         expect(App.game.breeding.__eggList[3].isNone()).toBe(false);
+    });
+
+    /** @note Those orders might change if new pokemon were to be added, or their value changed */
+    let regionTestCases =
+        [
+            { regionId: GameConstants.Region.kanto, regionName: "Kanto", expectedPokemons: [ "Pikachu", "Hitmonlee", "Ponyta", "Hitmonchan" ] },
+            { regionId: GameConstants.Region.johto, regionName: "Johto", expectedPokemons: [ "Qwilfish", "Magby", "Totodile", "Elekid" ] },
+            { regionId: GameConstants.Region.hoenn, regionName: "Hoenn", expectedPokemons: [ "Mudkip", "Clamperl", "Torchic", "Numel" ] },
+            { regionId: GameConstants.Region.sinnoh, regionName: "Sinnoh", expectedPokemons: [ "Pachirisu", "Carnivine", "Turtwig", "Buizel" ] },
+            { regionId: GameConstants.Region.unova, regionName: "Unova", expectedPokemons: [ "Sawk", "Throh", "Tepig", "Blitzle" ] },
+            { regionId: GameConstants.Region.kalos, regionName: "Kalos", expectedPokemons: [ "Chespin", "Froakie", "Fennekin", "Goomy" ] },
+            { regionId: GameConstants.Region.alola, regionName: "Alola", expectedPokemons: [ "Litten", "Crabrawler", "Turtonator", "Rowlet" ] }
+        ];
+
+    // Test the breeding order with infected and the SpreadPokerus setting enabled
+    test.each(regionTestCases)("Test breeding order with region set to $regionName", (testCase) =>
+    {
+        addSomePokemonsToThePlayersParty();
+
+        // Put the all pokemons to lvl100
+        for (const pokemon of App.game.party.caughtPokemon)
+        {
+            pokemon.level = 100;
+        }
+
+        // Set the region filter
+        Automation.Utils.LocalStorage.setValue(Automation.Hatchery.Settings.PrioritizedRegion, testCase.regionId);
+
+        // Simulate the loop
+        Automation.Hatchery.__internal__hatcheryLoop();
+
+        for (const i of testCase.expectedPokemons.keys())
+        {
+            expect(App.game.breeding.__eggList[i].pokemon).toEqual(testCase.expectedPokemons[i]);
+            expect(App.game.breeding.__eggList[i].isNone()).toBe(false);
+        }
     });
 });

--- a/tst/stubs/GameConstants.pokeclicker.stub.js
+++ b/tst/stubs/GameConstants.pokeclicker.stub.js
@@ -1,8 +1,6 @@
 // Stub of https://github.com/pokeclicker/pokeclicker/blob/cbeab9a0e658aa84ee2ba028f6ae83421c92776a/src/modules/GameConstants.ts
 class GameConstants
 {
-    static BREEDING_ATTACK_BONUS = 25;
-
     static Currency =
         {
             0: "money",
@@ -89,4 +87,7 @@ class GameConstants
             sinnoh: 3,
             unova: 4
         };
+
+    static BREEDING_ATTACK_BONUS = 25;
+    static MAX_AVAILABLE_REGION = this.Region.alola;
 }

--- a/tst/stubs/Hatchery/Breeding.pokeclicker.stub.js
+++ b/tst/stubs/Hatchery/Breeding.pokeclicker.stub.js
@@ -193,36 +193,71 @@ class Breeding
 
     __initHatchList()
     {
-        // Only region 1 and 2 pokemons are set for the tests
         this.hatchList[EggType.Fire] =
             [
                 ['Charmander', 'Vulpix', 'Growlithe', 'Ponyta'],
-                ['Cyndaquil', 'Slugma', 'Houndour', 'Magby']
+                ['Cyndaquil', 'Slugma', 'Houndour', 'Magby'],
+                ['Torchic', 'Numel'],
+                ['Chimchar'],
+                ['Tepig', 'Pansear'],
+                ['Fennekin'],
+                ['Litten'],
+                ['Scorbunny', 'Sizzlipede'],
             ];
         this.hatchList[EggType.Water] =
             [
                 ['Squirtle', 'Lapras', 'Staryu', 'Psyduck'],
-                ['Totodile', 'Wooper', 'Marill', 'Qwilfish']
+                ['Totodile', 'Wooper', 'Marill', 'Qwilfish'],
+                ['Mudkip', 'Feebas', 'Clamperl'],
+                ['Piplup', 'Finneon', 'Buizel'],
+                ['Oshawott', 'Panpour'],
+                ['Froakie'],
+                ['Popplio', 'Wimpod'],
+                ['Sobble', 'Chewtle'],
             ];
         this.hatchList[EggType.Grass] =
             [
                 ['Bulbasaur', 'Oddish', 'Tangela', 'Bellsprout'],
-                ['Chikorita', 'Hoppip', 'Sunkern']
+                ['Chikorita', 'Hoppip', 'Sunkern'],
+                ['Treecko', 'Tropius', 'Roselia'],
+                ['Turtwig', 'Carnivine', 'Budew'],
+                ['Snivy', 'Pansage'],
+                ['Chespin'],
+                ['Rowlet', 'Morelull'],
+                ['Grookey', 'Gossifleur'],
             ];
         this.hatchList[EggType.Fighting] =
             [
                 ['Hitmonlee', 'Hitmonchan', 'Machop', 'Mankey'],
-                ['Tyrogue']
+                ['Tyrogue'],
+                ['Makuhita', 'Meditite'],
+                ['Riolu'],
+                ['Throh', 'Sawk'],
+                [],
+                ['Crabrawler'],
+                ['Falinks'],
             ];
         this.hatchList[EggType.Electric] =
             [
                 ['Magnemite', 'Pikachu', 'Voltorb', 'Electabuzz'],
-                ['Chinchou', 'Mareep', 'Elekid']
+                ['Chinchou', 'Mareep', 'Elekid'],
+                ['Plusle', 'Minun', 'Electrike'],
+                ['Pachirisu', 'Shinx'],
+                ['Blitzle'],
+                [],
+                [],
+                ['Toxel', 'Pincurchin'],
             ];
         this.hatchList[EggType.Dragon] =
             [
                 ['Dratini', 'Dragonair', 'Dragonite'],
-                []
+                [],
+                ['Bagon', 'Shelgon', 'Salamence'],
+                ['Gible', 'Gabite', 'Garchomp'],
+                ['Deino', 'Zweilous', 'Hydreigon'],
+                ['Goomy'],
+                ['Turtonator', 'Drampa', 'Jangmo-o', 'Hakamo-o', 'Kommo-o'],
+                ['Dreepy', 'Drakloak', 'Dragapult'],
             ];
     }
 }

--- a/tst/stubs/Pokemon/Party.pokeclicker.stub.js
+++ b/tst/stubs/Pokemon/Party.pokeclicker.stub.js
@@ -33,6 +33,11 @@ class Party
         return this.__caughtPokemonMap.get(id);
     }
 
+    getRegionAttackMultiplier(highestRegion = player.highestRegion())
+    {
+        return Math.min(1, Math.max(0.2, 0.1 + (highestRegion / 10)));
+    }
+
     /***************************\
     |*   Test-only interface   *|
     \***************************/

--- a/tst/stubs/Pokemon/PartyController.pokeclicker.stub.js
+++ b/tst/stubs/Pokemon/PartyController.pokeclicker.stub.js
@@ -1,6 +1,15 @@
 // Stub of https://github.com/pokeclicker/pokeclicker/blob/develop/src/scripts/party/PartyController.ts#L3
 class PartyController
 {
+    static calculateRegionalMultiplier(pokemon, region)
+    {
+        if (region > -1 && PokemonHelper.calcNativeRegion(pokemon.name) !== region)
+        {
+            return App.game.party.getRegionAttackMultiplier();
+        }
+        return 1.0;
+    }
+
     static getCaughtStatusByName(name)
     {
         return this.getCaughtStatus(PokemonHelper.getPokemonByName(name).id);

--- a/tst/utils/PokemonLoader.utils.js
+++ b/tst/utils/PokemonLoader.utils.js
@@ -26,6 +26,13 @@ class PokemonLoader
         PokemonHelper.__registerPokemon("Slugma", 218, 1, { attack: 40 }, [ 1 ], 20);
         PokemonHelper.__registerPokemon("Houndour", 228, 1, { attack: 60 }, [ 15, 1 ], 20);
         PokemonHelper.__registerPokemon("Magby", 240, 1, { attack: 75 }, [ 1 ], 20);
+        PokemonHelper.__registerPokemon("Torchic", 255, 2, { attack: 60 }, [ 1 ], 20);
+        PokemonHelper.__registerPokemon("Numel", 322, 2, { attack: 60 }, [ 1, 8 ], 20);
+        PokemonHelper.__registerPokemon("Chimchar", 390, 3, { attack: 58 }, [ 1 ], 20);
+        PokemonHelper.__registerPokemon("Tepig", 498, 4, { attack: 63 }, [ 1 ], 20);
+        PokemonHelper.__registerPokemon("Pansear", 513, 4, { attack: 53 }, [ 1 ], 20);
+        PokemonHelper.__registerPokemon("Fennekin", 653, 5, { attack: 45 }, [ 1 ], 20);
+        PokemonHelper.__registerPokemon("Litten", 725, 6, { attack: 65 }, [ 1 ], 15);
 
         // Water egg pokemons
         PokemonHelper.__registerPokemon("Squirtle", 7, 0, { attack: 48 }, [ 2 ], 20);
@@ -36,6 +43,17 @@ class PokemonLoader
         PokemonHelper.__registerPokemon("Wooper", 194, 1, { attack: 45 }, [ 2, 8 ], 20);
         PokemonHelper.__registerPokemon("Marill", 183, 1, { attack: 20 }, [ 2, 17 ], 10);
         PokemonHelper.__registerPokemon("Qwilfish", 211, 1, { attack: 95 }, [ 2, 7 ], 20);
+        PokemonHelper.__registerPokemon("Mudkip", 258, 2, { attack: 70 }, [ 2 ], 20);
+        PokemonHelper.__registerPokemon("Feebas", 349, 2, { attack: 15 }, [ 2 ], 20);
+        PokemonHelper.__registerPokemon("Clamperl", 366, 2, { attack: 64 }, [ 2 ], 20);
+        PokemonHelper.__registerPokemon("Piplup", 393, 3, { attack: 51 }, [ 2 ], 20);
+        PokemonHelper.__registerPokemon("Finneon", 456, 3, { attack: 49 }, [ 2 ], 20);
+        PokemonHelper.__registerPokemon("Buizel", 418, 3, { attack: 65 }, [ 2 ], 20);
+        PokemonHelper.__registerPokemon("Oshawott", 501, 4, { attack: 55 }, [ 2 ], 20);
+        PokemonHelper.__registerPokemon("Panpour", 515, 4, { attack: 53 }, [ 2 ], 20);
+        PokemonHelper.__registerPokemon("Froakie", 656, 5, { attack: 56 }, [ 2 ], 20);
+        PokemonHelper.__registerPokemon("Popplio", 728, 6, { attack: 54 }, [ 2 ], 15);
+        PokemonHelper.__registerPokemon("Wimpod", 767, 6, { attack: 35 }, [ 11, 2 ], 20);
 
         // Grass egg pokemons
         PokemonHelper.__registerPokemon("Bulbasaur", 1, 0, { attack: 49 }, [ 4, 7 ], 20);
@@ -45,6 +63,17 @@ class PokemonLoader
         PokemonHelper.__registerPokemon("Chikorita", 152, 1, { attack: 49 }, [ 4 ], 20);
         PokemonHelper.__registerPokemon("Hoppip", 187, 1, { attack: 35 }, [ 4, 9 ], 20);
         PokemonHelper.__registerPokemon("Sunkern", 191, 1, { attack: 30 }, [ 4 ], 20);
+        PokemonHelper.__registerPokemon("Treecko", 252, 2, { attack: 45 }, [ 4 ], 20);
+        PokemonHelper.__registerPokemon("Tropius", 357, 2, { attack: 68 }, [ 4, 9 ], 25);
+        PokemonHelper.__registerPokemon("Roselia", 315, 2, { attack: 60 }, [ 4, 7 ], 20);
+        PokemonHelper.__registerPokemon("Turtwig", 387, 3, { attack: 68 }, [ 4 ], 20);
+        PokemonHelper.__registerPokemon("Carnivine", 455, 3, { attack: 100 }, [ 4 ], 25);
+        PokemonHelper.__registerPokemon("Budew", 406, 3, { attack: 30 }, [ 4, 7 ], 16);
+        PokemonHelper.__registerPokemon("Snivy", 495, 4, { attack: 45 }, [ 4 ], 20);
+        PokemonHelper.__registerPokemon("Pansage", 511, 4, { attack: 53 }, [ 4 ], 20);
+        PokemonHelper.__registerPokemon("Chespin", 650, 5, { attack: 61 }, [ 4 ], 20);
+        PokemonHelper.__registerPokemon("Rowlet", 722, 6, { attack: 55 }, [ 4, 9 ], 15);
+        PokemonHelper.__registerPokemon("Morelull", 755, 6, { attack: 35 }, [ 4, 17 ], 20);
 
         // Fighting egg pokemons
         PokemonHelper.__registerPokemon("Hitmonlee", 106, 0, { attack: 120 }, [ 6 ], 25);
@@ -52,6 +81,12 @@ class PokemonLoader
         PokemonHelper.__registerPokemon("Machop", 66, 0, { attack: 80 }, [ 6 ], 20);
         PokemonHelper.__registerPokemon("Mankey", 56, 0, { attack: 80 }, [ 6 ], 20);
         PokemonHelper.__registerPokemon("Tyrogue", 236, 1, { attack: 35 }, [ 6 ], 20);
+        PokemonHelper.__registerPokemon("Makuhita", 296, 2, { attack: 60 }, [ 6 ], 20);
+        PokemonHelper.__registerPokemon("Meditite", 307, 2, { attack: 40 }, [ 6, 10 ], 20);
+        PokemonHelper.__registerPokemon("Riolu", 447, 3, { attack: 70 }, [ 6 ], 25);
+        PokemonHelper.__registerPokemon("Throh", 538, 4, { attack: 100 }, [ 6 ], 20);
+        PokemonHelper.__registerPokemon("Sawk", 539, 4, { attack: 125 }, [ 6 ], 20);
+        PokemonHelper.__registerPokemon("Crabrawler", 739, 6, { attack: 82 }, [ 6 ], 20);
 
         // Electric egg pokemons
         PokemonHelper.__registerPokemon("Magnemite", 81, 0, { attack: 35 }, [ 3, 16 ], 20);
@@ -61,11 +96,32 @@ class PokemonLoader
         PokemonHelper.__registerPokemon("Chinchou", 170, 1, { attack: 38 }, [ 2, 3 ], 20);
         PokemonHelper.__registerPokemon("Mareep", 179, 1, { attack: 40 }, [ 3 ], 20);
         PokemonHelper.__registerPokemon("Elekid", 239, 1, { attack: 63 }, [ 3 ], 20);
+        PokemonHelper.__registerPokemon("Plusle", 311, 2, { attack: 50 }, [ 3 ], 20);
+        PokemonHelper.__registerPokemon("Minun", 312, 2, { attack: 40 }, [ 3 ], 20);
+        PokemonHelper.__registerPokemon("Electrike", 309, 2, { attack: 45 }, [ 3 ], 20);
+        PokemonHelper.__registerPokemon("Pachirisu", 417, 3, { attack: 45 }, [ 3 ], 10);
+        PokemonHelper.__registerPokemon("Shinx", 403, 3, { attack: 65 }, [ 3 ], 20);
+        PokemonHelper.__registerPokemon("Blitzle", 522, 4, { attack: 60 }, [ 3 ], 20);
 
         // Dragon egg pokemons
         PokemonHelper.__registerPokemon("Dratini", 147, 0, { attack: 64 }, [ 14 ], 40);
         PokemonHelper.__registerPokemon("Dragonair", 148, 0, { attack: 84 }, [ 14 ], 60);
         PokemonHelper.__registerPokemon("Dragonite", 149, 0, { attack: 134 }, [ 14, 9 ], 90);
+        PokemonHelper.__registerPokemon("Bagon", 371, 2, { attack: 75 }, [ 14 ], 40);
+        PokemonHelper.__registerPokemon("Shelgon", 372, 2, { attack: 95 }, [ 14 ], 60);
+        PokemonHelper.__registerPokemon("Salamence", 373, 2, { attack: 135 }, [ 14, 9 ], 90);
+        PokemonHelper.__registerPokemon("Gible", 443, 3, { attack: 70 }, [ 14, 8 ], 40);
+        PokemonHelper.__registerPokemon("Gabite", 444, 3, { attack: 90 }, [ 14, 8 ], 60);
+        PokemonHelper.__registerPokemon("Garchomp", 445, 3, { attack: 130 }, [ 14, 8 ], 90);
+        PokemonHelper.__registerPokemon("Deino", 633, 4, { attack: 65 }, [ 15, 14 ], 40);
+        PokemonHelper.__registerPokemon("Zweilous", 634, 4, { attack: 85 }, [ 15, 14 ], 60);
+        PokemonHelper.__registerPokemon("Hydreigon", 635, 4, { attack: 105 }, [ 15, 14 ], 90);
+        PokemonHelper.__registerPokemon("Goomy", 704, 5, { attack: 50 }, [ 14 ], 40);
+        PokemonHelper.__registerPokemon("Turtonator", 776, 6, { attack: 78 }, [ 1, 14 ], 20);
+        PokemonHelper.__registerPokemon("Drampa", 780, 6, { attack: 60 }, [ 0, 14 ], 20);
+        PokemonHelper.__registerPokemon("Jangmo-o", 782, 6, { attack: 55 }, [ 14 ], 40);
+        PokemonHelper.__registerPokemon("Hakamo-o", 783, 6, { attack: 75 }, [ 14, 6 ], 60);
+        PokemonHelper.__registerPokemon("Kommo-o", 784, 6, { attack: 110 }, [ 14, 6 ], 90);
     }
 
     /**
@@ -115,7 +171,7 @@ buffer += `\n\n\n\n`;
 for (const eggType of [ "Fire", "Water", "Grass", "Fighting", "Electric", "Dragon" ])
 {
     buffer += `\n        // ${eggType} egg pokemons\n`;
-    for (const pokename of App.game.breeding.hatchList[EggType[eggType]].slice(0, 2).flat())
+    for (const pokename of App.game.breeding.hatchList[EggType[eggType]].slice(0, GameConstants.MAX_AVAILABLE_REGION + 1).flat())
     {
         buffer += dataPrinter(pokename);
     }


### PR DESCRIPTION
Until now, only the Pokerus and shiny toggles allowed players to tune the hatchery algorithm.

This PR adds the following additional settings:
  - Prioritizing pokémons from a specific region
  - Considering regional attack debuff

Partially addresses #48