### PR TITLE
Farm: Fixup v0.9.11 regression

### DIFF
--- a/src/lib/Farm.js
+++ b/src/lib/Farm.js
@@ -245,7 +245,7 @@ class AutomationFarm
         {
             if (!plot.isUnlocked)
             {
-                FarmController.plotClick(index);
+                FarmController.plotClick(index, { shiftKey: false });
             }
         }
     }

--- a/tst/stubs/Farming/FarmController.pokeclicker.stub.js
+++ b/tst/stubs/Farming/FarmController.pokeclicker.stub.js
@@ -5,7 +5,7 @@ class FarmController
     |*  Pokéclicker interface  *|
     \***************************/
 
-    static plotClick(index)
+    static plotClick(index, event = null)
     {
         let plot = App.game.farming.plotList[index];
 


### PR DESCRIPTION
The plotClick function now takes a MouseEvent additional parameter.
This was added by pokeclicker [plot locking feature implementation](https://github.com/pokeclicker/pokeclicker/commit/7a2f9043a52854a3e11abc078dec77f11e332338#diff-da5cb4cb6f02bf9239bf779ec92a8b1a9878946a5c25b91fed13bcfbefb29a2dR87-R95).