### PR TITLE
Mine: Add a "Use restore items" advanced setting

### DIFF
--- a/src/lib/Focus.js
+++ b/src/lib/Focus.js
@@ -265,9 +265,6 @@ class AutomationFocus
                                                                this.Settings.OakItemLoadoutUpdate,
                                                                disableOakItemTooltip,
                                                                focusSettingPanel);
-
-        // Add the quests-specific settings
-        this.Quests.__addAdvancedSettings(focusSettingPanel);
     }
 
     /**

--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -89,7 +89,10 @@ class AutomationFocusAchievements
         this.__internal__updateTheAchievementIfNeeded();
 
         // Work on the current achievement
-        this.__internal__workOnAchievement();
+        if (this.__internal__currentAchievement !== null)
+        {
+            this.__internal__workOnAchievement();
+        }
     }
 
     /**

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -6,8 +6,6 @@
  */
 class AutomationFocusQuests
 {
-    static Settings = { UseSmallRestore: "Focus-Quest-UseSmallRestore" };
-
     /******************************************************************************\
     |***    Focus-specific members, should only be used by focus sub-classes    ***|
     \******************************************************************************/
@@ -39,31 +37,6 @@ class AutomationFocusQuests
                 isUnlocked: function (){ return App.game.quests.isDailyQuestsUnlocked(); },
                 refreshRateAsMs: Automation.Focus.__noFunctionalityRefresh
             });
-    }
-
-    /**
-     * @brief Adds the Quest-specific advanced settings
-     *
-     * The 'Use/buy Small Restore' setting is disabled by default (if never set in a previous session)
-     *
-     * @param parent: The div container to insert the settings to
-     */
-    static __addAdvancedSettings(parent)
-    {
-        // Disable use/buy small restore mode by default
-        Automation.Utils.LocalStorage.setDefaultValue(this.Settings.UseSmallRestore, false);
-
-        let smallRestoreTooltip = "Allows the Quests focus topic to buy and use Small Restore items"
-                                + Automation.Menu.TooltipSeparator
-                                + "This will only be used when a mining quest is active.\n"
-                                + "⚠️ This can be cost-heavy during early game";
-        let smallRestoreLabel = 'Automatically buy and use<img src="assets/images/items/SmallRestore.png"'
-                              // Set the width smaller than the actual image one, and set it to preserve the image ratio to shrink the image margins
-                              + ' style="height: 26px; width: 19px; object-fit: cover; object-position: left top;">';
-        Automation.Menu.addLabeledAdvancedSettingsToggleButton(smallRestoreLabel,
-                                                               this.Settings.UseSmallRestore,
-                                                               smallRestoreTooltip,
-                                                               parent);
     }
 
     /*********************************************************************\
@@ -114,7 +87,6 @@ class AutomationFocusQuests
 
         // Reset demands
         Automation.Farm.ForcePlantBerriesAsked = false;
-        Automation.Underground.UseSmallRestoreAsked = false;
         Automation.Dungeon.AutomationRequestedMode = Automation.Dungeon.InternalModes.None;
 
         // Reset other modes status
@@ -317,8 +289,6 @@ class AutomationFocusQuests
 
         let isFarmingSpecificBerry = false;
 
-        let hasMiningQuest = false;
-
         // Filter the quests that do not need specific action
         for (const quest of currentQuests)
         {
@@ -333,15 +303,7 @@ class AutomationFocusQuests
                 let bestBerry = this.__internal__getMostSuitableBerryForQuest(quest);
                 this.__internal__enableFarmingForBerryType(bestBerry);
             }
-            else if ((quest instanceof MineItemsQuest)
-                     || (quest instanceof MineLayersQuest))
-            {
-                hasMiningQuest = true;
-            }
         }
-
-        Automation.Underground.UseSmallRestoreAsked =
-            hasMiningQuest && (Automation.Utils.LocalStorage.getValue(this.Settings.UseSmallRestore) === "true");
     }
 
     /**

--- a/tst/imports/Pokeclicker.import.js
+++ b/tst/imports/Pokeclicker.import.js
@@ -41,9 +41,12 @@ import "tst/stubs/Hatchery/Egg.pokeclicker.stub.js";
 
 // Import pokeclicker Items types and classes
 import "tst/stubs/Items/Item.pokeclicker.stub.js"; // Base class, needs to be imported first
+import "tst/stubs/Items/BattleItem.pokeclicker.stub.js";
 import "tst/stubs/Items/EggItem.pokeclicker.stub.js";
+import "tst/stubs/Items/EnergyRestore.pokeclicker.stub.js";
 import "tst/stubs/Items/FluteEffectRunner.pokeclicker.stub.js";
 import "tst/stubs/Items/Pokeball.pokeclicker.stub.js";
+import "tst/stubs/Items/PokeballItem.pokeclicker.stub.js";
 import "tst/stubs/Items/Pokeballs.pokeclicker.stub.js";
 
 // Import pokeclicker OakItems types and classes
@@ -66,7 +69,9 @@ import "tst/stubs/Route/Routes.pokeclicker.stub.js";
 
 // Import pokeclicker Town types and classes
 import "tst/stubs/Town/Town.pokeclicker.stub.js"; // Base class of DungeonTown, needs to be imported first
+import "tst/stubs/Town/Shop.pokeclicker.stub.js"; // Used by PokeMartShop, needs to be imported first
 import "tst/stubs/Town/DungeonTown.pokeclicker.stub.js";
+import "tst/stubs/Town/PokeMartShop.pokeclicker.stub.js";
 import "tst/stubs/Town/TownList.pokeclicker.stub.js";
 
 // Import pokeclicker Type types and classes

--- a/tst/stubs/GameConstants.pokeclicker.stub.js
+++ b/tst/stubs/GameConstants.pokeclicker.stub.js
@@ -6,6 +6,21 @@ class GameConstants
         return Math.min(Math.max(num, min), max);
     }
 
+    static getGymIndex(gymName)
+    {
+        return this.RegionGyms.flat().findIndex((g) => g === gymName);
+    }
+
+    static BattleItemType =
+    {
+        Dowsing_machine: "Dowsing_machine",
+        Lucky_egg: "Lucky_egg",
+        Lucky_incense: "Lucky_incense",
+        Token_collector: "Token_collector",
+        xAttack: "xAttack",
+        xClick: "xClick"
+    };
+
     static Currency =
         {
             0: "money",
@@ -53,6 +68,16 @@ class GameConstants
             Pokemon_egg: 6,
             Water_egg: 1
         };
+
+    static EnergyRestoreSize =
+    {
+        0: "SmallRestore",
+        1: "MediumRestore",
+        2: "LargeRestore",
+        LargeRestore: 2,
+        MediumRestore: 1,
+        SmallRestore: 0
+    };
 
     static FossilToPokemon =
         {
@@ -186,6 +211,43 @@ class GameConstants
             NotVery: 0.5,
             Very: 2
         };
+
+    // RegionGym
+    static KantoGyms =
+        [
+            'Pewter City',
+            'Cerulean City',
+            'Vermilion City',
+            'Celadon City',
+            'Saffron City',
+            'Fuchsia City',
+            'Cinnabar Island',
+            'Viridian City',
+            'Elite Lorelei',
+            'Elite Bruno',
+            'Elite Agatha',
+            'Elite Lance',
+            'Champion Blue',
+        ];
+
+    static JohtoGyms =
+        [
+            'Violet City',
+            'Azalea Town',
+            'Goldenrod City',
+            'Ecruteak City',
+            'Cianwood City',
+            'Olivine City',
+            'Mahogany Town',
+            'Blackthorn City',
+            'Elite Will',
+            'Elite Koga',
+            'Elite Bruno2',
+            'Elite Karen',
+            'Champion Lance',
+        ];
+
+    static RegionGyms = [ this.KantoGyms, this.JohtoGyms ];
 
     static EP_CHALLENGE_MODIFIER = 10;
     static EP_EV_RATIO = 1000;

--- a/tst/stubs/Items/BattleItem.pokeclicker.stub.js
+++ b/tst/stubs/Items/BattleItem.pokeclicker.stub.js
@@ -1,0 +1,18 @@
+// Stub of https://github.com/pokeclicker/pokeclicker/blob/26fe119da094d14cb263c229549d9aeb2e6180bb/src/scripts/items/BattleItem.ts#L2
+class BattleItem extends Item
+{
+    // Stripped: description, displayName, multiplierType, multiplyBy
+    constructor(type, basePrice, currency = GameConstants.Currency.money)
+    {
+        super(GameConstants.BattleItemType[type], basePrice, currency);
+
+        this.type = type;
+    }
+}
+
+ItemList.xAttack         = new BattleItem(GameConstants.BattleItemType.xAttack, 600);
+ItemList.xClick          = new BattleItem(GameConstants.BattleItemType.xClick, 400);
+ItemList.Lucky_egg       = new BattleItem(GameConstants.BattleItemType.Lucky_egg, 800);
+ItemList.Token_collector = new BattleItem(GameConstants.BattleItemType.Token_collector, 1000);
+ItemList.Dowsing_machine = new BattleItem(GameConstants.BattleItemType.Dowsing_machine, 1500);
+ItemList.Lucky_incense   = new BattleItem(GameConstants.BattleItemType.Lucky_incense, 2000);

--- a/tst/stubs/Items/EnergyRestore.pokeclicker.stub.js
+++ b/tst/stubs/Items/EnergyRestore.pokeclicker.stub.js
@@ -1,0 +1,14 @@
+// Stub of https://github.com/pokeclicker/pokeclicker/blob/196018b66b940672c27e33626b217ea825dba3fe/src/scripts/items/EnergyRestore.ts#L2
+class EnergyRestore extends Item
+{
+    // Skipped: displayName
+    constructor(type, basePrice, currency = GameConstants.Currency.money)
+    {
+        super(GameConstants.EnergyRestoreSize[type], basePrice, currency);
+        this.type = type;
+    }
+}
+
+ItemList.SmallRestore  = new EnergyRestore(GameConstants.EnergyRestoreSize.SmallRestore, 30000);
+ItemList.MediumRestore = new EnergyRestore(GameConstants.EnergyRestoreSize.MediumRestore, 100000);
+ItemList.LargeRestore  = new EnergyRestore(GameConstants.EnergyRestoreSize.LargeRestore, 400000);

--- a/tst/stubs/Items/PokeballItem.pokeclicker.stub.js
+++ b/tst/stubs/Items/PokeballItem.pokeclicker.stub.js
@@ -1,0 +1,15 @@
+// Stub of https://github.com/pokeclicker/pokeclicker/blob/541f4c8590a16a1f19ea9d1fb6d81c88c75bb214/src/scripts/items/PokeballItem.ts#L4
+class PokeballItem extends Item
+{
+    // Skipped: options, displayName
+    constructor(type, basePrice, currency = GameConstants.Currency.money)
+    {
+        super(GameConstants.Pokeball[type], basePrice, currency);
+
+        this.type = type;
+    }
+}
+
+ItemList.Pokeball = new PokeballItem(GameConstants.Pokeball.Pokeball, 100);
+ItemList.Greatball = new PokeballItem(GameConstants.Pokeball.Greatball, 500);
+ItemList.Ultraball = new PokeballItem(GameConstants.Pokeball.Ultraball, 2000);

--- a/tst/stubs/Statistics.pokeclicker.stub.js
+++ b/tst/stubs/Statistics.pokeclicker.stub.js
@@ -7,9 +7,16 @@ class Statistics
 
     constructor()
     {
-        this.pokemonCaptured = new Object();
+        this.gymsDefeated = [];
 
+        this.pokemonCaptured = new Object();
         this.__pokemonCapturedCount = new Object();
+
+        this.__gymsDefeated = GameConstants.RegionGyms.flat().map(_ => 0);
+        for (const index of this.__gymsDefeated.keys())
+        {
+            this.gymsDefeated[index] = function() { return this.__gymsDefeated[index]; }.bind(this);
+        }
     }
 
     /***************************\

--- a/tst/stubs/Town/PokeMartShop.pokeclicker.stub.js
+++ b/tst/stubs/Town/PokeMartShop.pokeclicker.stub.js
@@ -1,0 +1,15 @@
+// Stub of https://github.com/pokeclicker/pokeclicker/blob/70b0acc9cb961523a994cd60efe7dfb09a485d5d/src/scripts/towns/TownList.ts#L10
+const pokeMartShop = new Shop([
+    ItemList.Pokeball,
+    ItemList.Greatball,
+    ItemList.Ultraball,
+    ItemList.xAttack,
+    ItemList.xClick,
+    ItemList.Lucky_egg,
+    ItemList.Token_collector,
+    ItemList.Dowsing_machine,
+    ItemList.Lucky_incense,
+    ItemList.SmallRestore,
+    ItemList.MediumRestore,
+    ItemList.LargeRestore
+], 'Explorers Poké Mart');

--- a/tst/stubs/Town/Shop.pokeclicker.stub.js
+++ b/tst/stubs/Town/Shop.pokeclicker.stub.js
@@ -1,0 +1,13 @@
+// Stub of https://github.com/pokeclicker/pokeclicker/blob/70b0acc9cb961523a994cd60efe7dfb09a485d5d/src/scripts/shop/Shop.ts#L3
+class Shop extends TownContent
+{
+    constructor(items,
+                name = undefined,
+                requirements = [])
+    {
+        super(requirements);
+
+        this.name = name;
+        this.items = items;
+    }
+}

--- a/tst/tests/Shop/AutoShop.test.in.js
+++ b/tst/tests/Shop/AutoShop.test.in.js
@@ -1,0 +1,210 @@
+import "tst/utils/tests.utils.js";
+
+// Import pokéclicker App
+import "tst/imports/Pokeclicker.import.js";
+
+// Import current lib stubs
+import "tst/stubs/localStorage.stub.js";
+import "tst/stubs/Automation/Menu.stub.js";
+
+// Import current lib elements
+import "tst/imports/AutomationUtils.import.js";
+import "src/lib/Shop.js";
+
+import "tst/utils/PokemonLoader.utils.js";
+
+/************************\
+|***    TEST-SETUP    ***|
+\************************/
+
+// Stub the Automation class to the bare minimum
+class Automation
+{
+    static Shop = AutomationShop;
+    static Menu = AutomationMenu;
+    static Utils = AutomationUtils;
+
+    static Settings = { Notifications: "Notifications" };
+}
+
+Automation.Shop.__internal__buildShopItemList();
+
+/**************************\
+|***    TEST-HELPERS    ***|
+\**************************/
+
+function checkItemConditions(item, firstUnlockTown, secondUnlockTown)
+{
+    expect(Automation.Shop.__internal__isPokeMarkUnlocked()).toBe(false);
+    expect(item.isUnlocked()).toBe(false);
+    expect(item.isPurchasable()).toBe(false);
+
+    // Unlocking the town should unlock the option
+    TownList[firstUnlockTown].__isUnlocked = true;
+    expect(item.isUnlocked()).toBe(true);
+    expect(item.isPurchasable()).toBe(true);
+
+    // Simulate the player moving to Johto
+    player.__highestRegion = GameConstants.Region.johto;
+    player.region = GameConstants.Region.johto;
+
+    expect(item.isUnlocked()).toBe(true);
+    expect(item.isPurchasable()).toBe(false);
+
+    // Unlocking the town should unlock the option
+    TownList[secondUnlockTown].__isUnlocked = true;
+    expect(item.isPurchasable()).toBe(true);
+
+    // Simulate the player moving to Hoenn (and thus having beaten the johto league)
+    player.__highestRegion = GameConstants.Region.hoenn;
+    player.region = GameConstants.Region.hoenn;
+    App.game.statistics.__gymsDefeated[GameConstants.getGymIndex('Champion Lance')] = 1;
+    expect(Automation.Shop.__internal__isPokeMarkUnlocked()).toBe(true);
+
+    expect(item.isUnlocked()).toBe(true);
+    expect(item.isPurchasable()).toBe(true);
+}
+
+function checkRestoreItemConditions(item, initialRegion, unlockTown)
+{
+    // Simulate the player being in the right
+    player.__highestRegion = initialRegion;
+    player.region = initialRegion;
+
+    expect(item.isUnlocked()).toBe(false);
+    expect(item.isPurchasable()).toBe(false);
+
+    // Unlocking the town should unlock the option
+    TownList[unlockTown].__isUnlocked = true;
+    expect(item.isUnlocked()).toBe(true);
+    expect(item.isPurchasable()).toBe(true);
+
+    // Simulate the player moving to the next region
+    player.__highestRegion += 1;
+    player.region += 1;
+
+    // No other condition needed, it should still be unlocked and purchasable
+    expect(item.isUnlocked()).toBe(true);
+    expect(item.isPurchasable()).toBe(true);
+}
+
+/************************\
+|***    TEST-SUITE    ***|
+\************************/
+
+beforeEach(() =>
+{
+    player.region = 0;
+    player.__highestRegion = 0;
+
+    // Reset all town to locked
+    for (const townName in TownList)
+    {
+        TownList[townName].__isUnlocked = false;
+    }
+
+    App.game.statistics.__gymsDefeated[GameConstants.getGymIndex('Champion Lance')] = 0;
+});
+
+// Check the item internal data behaviour
+describe(`${AutomationTestUtils.categoryPrefix}Test item internal data`, () =>
+{
+    test("Test Pokeball", () =>
+    {
+        let itemData = Automation.Shop.__internal__shopItems[0];
+        expect(itemData.item.name).toBe("Pokeball");
+
+        expect(itemData.isUnlocked()).toBe(true);
+        expect(itemData.isPurchasable()).toBe(true);
+    });
+
+    test("Test Greatball", () =>
+    {
+        let itemData = Automation.Shop.__internal__shopItems[1];
+        expect(itemData.item.name).toBe("Greatball");
+
+        checkItemConditions(itemData, "Lavender Town", "Ecruteak City");
+    });
+
+    test("Test Ultraball", () =>
+    {
+        let itemData = Automation.Shop.__internal__shopItems[2];
+        expect(itemData.item.name).toBe("Ultraball");
+
+        checkItemConditions(itemData, "Fuchsia City", "Blackthorn City");
+    });
+
+    test("Test xAttack", () =>
+    {
+        let itemData = Automation.Shop.__internal__shopItems[3];
+        expect(itemData.item.name).toBe("xAttack");
+
+        expect(itemData.isUnlocked()).toBe(true);
+        expect(itemData.isPurchasable()).toBe(true);
+    });
+
+    test("Test xClick", () =>
+    {
+        let itemData = Automation.Shop.__internal__shopItems[4];
+        expect(itemData.item.name).toBe("xClick");
+
+        expect(itemData.isUnlocked()).toBe(true);
+        expect(itemData.isPurchasable()).toBe(true);
+    });
+
+    test("Test Lucky egg", () =>
+    {
+        let itemData = Automation.Shop.__internal__shopItems[5];
+        expect(itemData.item.name).toBe("Lucky_egg");
+
+        checkItemConditions(itemData, "Pewter City", "Violet City");
+    });
+
+    test("Test Token collector", () =>
+    {
+        let itemData = Automation.Shop.__internal__shopItems[6];
+        expect(itemData.item.name).toBe("Token_collector");
+
+        checkItemConditions(itemData, "Pewter City", "Violet City");
+    });
+
+    test("Test Dowsing machine", () =>
+    {
+        let itemData = Automation.Shop.__internal__shopItems[7];
+        expect(itemData.item.name).toBe("Dowsing_machine");
+
+        checkItemConditions(itemData, "Lavender Town", "Olivine City");
+    });
+
+    test("Test Lucky incense", () =>
+    {
+        let itemData = Automation.Shop.__internal__shopItems[8];
+        expect(itemData.item.name).toBe("Lucky_incense");
+
+        checkItemConditions(itemData, "Lavender Town", "Olivine City");
+    });
+
+    test("Test SmallRestore", () =>
+    {
+        let itemData = Automation.Shop.__internal__shopItems[9];
+        expect(itemData.item.name).toBe("SmallRestore");
+
+        checkRestoreItemConditions(itemData, GameConstants.Region.kanto, "Cinnabar Island");
+    });
+
+    test("Test MediumRestore", () =>
+    {
+        let itemData = Automation.Shop.__internal__shopItems[10];
+        expect(itemData.item.name).toBe("MediumRestore");
+
+        checkRestoreItemConditions(itemData, GameConstants.Region.johto, "Violet City");
+    });
+
+    test("Test LargeRestore", () =>
+    {
+        let itemData = Automation.Shop.__internal__shopItems[11];
+        expect(itemData.item.name).toBe("LargeRestore");
+
+        checkRestoreItemConditions(itemData, GameConstants.Region.johto, "Blackthorn City");
+    });
+});


### PR DESCRIPTION
A new advanced setting panel was added to the Mining feature.
This panel contains two toggles:
  - Automatically use restore items
  - Only use restore items when a mining quest is active

Both are enabled by default.

The Focus "Automatically buy and use small restores" advanced setting was removed.

Note: The restore items can automatically be bought using the "Auto shop" feature.

Fixes #109

---

The auto shop feature was adapted to allow the player to by items right after they've been unlocked instead of having the wait for the Poké Mark in-game shop to be unlocked