### PR TITLE
Farm: Synchronize berries riping time

### DIFF
--- a/src/lib/Farm.js
+++ b/src/lib/Farm.js
@@ -1622,12 +1622,42 @@ class AutomationFarm
                 this.__internal__removeAnyUnwantedBerry(index, berryType);
             }
 
+            let bloomTarget = 0;
             for (const berryType of berriesOrder)
             {
-                for (const index of berriesIndexes[berryType])
+                let currentBerryBloomDuration = App.game.farming.berryData[berryType].growthTime[PlotStage.Bloom];
+
+                if (bloomTarget == 0)
                 {
-                    // We need to use parseInt here to convert the object key from string to int
-                    this.__internal__tryPlantBerryAtIndex(index, parseInt(berryType), false);
+                    bloomTarget = currentBerryBloomDuration;
+                    for (const index of berriesIndexes[berryType])
+                    {
+                        let plot = App.game.farming.plotList[index];
+
+                        if (!plot.isEmpty() && (plot.berry === berryType))
+                        {
+                            // Sync with the one with the lowest remaining time
+                            let remainingTime = currentBerryBloomDuration - plot.age;
+                            if (remainingTime < bloomTarget)
+                            {
+                                bloomTarget = remainingTime;
+                            }
+                        }
+                        this.__internal__tryPlantBerryAtIndex(index, berryType, false);
+                    }
+                }
+                else
+                {
+                    // Wait to sync riping
+                    if (currentBerryBloomDuration < bloomTarget)
+                    {
+                        break;
+                    }
+
+                    for (const index of berriesIndexes[berryType])
+                    {
+                        this.__internal__tryPlantBerryAtIndex(index, berryType, false);
+                    }
                 }
             }
         }.bind(this);

--- a/src/lib/Farm.js
+++ b/src/lib/Farm.js
@@ -185,6 +185,11 @@ class AutomationFarm
         {
             this.__internal__chooseUnlockStrategy();
         }
+        else if (this.__internal__currentStrategy !== null)
+        {
+            // If the focus is turned off, clear the current strategy
+            this.__internal__currentStrategy = null;
+        }
 
         if ((Automation.Utils.LocalStorage.getValue(this.Settings.FocusOnUnlocks) === "true")
             && !this.ForcePlantBerriesAsked)
@@ -327,11 +332,13 @@ class AutomationFarm
     }
 
     /**
-     * @brief Selects the optimum berry placement for mutation requiring over 600 points, with a single berry type
+     * @brief Builds the optimum berry configuration for mutation requiring over 600 points, with a single berry type
      *
      * @param berryType: The type of berry to plant
+     *
+     * @returns The built config { <berryType>: [ indexes... ] }
      */
-    static __internal__plantABerryForMutationRequiringOver600Points(berryType)
+    static __internal__plantABerryForMutationRequiringOver600PointsConfig(berryType)
     {
         // This represents the following strategy
         //  |o|o|o|o|o|
@@ -339,25 +346,19 @@ class AutomationFarm
         //  |o| | | |o|
         //  |o|o|o|o|o|
         //  |o|o|o|o|o|
-        for (const index of App.game.farming.plotList.keys())
-        {
-            if (![ 6, 8, 11, 12, 13 ].includes(index))
-            {
-                this.__internal__tryPlantBerryAtIndex(index, berryType);
-            }
-            else
-            {
-                this.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-            }
-        }
+        let config = {};
+        config[berryType] = App.game.farming.plotList.map((_, index) => index).filter(index => ![ 6, 8, 11, 12, 13 ].includes(index));
+        return config;
     }
 
     /**
-     * @brief Selects the optimum berry placement for mutation requiring 23 berries on the field, with a single berry type
+     * @brief Builds the optimum berry configuration for mutation requiring 23 berries on the field, with a single berry type
      *
      * @param berryType: The type of berry to plant
+     *
+     * @returns The built config { <berryType>: [ indexes... ] }
      */
-    static __internal__plantABerryForMutationRequiring23Berries(berryType)
+    static __internal__plantABerryForMutationRequiring23BerriesConfig(berryType)
     {
         // This represents the following strategy
         //  |o|o|o|o|o|
@@ -365,28 +366,27 @@ class AutomationFarm
         //  |o|o| | |o|
         //  |o|o|o|o|o|
         //  |o|o|o|o|o|
-        for (const index of App.game.farming.plotList.keys())
-        {
-            if (![ 12, 13 ].includes(index))
-            {
-                this.__internal__tryPlantBerryAtIndex(index, berryType);
-            }
-            else
-            {
-                this.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-            }
-        }
+        let config = {};
+        config[berryType] = App.game.farming.plotList.map((_, index) => index).filter(index => ![ 12, 13 ].includes(index));
+        return config;
     }
 
     /**
-     * @brief Selects the optimum berry placement for mutation, with two different berry types
+     * @brief Builds the optimum berry configuration for mutation, with two different berry types
      *
      * @param berry1Type: The first berry type
      * @param berry2Type: The second berry type
+     * @param everyPlotUnlocked: Set to true if every single plot is expected to be unlocked
+     * @param thirteenthPlotUnlocked: Set to true if at least 13 plots are expected to be unlocked
+     * @param tenthPlotUnlocked: Set to true if at least 10 plots are expected to be unlocked
+     *
+     * @returns The built config { <berryType>: [ indexes... ], ... }
      */
-    static __internal__plantTwoBerriesForMutation(berry1Type, berry2Type)
+    static __internal__plantTwoBerriesForMutationConfig(
+        berry1Type, berry2Type, everyPlotUnlocked = true, thirteenthPlotUnlocked = true, tenthPlotUnlocked = true)
     {
-        if (App.game.farming.plotList.every((plot) => plot.isUnlocked))
+        let config = {};
+        if (everyPlotUnlocked)
         {
             // This represents the following strategy
             //  |1| | |1| |
@@ -394,27 +394,12 @@ class AutomationFarm
             //  | | | | | |
             //  |1| | |1| |
             //  | |2| | |2|
-            for (const index of App.game.farming.plotList.keys())
-            {
-                if ([ 0, 3, 15, 18 ].includes(index))
-                {
-                    this.__internal__tryPlantBerryAtIndex(index, berry1Type);
-                }
-                else if ([ 6, 9, 21, 24 ].includes(index))
-                {
-                    this.__internal__tryPlantBerryAtIndex(index, berry2Type);
-                }
-                else
-                {
-                    this.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-                }
-            }
+            config[berry1Type] = [ 0, 3, 15, 18 ];
+            config[berry2Type] = [ 6, 9, 21, 24 ];
         }
-        else if (App.game.farming.plotList[2].isUnlocked)
+        else if (tenthPlotUnlocked)
         {
-            if (App.game.farming.plotList[10].isUnlocked
-                && App.game.farming.plotList[14].isUnlocked
-                && App.game.farming.plotList[22].isUnlocked)
+            if (thirteenthPlotUnlocked)
             {
                 // This represents the following strategy
                 //  |x|x|1|x|x|
@@ -422,21 +407,8 @@ class AutomationFarm
                 //  |1| |2| |1|
                 //  |x| | | |x|
                 //  |x|x|1|x|x|
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    if (index == 12)
-                    {
-                        this.__internal__tryPlantBerryAtIndex(index, berry2Type);
-                    }
-                    else if ([ 2, 10, 14, 22 ].includes(index))
-                    {
-                        this.__internal__tryPlantBerryAtIndex(index, berry1Type);
-                    }
-                    else
-                    {
-                        this.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-                    }
-                }
+                config[berry1Type] = [ 2, 10, 14, 22 ];
+                config[berry2Type] = [ 12 ];
             }
             else
             {
@@ -446,21 +418,8 @@ class AutomationFarm
                 //  |x| |2| |x|
                 //  |x| |1| |x|
                 //  |x|x|x|x|x|
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    if (index == 12)
-                    {
-                        this.__internal__tryPlantBerryAtIndex(index, berry2Type);
-                    }
-                    else if ([ 2, 17 ].includes(index))
-                    {
-                        this.__internal__tryPlantBerryAtIndex(index, berry1Type);
-                    }
-                    else
-                    {
-                        this.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-                    }
-                }
+                config[berry1Type] = [ 2, 17 ];
+                config[berry2Type] = [ 12 ];
             }
         }
         else
@@ -471,32 +430,23 @@ class AutomationFarm
             //  |x|2| |2|x|
             //  |x| |1| |x|
             //  |x|x|x|x|x|
-        for (const index of App.game.farming.plotList.keys())
-            {
-                if ([ 7, 17 ].includes(index))
-                {
-                    this.__internal__tryPlantBerryAtIndex(index, berry1Type);
-                }
-                else if ([ 11, 13 ].includes(index))
-                {
-                    this.__internal__tryPlantBerryAtIndex(index, berry2Type);
-                }
-                else
-                {
-                    this.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-                }
-            }
+            config[berry1Type] = [ 7, 17 ];
+            config[berry2Type] = [ 11, 13 ];
         }
+
+        return config;
     }
 
     /**
-     * @brief Selects the optimum berry placement for mutation, with three different berry types
+     * @brief Builds the optimum berry configuration for mutation, with three different berry types
      *
      * @param berry1Type: The first berry type
      * @param berry2Type: The second berry type
      * @param berry3Type: The third berry type
+     *
+     * @returns The built config { <berryType>: [ indexes... ], ... }
      */
-    static __internal__plantThreeBerriesForMutation(berry1Type, berry2Type, berry3Type)
+    static __internal__plantThreeBerriesForMutationConfig(berry1Type, berry2Type, berry3Type)
     {
         // This represents the following strategy
         //  | |1| | |1|
@@ -504,36 +454,25 @@ class AutomationFarm
         //  | | | | | |
         //  | |1| | |1|
         //  |2|3| |2|3|
-        for (const index of App.game.farming.plotList.keys())
-        {
-            if ([ 1, 4, 16, 19 ].includes(index))
-            {
-                this.__internal__tryPlantBerryAtIndex(index, berry1Type);
-            }
-            else if ([ 5, 8, 20, 23 ].includes(index))
-            {
-                this.__internal__tryPlantBerryAtIndex(index, berry2Type);
-            }
-            else if ([ 6, 9, 21, 24 ].includes(index))
-            {
-                this.__internal__tryPlantBerryAtIndex(index, berry3Type);
-            }
-            else
-            {
-                this.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-            }
-        }
+        let config = {};
+        config[berry1Type] = [ 1, 4, 16, 19 ];
+        config[berry2Type] = [ 5, 8, 20, 23 ];
+        config[berry3Type] = [ 6, 9, 21, 24 ];
+
+        return config;
     }
 
     /**
-     * @brief Selects the optimum berry placement for mutation, with four different berry types
+     * @brief Builds the optimum berry configuration for mutation, with four different berry types
      *
      * @param berry1Type: The first berry type
      * @param berry2Type: The second berry type
      * @param berry3Type: The third berry type
      * @param berry4Type: The fourth berry type
+     *
+     * @returns The built config { <berryType>: [ indexes... ], ... }
      */
-    static __internal__plantFourBerriesForMutation(berry1Type, berry2Type, berry3Type, berry4Type)
+    static __internal__plantFourBerriesForMutationConfig(berry1Type, berry2Type, berry3Type, berry4Type)
     {
         // This represents the following strategy
         //  |1| |2| |1|
@@ -541,38 +480,24 @@ class AutomationFarm
         //  | | | | | |
         //  |2| |1| |2|
         //  |4| |3| |4|
-        for (const index of App.game.farming.plotList.keys())
-        {
-            if ([ 0, 4, 17 ].includes(index))
-            {
-                this.__internal__tryPlantBerryAtIndex(index, berry1Type);
-            }
-            else if ([ 2, 15, 19 ].includes(index))
-            {
-                this.__internal__tryPlantBerryAtIndex(index, berry2Type);
-            }
-            else if ([ 5, 9, 22 ].includes(index))
-            {
-                this.__internal__tryPlantBerryAtIndex(index, berry3Type);
-            }
-            else if ([ 7, 20, 24 ].includes(index))
-            {
-                this.__internal__tryPlantBerryAtIndex(index, berry4Type);
-            }
-            else
-            {
-                this.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-            }
-        }
+        let config = {};
+        config[berry1Type] = [ 0, 4, 17 ];
+        config[berry2Type] = [ 2, 15, 19 ];
+        config[berry3Type] = [ 5, 9, 22 ];
+        config[berry4Type] = [ 7, 20, 24 ];
+
+        return config;
     }
 
     /**
-     * @brief Selects the optimum berry placement for surrounding berry mutation, with two different berry types
+     * @brief Builds the optimum berry configuration for surrounding berry mutation, with two different berry types
      *
      * @param triggerBerryType: The berry type that triggers the mutation
      * @param mutatedBerryType: The berry type of the mutated berry
+     *
+     * @returns The built config { <berryType>: [ indexes... ], ... }
      */
-    static __internal__plantTwoBerriesForSurroundingMutation(triggerBerryType, mutatedBerryType)
+    static __internal__plantTwoBerriesForSurroundingMutationConfig(triggerBerryType, mutatedBerryType)
     {
         // This represents the following strategy (triggerBerryType = x, mutatedBerryType = o)
         //  |o|o|o|o|o|
@@ -580,15 +505,15 @@ class AutomationFarm
         //  |o|o|o|o|o|
         //  |o|o|o|o|o|
         //  |o|x|o|o|x|
-        for (const index of App.game.farming.plotList.keys())
-        {
-            let berryType = [ 6, 9, 21, 24 ].includes(index) ? triggerBerryType : mutatedBerryType;
-            this.__internal__tryPlantBerryAtIndex(index, berryType);
-        }
+        let config = {};
+        config[triggerBerryType] = [ 6, 9, 21, 24 ];
+        config[mutatedBerryType] = App.game.farming.plotList.map((_, index) => index).filter(x => !config[triggerBerryType].includes(x));
+
+        return config;
     }
 
     /**
-     * @brief Tries to plant the given @p berryType in the selected @p index
+     * @brief Tries to plant the given @p berryType at the given @p index
      *
      * A berry can only be planted if:
      *    - The selected spot is unlocked
@@ -598,41 +523,38 @@ class AutomationFarm
      * @param index: The index of the spot to plant the berry in
      * @param berryType: The type of the berry to plant
      *                   (passing BerryType.None will remove any present berry, but plant none)
+     * @param removeAnyUnwantedBerry: If set to true, any unwanted berry at the given @p index will be removed, if possible
+     *
+     * @returns True if a berry was planted, false otherwise
      */
-    static __internal__tryPlantBerryAtIndex(index, berryType)
+    static __internal__tryPlantBerryAtIndex(index, berryType, removeAnyUnwantedBerry = true)
     {
         let plot = App.game.farming.plotList[index];
 
         if (!plot.isUnlocked)
         {
-            return;
+            return false;
         }
 
         // Remove any mutation that might have occured, as soon as possible
-        if (!plot.isEmpty())
+        if (removeAnyUnwantedBerry && !this.__internal__removeAnyUnwantedBerry(index, berryType))
         {
-            // TODO (02/08/2022): We should add an option to use shovels in such case
-            if ((plot.berry !== berryType) && (plot.stage() == PlotStage.Berry))
-            {
-                this.__internal__harvestCount++;
-                App.game.farming.harvest(index);
-            }
-            else
-            {
-                return;
-            }
+            return false;
         }
 
         if (berryType === BerryType.None)
         {
-            return;
+            return false;
         }
 
         if (App.game.farming.hasBerry(berryType))
         {
             App.game.farming.plant(index, berryType, true);
             this.__internal__plantedBerryCount++;
+            return true;
         }
+
+        return false;
     }
 
     /**
@@ -723,147 +645,82 @@ class AutomationFarm
 
         // #9 Unlock at least one Persim berry through mutation
         this.__internal__addUnlockMutationStrategy(
-            BerryType.Persim, function() { Automation.Farm.__internal__plantTwoBerriesForMutation(BerryType.Oran, BerryType.Pecha); });
+            BerryType.Persim, this.__internal__plantTwoBerriesForMutationConfig(BerryType.Oran, BerryType.Pecha, false, false, false));
 
         // Unlock the slot requiring Persim
         this.__internal__addUnlockSlotStrategy(2, BerryType.Persim);
 
         // #10 Unlock at least one Razz berry through mutation
         this.__internal__addUnlockMutationStrategy(
-            BerryType.Razz, function() { Automation.Farm.__internal__plantTwoBerriesForMutation(BerryType.Leppa, BerryType.Cheri); });
+            BerryType.Razz, this.__internal__plantTwoBerriesForMutationConfig(BerryType.Leppa, BerryType.Cheri, false, false));
 
         // Unlock the slot requiring Razz
         this.__internal__addUnlockSlotStrategy(14, BerryType.Razz);
 
         // #11 Unlock at least one Bluk berry through mutation
         this.__internal__addUnlockMutationStrategy(
-            BerryType.Bluk, function() { Automation.Farm.__internal__plantTwoBerriesForMutation(BerryType.Leppa, BerryType.Chesto); });
+            BerryType.Bluk, this.__internal__plantTwoBerriesForMutationConfig(BerryType.Leppa, BerryType.Chesto, false, false));
 
         // Unlock the slot requiring Bluk
         this.__internal__addUnlockSlotStrategy(22, BerryType.Bluk);
 
         // #12 Unlock at least one Nanab berry through mutation
         this.__internal__addUnlockMutationStrategy(
-            BerryType.Nanab, function() { Automation.Farm.__internal__plantTwoBerriesForMutation(BerryType.Aspear, BerryType.Pecha); });
+            BerryType.Nanab, this.__internal__plantTwoBerriesForMutationConfig(BerryType.Aspear, BerryType.Pecha, false, false));
 
         // Unlock the slot requiring Nanab
         this.__internal__addUnlockSlotStrategy(10, BerryType.Nanab);
 
         // #13 Unlock at least one Wepear berry through mutation
         this.__internal__addUnlockMutationStrategy(
-            BerryType.Wepear, function() { Automation.Farm.__internal__plantTwoBerriesForMutation(BerryType.Oran, BerryType.Rawst); });
+            BerryType.Wepear, this.__internal__plantTwoBerriesForMutationConfig(BerryType.Oran, BerryType.Rawst, false));
 
         // Unlock the slot requiring Wepear
         this.__internal__addUnlockSlotStrategy(3, BerryType.Wepear);
 
         // #14 Unlock at least one Pinap berry through mutation
         this.__internal__addUnlockMutationStrategy(
-            BerryType.Pinap, function() { Automation.Farm.__internal__plantTwoBerriesForMutation(BerryType.Sitrus, BerryType.Aspear); });
+            BerryType.Pinap, this.__internal__plantTwoBerriesForMutationConfig(BerryType.Sitrus, BerryType.Aspear, false));
 
         // Unlock the slot requiring Pinap
         this.__internal__addUnlockSlotStrategy(19, BerryType.Pinap);
 
         // #15 Unlock at least one Figy berry through mutation
-        this.__internal__addUnlockMutationStrategy(
-            BerryType.Figy,
-            function()
-            {
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    if ([ 2, 3, 6, 10, 14, 16, 18, 19, 22 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Cheri);
-                    }
-                    else
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-                    }
-                }
-            });
+        let figyConfig = {};
+        figyConfig[BerryType.Cheri] = [ 2, 3, 6, 10, 14, 16, 18, 19, 22 ];
+        this.__internal__addUnlockMutationStrategy(BerryType.Figy, figyConfig);
 
         // Unlock the slot requiring Figy
         this.__internal__addUnlockSlotStrategy(21, BerryType.Figy);
 
         // #16 Unlock at least one Wiki berry through mutation
-        this.__internal__addUnlockMutationStrategy(
-            BerryType.Wiki,
-            function()
-            {
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    if ([ 2, 3, 6, 10, 12, 14, 19, 21, 22 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Chesto);
-                    }
-                    else
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-                    }
-                }
-            });
+        let chestoConfig = {};
+        chestoConfig[BerryType.Chesto] = [ 2, 3, 6, 10, 12, 14, 19, 21, 22 ];
+        this.__internal__addUnlockMutationStrategy(BerryType.Wiki, chestoConfig);
 
         // Unlock the slot requiring Wiki
         this.__internal__addUnlockSlotStrategy(5, BerryType.Wiki);
 
         // #17 Unlock at least one Mago berry through mutation
-        this.__internal__addUnlockMutationStrategy(
-            BerryType.Mago,
-            function()
-            {
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    if ([ 2, 3, 5, 10, 12, 14, 19, 21, 22 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Pecha);
-                    }
-                    else
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-                    }
-                }
-            });
+        let magoConfig = {};
+        magoConfig[BerryType.Pecha] = [ 2, 3, 5, 10, 12, 14, 19, 21, 22 ];
+        this.__internal__addUnlockMutationStrategy(BerryType.Mago, magoConfig);
 
         // Unlock the slot requiring Mago
         this.__internal__addUnlockSlotStrategy(1, BerryType.Mago);
 
         // #18 Unlock at least one Aguav berry through mutation
-        this.__internal__addUnlockMutationStrategy(
-            BerryType.Aguav,
-            function()
-            {
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    if ([ 2, 3, 5, 10, 12, 14, 19, 21, 22 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Rawst);
-                    }
-                    else
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-                    }
-                }
-            });
+        let aguavConfig = {};
+        aguavConfig[BerryType.Rawst] = [ 2, 3, 5, 10, 12, 14, 19, 21, 22 ];
+        this.__internal__addUnlockMutationStrategy(BerryType.Aguav, aguavConfig);
 
         // Unlock the slot requiring Aguav
         this.__internal__addUnlockSlotStrategy(9, BerryType.Aguav);
 
         // #19 Unlock at least one Iapapa berry through mutation
-        this.__internal__addUnlockMutationStrategy(
-            BerryType.Iapapa,
-            function()
-            {
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    if ([ 2, 3, 5, 10, 12, 14, 19, 21, 22 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Aspear);
-                    }
-                    else
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-                    }
-                }
-            });
+        let iapapaConfig = {};
+        iapapaConfig[BerryType.Aspear] = [ 2, 3, 5, 10, 12, 14, 19, 21, 22 ];
+        this.__internal__addUnlockMutationStrategy(BerryType.Iapapa, iapapaConfig);
 
         // Unlock the slot requiring Iapapa
         this.__internal__addUnlockSlotStrategy(23, BerryType.Iapapa);
@@ -891,130 +748,47 @@ class AutomationFarm
         \*********************************/
 
         // #21 Unlock at least one Pomeg berry through mutation
-        this.__internal__addUnlockMutationStrategy(
-            BerryType.Pomeg,
-            function()
-            {
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    if ([ 5, 8, 16, 19 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Iapapa);
-                    }
-                    else if ([ 6, 9, 22 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Mago);
-                    }
-                    else
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-                    }
-                }
-            });
+        let pomegConfig = {};
+        pomegConfig[BerryType.Iapapa] = [ 5, 8, 16, 19 ];
+        pomegConfig[BerryType.Mago] = [ 6, 9, 22 ];
+        this.__internal__addUnlockMutationStrategy(BerryType.Pomeg, pomegConfig);
 
         // Unlock the slot requiring Pomeg
         this.__internal__addUnlockSlotStrategy(15, BerryType.Pomeg);
 
         // #22 Unlock at least one Kelpsy berry through mutation
-        this.__internal__addUnlockMutationStrategy(
-            BerryType.Kelpsy,
-            function()
-            {
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    if ([ 6, 8, 21, 23 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Persim);
-                    }
-                    else if ([ 7, 10, 14, 22 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Chesto);
-                    }
-                    else
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-                    }
-                }
-            });
+        let kelpsyConfig = {};
+        kelpsyConfig[BerryType.Persim] = [ 6, 8, 21, 23 ];
+        kelpsyConfig[BerryType.Chesto] = [ 7, 10, 14, 22 ];
+        this.__internal__addUnlockMutationStrategy(BerryType.Kelpsy, kelpsyConfig);
 
         // Unlock the slot requiring Kelpsy
         this.__internal__addUnlockSlotStrategy(0, BerryType.Kelpsy);
 
         // #23 Unlock at least one Qualot berry through mutation
-        this.__internal__addUnlockMutationStrategy(
-            BerryType.Qualot,
-            function()
-            {
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    if ([ 0, 8, 15, 18 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Pinap);
-                    }
-                    else if ([ 6, 9, 19, 21 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Mago);
-                    }
-                    else
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-                    }
-                }
-            });
+        let qualotConfig = {};
+        qualotConfig[BerryType.Pinap] = [ 0, 8, 15, 18 ];
+        qualotConfig[BerryType.Mago] = [ 6, 9, 19, 21 ];
+        this.__internal__addUnlockMutationStrategy(BerryType.Qualot, qualotConfig);
 
         // Unlock the slot requiring Qualot
         this.__internal__addUnlockSlotStrategy(4, BerryType.Qualot);
 
         // #24 Unlock at least one Hondew berry through mutation
-        this.__internal__addUnlockMutationStrategy(
-            BerryType.Hondew,
-            function()
-            {
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    if ([ 1, 8, 15, 23 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Figy);
-                    }
-                    else if ([ 3, 5, 17, 19 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Wiki);
-                    }
-                    else if ([ 6, 9, 22 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Aguav);
-                    }
-                    else
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-                    }
-                }
-            });
+        let hondewConfig = {};
+        hondewConfig[BerryType.Figy] = [ 1, 8, 15, 23 ];
+        hondewConfig[BerryType.Wiki] = [ 3, 5, 17, 19 ];
+        hondewConfig[BerryType.Aguav] = [ 6, 9, 22 ];
+        this.__internal__addUnlockMutationStrategy(BerryType.Hondew, hondewConfig);
 
         // Unlock the slot requiring Hondew
         this.__internal__addUnlockSlotStrategy(24, BerryType.Hondew);
 
         // #25 Unlock at least one Grepa berry through mutation
-        this.__internal__addUnlockMutationStrategy(
-            BerryType.Grepa,
-            function()
-            {
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    if ([ 0, 3, 15, 18 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Aguav);
-                    }
-                    else if ([ 6, 9, 21, 24 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Figy);
-                    }
-                    else
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-                    }
-                }
-            });
+        let grepaConfig = {};
+        grepaConfig[BerryType.Aguav] = [ 0, 3, 15, 18 ];
+        grepaConfig[BerryType.Figy] = [ 6, 9, 21, 24 ];
+        this.__internal__addUnlockMutationStrategy(BerryType.Grepa, grepaConfig);
 
         // Unlock the slot requiring Grepa
         this.__internal__addUnlockSlotStrategy(20, BerryType.Grepa);
@@ -1025,44 +799,24 @@ class AutomationFarm
 
         // #26 Unlock at least one Tamato berry through mutation
         this.__internal__addUnlockMutationStrategy(
-            BerryType.Tamato,
-            function() { Automation.Farm.__internal__plantTwoBerriesForSurroundingMutation(BerryType.Pomeg, BerryType.Razz); });
+            BerryType.Tamato, this.__internal__plantTwoBerriesForSurroundingMutationConfig(BerryType.Pomeg, BerryType.Razz));
 
         // #27 Unlock at least one Cornn berry through mutation
         this.__internal__addUnlockMutationStrategy(
-            BerryType.Cornn,
-            function() { Automation.Farm.__internal__plantThreeBerriesForMutation(BerryType.Leppa, BerryType.Bluk, BerryType.Wiki); });
+            BerryType.Cornn, this.__internal__plantThreeBerriesForMutationConfig(BerryType.Leppa, BerryType.Bluk, BerryType.Wiki));
 
         // #28 Unlock at least one Magost berry through mutation
         this.__internal__addUnlockMutationStrategy(
-            BerryType.Magost,
-            function() { Automation.Farm.__internal__plantThreeBerriesForMutation(BerryType.Pecha, BerryType.Nanab, BerryType.Mago); });
+            BerryType.Magost, this.__internal__plantThreeBerriesForMutationConfig(BerryType.Pecha, BerryType.Nanab, BerryType.Mago));
 
         // #29 Unlock at least one Rabuta berry through mutation
         this.__internal__addUnlockMutationStrategy(
-            BerryType.Rabuta,
-            function()
-            {
-                Automation.Farm.__internal__plantTwoBerriesForSurroundingMutation(BerryType.Aguav, BerryType.Aspear);
-            });
+            BerryType.Rabuta, this.__internal__plantTwoBerriesForSurroundingMutationConfig(BerryType.Aguav, BerryType.Aspear));
 
         // #30 Unlock at least one Nomel berry through mutation
-        this.__internal__addUnlockMutationStrategy(
-            BerryType.Nomel,
-            function()
-            {
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    if ([ 6, 9, 21, 24 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Pinap);
-                    }
-                    else
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-                    }
-                }
-            });
+        let nomelConfig = {};
+        nomelConfig[BerryType.Pinap] = [ 6, 9, 21, 24 ];
+        this.__internal__addUnlockMutationStrategy(BerryType.Nomel, nomelConfig);
 
         // Make sure to have at least 25 of each berry type before proceeding
         this.__internal__addBerryRequirementBeforeFurtherUnlockStrategy(
@@ -1072,62 +826,30 @@ class AutomationFarm
             ]);
 
         // #31 Unlock at least one Spelon berry through mutation
-        this.__internal__addUnlockMutationStrategy(
-            BerryType.Spelon,
-            function()
-            {
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Tamato);
-                }
-            });
+        let allSlotIndexes = App.game.farming.plotList.map((_, index) => index)
+        let spelonConfig = {};
+        spelonConfig[BerryType.Tamato] = allSlotIndexes;
+        this.__internal__addUnlockMutationStrategy(BerryType.Spelon, spelonConfig);
 
         // #32 Unlock at least one Pamtre berry through mutation
-        this.__internal__addUnlockMutationStrategy(
-            BerryType.Pamtre,
-            function()
-            {
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Cornn);
-                }
-            },
-            1,
-            null,
-            [ OakItemType.Cell_Battery ]);
+        let pamtreConfig = {};
+        pamtreConfig[BerryType.Cornn] = allSlotIndexes;
+        this.__internal__addUnlockMutationStrategy(BerryType.Pamtre, pamtreConfig, 1, null, [ OakItemType.Cell_Battery ]);
 
         // #33 Unlock at least one Watmel berry through mutation
-        this.__internal__addUnlockMutationStrategy(
-            BerryType.Watmel,
-            function()
-            {
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Magost);
-                }
-            });
+        let watmelConfig = {};
+        watmelConfig[BerryType.Magost] = allSlotIndexes;
+        this.__internal__addUnlockMutationStrategy(BerryType.Watmel, watmelConfig);
 
         // #34 Unlock at least one Durin berry through mutation
-        this.__internal__addUnlockMutationStrategy(
-            BerryType.Durin,
-            function()
-            {
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Rabuta);
-                }
-            });
+        let durinConfig = {};
+        durinConfig[BerryType.Rabuta] = allSlotIndexes;
+        this.__internal__addUnlockMutationStrategy(BerryType.Durin, durinConfig);
 
         // #35 Unlock at least one Belue berry through mutation
-        this.__internal__addUnlockMutationStrategy(
-            BerryType.Belue,
-            function()
-            {
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Nomel);
-                }
-            });
+        let belueConfig = {};
+        belueConfig[BerryType.Nomel] = allSlotIndexes;
+        this.__internal__addUnlockMutationStrategy(BerryType.Belue, belueConfig);
 
         /**********************************\
         |*   Harvest some Gen 3 berries   *|
@@ -1153,89 +875,46 @@ class AutomationFarm
 
         // #36 Unlock at least one Occa berry through mutation
         this.__internal__addUnlockMutationStrategy(
-            BerryType.Occa,
-            function()
-            {
-                Automation.Farm.__internal__plantFourBerriesForMutation(BerryType.Tamato, BerryType.Figy, BerryType.Spelon, BerryType.Razz);
-            },
+            BerryType.Occa, this.__internal__plantFourBerriesForMutationConfig(BerryType.Tamato, BerryType.Figy, BerryType.Spelon, BerryType.Razz),
             1,
             null,
             [ OakItemType.Blaze_Cassette ]);
 
         // #44 Unlock at least one Coba berry through mutation (even though it's a berry further in the list, it's needed for the next berry's unlock)
         this.__internal__addUnlockMutationStrategy(
-            BerryType.Coba,
-            function() { Automation.Farm.__internal__plantTwoBerriesForMutation(BerryType.Wiki, BerryType.Aguav); });
+            BerryType.Coba, this.__internal__plantTwoBerriesForMutationConfig(BerryType.Wiki, BerryType.Aguav));
 
         // #37 Unlock at least one Passho berry through mutation
         this.__internal__addUnlockMutationStrategy(
-            BerryType.Passho,
-            function()
-            {
-                Automation.Farm.__internal__plantFourBerriesForMutation(BerryType.Oran, BerryType.Kelpsy, BerryType.Chesto, BerryType.Coba);
-            });
+            BerryType.Passho, this.__internal__plantFourBerriesForMutationConfig(BerryType.Oran, BerryType.Kelpsy, BerryType.Chesto, BerryType.Coba));
 
         // #38 Unlock at least one Wacan berry through mutation
         this.__internal__addUnlockMutationStrategy(
-            BerryType.Wacan,
-            function()
-            {
-                Automation.Farm.__internal__plantFourBerriesForMutation(BerryType.Iapapa, BerryType.Pinap, BerryType.Qualot, BerryType.Grepa);
-            });
+            BerryType.Wacan, this.__internal__plantFourBerriesForMutationConfig(BerryType.Iapapa, BerryType.Pinap, BerryType.Qualot, BerryType.Grepa));
 
         // #39 Unlock at least one Rindo berry through mutation
         this.__internal__addUnlockMutationStrategy(
-            BerryType.Rindo,
-            function() { Automation.Farm.__internal__plantTwoBerriesForMutation(BerryType.Figy, BerryType.Aguav); });
+            BerryType.Rindo, this.__internal__plantTwoBerriesForMutationConfig(BerryType.Figy, BerryType.Aguav));
 
         // #40 Unlock at least one Yache berry through mutation
-        this.__internal__addUnlockMutationStrategy(
-            BerryType.Yache,
-            function()
-            {
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    if ([ 0, 2, 4, 10, 12, 14, 20, 22, 24 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Passho);
-                    }
-                    else
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-                    }
-                }
-            });
+        let yacheConfig = {};
+        yacheConfig[BerryType.Passho] = [ 0, 2, 4, 10, 12, 14, 20, 22, 24 ];
+        this.__internal__addUnlockMutationStrategy(BerryType.Yache, yacheConfig);
 
         // #45 Unlock at least one Payapa berry through mutation
         this.__internal__addUnlockMutationStrategy(
             BerryType.Payapa,
-            function()
-            {
-                Automation.Farm.__internal__plantFourBerriesForMutation(BerryType.Wiki, BerryType.Cornn, BerryType.Bluk, BerryType.Pamtre);
-            },
+            this.__internal__plantFourBerriesForMutationConfig(BerryType.Wiki, BerryType.Cornn, BerryType.Bluk, BerryType.Pamtre),
             1,
             null,
             [ OakItemType.Rocky_Helmet, OakItemType.Cell_Battery ]);
 
         // #46 Unlock at least one Tanga berry through mutation
-        this.__internal__addUnlockMutationStrategy(
-            BerryType.Tanga,
-            function()
-            {
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    if (![ 6, 8, 16, 18 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Rindo);
-                    }
-                    else
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-                    }
-                }
-            });
+        let tangaConfig = {};
+        tangaConfig[BerryType.Rindo] = App.game.farming.plotList.map((_, index) => index).filter(index => ![ 6, 8, 16, 18 ].includes(index));
+        this.__internal__addUnlockMutationStrategy(BerryType.Tanga, tangaConfig);
 
-        // #48 Unlock at least one Kasib berry through mutation
+        // #48 Unlock at least four Kasib berries through mutation
         this.__internal__unlockStrategySelection.push(
             {
                 // Check if the berry is unlocked and the player has at least 1 of them in stock or planted
@@ -1266,24 +945,16 @@ class AutomationFarm
 
         // #49 Unlock at least one Haban berry through mutation
         this.__internal__addUnlockMutationStrategy(
-            BerryType.Haban,
-            function()
-            {
-                Automation.Farm.__internal__plantFourBerriesForMutation(BerryType.Occa, BerryType.Passho, BerryType.Wacan, BerryType.Rindo);
-            });
+            BerryType.Haban, this.__internal__plantFourBerriesForMutationConfig(BerryType.Occa, BerryType.Passho, BerryType.Wacan, BerryType.Rindo));
 
         // #50 Unlock at least one Colbur berry through mutation
         this.__internal__addUnlockMutationStrategy(
-            BerryType.Colbur,
-            function() { Automation.Farm.__internal__plantThreeBerriesForMutation(BerryType.Rabuta, BerryType.Kasib, BerryType.Payapa); });
+            BerryType.Colbur, this.__internal__plantThreeBerriesForMutationConfig(BerryType.Rabuta, BerryType.Kasib, BerryType.Payapa));
 
         // #53 Unlock at least one Roseli berry through mutation
         this.__internal__addUnlockMutationStrategy(
             BerryType.Roseli,
-            function()
-            {
-                Automation.Farm.__internal__plantFourBerriesForMutation(BerryType.Mago, BerryType.Magost, BerryType.Nanab, BerryType.Watmel);
-            },
+            this.__internal__plantFourBerriesForMutationConfig(BerryType.Mago, BerryType.Magost, BerryType.Nanab, BerryType.Watmel),
             1,
             null,
             [ OakItemType.Sprinklotad ]);
@@ -1292,65 +963,26 @@ class AutomationFarm
         // Perform mutations requiring Oak items last to avoid any problem du to the player not having unlocked those
 
         // #43 Unlock at least one Shuca berry through mutation (moved this far to avoid any problem, since it uses Oak items)
-        this.__internal__addUnlockMutationStrategy(
-            BerryType.Shuca,
-            function()
-            {
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Watmel);
-                }
-            },
-            1,
-            OakItemType.Sprinklotad);
+        let allSlotIndexes = App.game.farming.plotList.map((_, index) => index)
+        let shucaConfig = {};
+        shucaConfig[BerryType.Watmel] = allSlotIndexes;
+        this.__internal__addUnlockMutationStrategy(BerryType.Shuca, shucaConfig, 1, OakItemType.Sprinklotad);
 
         // #47 Unlock at least one Charti berry through mutation (moved this far to avoid any problem, since it uses Oak items)
-        this.__internal__addUnlockMutationStrategy(
-            BerryType.Charti,
-            function()
-            {
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Cornn);
-                }
-            },
-            1,
-            OakItemType.Cell_Battery);
+        let chartiConfig = {};
+        chartiConfig[BerryType.Cornn] = allSlotIndexes;
+        this.__internal__addUnlockMutationStrategy(BerryType.Charti, chartiConfig, 1, OakItemType.Cell_Battery);
 
         // #51 Unlock at least one Babiri berry through mutation
-        this.__internal__addUnlockMutationStrategy(
-            BerryType.Babiri,
-            function()
-            {
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    if ([ 0, 1, 2, 3, 4, 7, 17, 20, 21, 22, 23, 24 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Shuca);
-                    }
-                    else if ([ 5, 9, 10, 11, 12, 13, 14, 15, 19 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Charti);
-                    }
-                    else
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-                    }
-                }
-            });
+        let babiriConfig = {};
+        babiriConfig[BerryType.Shuca] = [ 0, 1, 2, 3, 4, 7, 17, 20, 21, 22, 23, 24 ];
+        babiriConfig[BerryType.Charti] = [ 5, 9, 10, 11, 12, 13, 14, 15, 19 ];
+        this.__internal__addUnlockMutationStrategy(BerryType.Babiri, babiriConfig);
 
         // #41 Unlock at least one Chople berry through mutation (moved this far to avoid any problem, since it uses Oak items)
-        this.__internal__addUnlockMutationStrategy(
-            BerryType.Chople,
-            function()
-            {
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Spelon);
-                }
-            },
-            1,
-            OakItemType.Blaze_Cassette);
+        let chopleConfig = {};
+        chopleConfig[BerryType.Spelon] = allSlotIndexes;
+        this.__internal__addUnlockMutationStrategy(BerryType.Chople, chopleConfig, 1, OakItemType.Blaze_Cassette);
 
         // The next mutation need to grow berries while others are ripe, so we need to start on a empty farm
         this.__internal__unlockStrategySelection.push(
@@ -1373,40 +1005,50 @@ class AutomationFarm
             });
 
         // #52 Unlock at least one Chilan berry through mutation
-        this.__internal__addUnlockMutationStrategy(
-            BerryType.Chilan,
-            function()
+        this.__internal__unlockStrategySelection.push(
             {
-                // Nothing planted, plant the first batch
-                if (App.game.farming.plotList[6].isEmpty())
-                {
-                    for (const index of [ 6, 8, 16, 18 ])
+                // Check if the berry is unlocked and the player has at least 1 of them in stock or planted
+                isNeeded: function()
                     {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Chople);
+                        if (!App.game.farming.unlockedBerries[BerryType.Chilan]())
+                        {
+                            return true;
+                        }
+
+                        let totalCount = App.game.farming.berryList[BerryType.Chilan]() + this.__internal__getPlantedBerriesCount(BerryType.Chilan);
+                        return (totalCount < 1);
+                    }.bind(this),
+                berryToUnlock: BerryType.Chilan,
+                harvestStrategy: this.__internal__harvestTimingType.RightBeforeWithering,
+                oakItemToEquip: null,
+                forbiddenOakItems: [],
+                requiredPokemon: null,
+                requiresDiscord: false,
+                action: function()
+                {
+                    // Nothing planted, plant the first batch
+                    if (App.game.farming.plotList[6].isEmpty())
+                    {
+                        for (const index of [ 6, 8, 16, 18 ])
+                        {
+                            Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Chople);
+                        }
                     }
-                }
-                // First batch ripped, plant the rest
-                else if (App.game.farming.plotList[6].age > App.game.farming.plotList[6].berryData.growthTime[PlotStage.Bloom])
-                {
-                    for (const index of App.game.farming.plotList.keys())
+                    // First batch ripped, plant the rest
+                    else if (App.game.farming.plotList[6].age > App.game.farming.plotList[6].berryData.growthTime[PlotStage.Bloom])
                     {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Chople);
+                        for (const index of App.game.farming.plotList.keys())
+                        {
+                            Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Chople);
+                        }
                     }
                 }
             });
 
         // #42 Unlock at least one Kebia berry through mutation
-        this.__internal__addUnlockMutationStrategy(
-            BerryType.Kebia,
-            function()
-            {
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Pamtre);
-                }
-            },
-            1,
-            OakItemType.Rocky_Helmet);
+        let kebiaConfig = {};
+        kebiaConfig[BerryType.Pamtre] = allSlotIndexes;
+        this.__internal__addUnlockMutationStrategy(BerryType.Kebia, kebiaConfig, 1, OakItemType.Rocky_Helmet);
     }
 
     /**
@@ -1421,7 +1063,7 @@ class AutomationFarm
         // #54 Unlock at least one Micle berry through mutation
         this.__internal__addUnlockMutationStrategy(
             BerryType.Micle,
-            function() { Automation.Farm.__internal__plantABerryForMutationRequiringOver600Points(BerryType.Pamtre); },
+            this.__internal__plantABerryForMutationRequiringOver600PointsConfig(BerryType.Pamtre),
             1,
             null,
             [ OakItemType.Rocky_Helmet ]);
@@ -1429,18 +1071,18 @@ class AutomationFarm
         // #55 Unlock at least one Custap berry through mutation
         this.__internal__addUnlockMutationStrategy(
             BerryType.Custap,
-            function() { Automation.Farm.__internal__plantABerryForMutationRequiringOver600Points(BerryType.Watmel); },
+            this.__internal__plantABerryForMutationRequiringOver600PointsConfig(BerryType.Watmel),
             1,
             null,
             [ OakItemType.Sprinklotad ]);
 
         // #56 Unlock at least one Jaboca berry through mutation
         this.__internal__addUnlockMutationStrategy(
-            BerryType.Jaboca, function() { Automation.Farm.__internal__plantABerryForMutationRequiringOver600Points(BerryType.Durin); });
+            BerryType.Jaboca, this.__internal__plantABerryForMutationRequiringOver600PointsConfig(BerryType.Durin));
 
         // #57 Unlock at least one Rowap berry through mutation
         this.__internal__addUnlockMutationStrategy(
-            BerryType.Rowap, function() { Automation.Farm.__internal__plantABerryForMutationRequiringOver600Points(BerryType.Belue); });
+            BerryType.Rowap, this.__internal__plantABerryForMutationRequiringOver600PointsConfig(BerryType.Belue));
 
         //////
         // The following mutations require the player to have caught legendary pokemons
@@ -1448,7 +1090,7 @@ class AutomationFarm
         // #60 Unlock at least one Liechi berry through mutation
         this.__internal__addUnlockMutationStrategy(
             BerryType.Liechi,
-            function() { Automation.Farm.__internal__plantABerryForMutationRequiring23Berries(BerryType.Passho); },
+            this.__internal__plantABerryForMutationRequiring23BerriesConfig(BerryType.Passho),
             4,
             null,
             [],
@@ -1457,7 +1099,7 @@ class AutomationFarm
         // #61 Unlock at least one Ganlon berry through mutation
         this.__internal__addUnlockMutationStrategy(
             BerryType.Ganlon,
-            function() { Automation.Farm.__internal__plantABerryForMutationRequiring23Berries(BerryType.Shuca); },
+            this.__internal__plantABerryForMutationRequiring23BerriesConfig(BerryType.Shuca),
             4,
             null,
             [],
@@ -1465,58 +1107,47 @@ class AutomationFarm
 
         // #58 Unlock at least one Kee berry through mutation
         this.__internal__addUnlockMutationStrategy(
-            BerryType.Kee,
-            function() { Automation.Farm.__internal__plantTwoBerriesForMutation(BerryType.Liechi, BerryType.Ganlon); });
+            BerryType.Kee, this.__internal__plantTwoBerriesForMutationConfig(BerryType.Liechi, BerryType.Ganlon));
 
-        // #62 Unlock at least one Salac berry through mutation
+        // #62 Unlock at least four Salac berries through mutation
         this.__internal__addUnlockMutationStrategy(
             BerryType.Salac,
-            function() { Automation.Farm.__internal__plantABerryForMutationRequiring23Berries(BerryType.Coba); },
+            this.__internal__plantABerryForMutationRequiring23BerriesConfig(BerryType.Coba),
             4,
             null,
             [],
             "Rayquaza");
 
-        // #63 Unlock at least one Petaya berry through mutation
-        this.__internal__addUnlockMutationStrategy(BerryType.Petaya,
-                                                   function()
-                                                   {
-                                                       // Plant the needed berries
-                                                       Automation.Farm.__internal__tryPlantBerryAtIndex(0, BerryType.Kasib);
-                                                       Automation.Farm.__internal__tryPlantBerryAtIndex(2, BerryType.Payapa);
-                                                       Automation.Farm.__internal__tryPlantBerryAtIndex(4, BerryType.Yache);
-                                                       Automation.Farm.__internal__tryPlantBerryAtIndex(5, BerryType.Shuca);
-                                                       Automation.Farm.__internal__tryPlantBerryAtIndex(9, BerryType.Wacan);
-                                                       Automation.Farm.__internal__tryPlantBerryAtIndex(10, BerryType.Chople);
-                                                       Automation.Farm.__internal__tryPlantBerryAtIndex(11, BerryType.Coba);
-                                                       Automation.Farm.__internal__tryPlantBerryAtIndex(12, BerryType.Kebia);
-                                                       Automation.Farm.__internal__tryPlantBerryAtIndex(14, BerryType.Haban);
-                                                       Automation.Farm.__internal__tryPlantBerryAtIndex(15, BerryType.Colbur);
-                                                       Automation.Farm.__internal__tryPlantBerryAtIndex(16, BerryType.Babiri);
-                                                       Automation.Farm.__internal__tryPlantBerryAtIndex(17, BerryType.Charti);
-                                                       Automation.Farm.__internal__tryPlantBerryAtIndex(19, BerryType.Tanga);
-                                                       Automation.Farm.__internal__tryPlantBerryAtIndex(20, BerryType.Occa);
-                                                       Automation.Farm.__internal__tryPlantBerryAtIndex(21, BerryType.Rindo);
-                                                       Automation.Farm.__internal__tryPlantBerryAtIndex(22, BerryType.Passho);
-                                                       Automation.Farm.__internal__tryPlantBerryAtIndex(23, BerryType.Roseli);
-                                                       Automation.Farm.__internal__tryPlantBerryAtIndex(24, BerryType.Chilan);
-
-                                                       for (const index of [ 1, 3, 6, 7, 8, 13, 18 ])
-                                                       {
-                                                           Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-                                                       }
-                                                   },
-                                                   4);
+        // #63 Unlock at least four Petaya berries through mutation
+        let petayaConfig = {};
+        petayaConfig[BerryType.Kasib] = [ 0 ];
+        petayaConfig[BerryType.Payapa] = [ 2 ];
+        petayaConfig[BerryType.Yache] = [ 4 ];
+        petayaConfig[BerryType.Shuca] = [ 5 ];
+        petayaConfig[BerryType.Wacan] = [ 9 ];
+        petayaConfig[BerryType.Chople] = [ 10 ];
+        petayaConfig[BerryType.Coba] = [ 11 ];
+        petayaConfig[BerryType.Kebia] = [ 12 ];
+        petayaConfig[BerryType.Haban] = [ 14 ];
+        petayaConfig[BerryType.Colbur] = [ 15 ];
+        petayaConfig[BerryType.Babiri] = [ 16 ];
+        petayaConfig[BerryType.Charti] = [ 17 ];
+        petayaConfig[BerryType.Tanga] = [ 19 ];
+        petayaConfig[BerryType.Occa] = [ 20 ];
+        petayaConfig[BerryType.Rindo] = [ 21 ];
+        petayaConfig[BerryType.Passho] = [ 22 ];
+        petayaConfig[BerryType.Roseli] = [ 23 ];
+        petayaConfig[BerryType.Chilan] = [ 24 ];
+        this.__internal__addUnlockMutationStrategy(BerryType.Petaya, petayaConfig, 4);
 
         // #59 Unlock at least one Maranga berry through mutation
         this.__internal__addUnlockMutationStrategy(
-            BerryType.Maranga,
-            function() { Automation.Farm.__internal__plantTwoBerriesForMutation(BerryType.Salac, BerryType.Petaya); });
+            BerryType.Maranga, this.__internal__plantTwoBerriesForMutationConfig(BerryType.Salac, BerryType.Petaya));
 
         // #64 Unlock at least one Apicot berry through mutation
         this.__internal__addUnlockMutationStrategy(
             BerryType.Apicot,
-            function() { Automation.Farm.__internal__plantABerryForMutationRequiring23Berries(BerryType.Chilan); },
+            this.__internal__plantABerryForMutationRequiring23BerriesConfig(BerryType.Chilan),
             1,
             null,
             [],
@@ -1525,28 +1156,16 @@ class AutomationFarm
         // #65 Unlock at least one Lansat berry through mutation
         this.__internal__addUnlockMutationStrategy(
             BerryType.Lansat,
-            function() { Automation.Farm.__internal__plantABerryForMutationRequiring23Berries(BerryType.Roseli); },
+            this.__internal__plantABerryForMutationRequiring23BerriesConfig(BerryType.Roseli),
             1,
             null,
             [],
             "Dialga");
 
         // #66 Unlock at least one Starf berry through mutation
-        this.__internal__addUnlockMutationStrategy(BerryType.Starf,
-                                                   function()
-                                                   {
-                                                       for (const index of App.game.farming.plotList.keys())
-                                                       {
-                                                           if (![ 11, 12, 13 ].includes(index))
-                                                           {
-                                                               Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Roseli);
-                                                           }
-                                                           else
-                                                           {
-                                                               Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-                                                           }
-                                                       }
-                                                   });
+        let starfConfig = {};
+        starfConfig[BerryType.Roseli] = App.game.farming.plotList.map((_, index) => index).filter(index => ![ 11, 12, 13 ].includes(index));
+        this.__internal__addUnlockMutationStrategy(BerryType.Starf, starfConfig);
     }
 
     /**
@@ -1560,50 +1179,16 @@ class AutomationFarm
         \*************/
 
         // #20 Unlock and gather at least 24 Lum berry through mutation
-        this.__internal__addUnlockMutationStrategy(BerryType.Lum,
-            function()
-            {
-                for (const index of App.game.farming.plotList.keys())
-                {
-                    if ([ 0, 4, 20, 24 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Sitrus);
-                    }
-                    else if ([ 1, 3, 21, 23 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Oran);
-                    }
-                    else if ([ 2, 22 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Aspear);
-                    }
-                    else if ([ 5, 9, 15, 19 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Leppa);
-                    }
-                    else if ([ 7, 17 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Pecha);
-                    }
-                    else if ([ 10, 14 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Rawst);
-                    }
-                    else if ([ 11, 13 ].includes(index))
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Chesto);
-                    }
-                    else if (index == 12)
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.Cheri);
-                    }
-                    else
-                    {
-                        Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-                    }
-                }
-            },
-            24);
+        let lumConfig = {};
+        lumConfig[BerryType.Sitrus] = [ 0, 4, 20, 24 ];
+        lumConfig[BerryType.Oran] = [ 1, 3, 21, 23 ];
+        lumConfig[BerryType.Aspear] = [ 2, 22 ];
+        lumConfig[BerryType.Leppa] = [ 5, 9, 15, 19 ];
+        lumConfig[BerryType.Pecha] = [ 7, 17 ];
+        lumConfig[BerryType.Rawst] = [ 10, 14 ];
+        lumConfig[BerryType.Chesto] = [ 11, 13 ];
+        lumConfig[BerryType.Cheri] = [ 12 ];
+        this.__internal__addUnlockMutationStrategy(BerryType.Lum, lumConfig, 24);
     }
 
     /**
@@ -1611,49 +1196,22 @@ class AutomationFarm
      */
     static __internal__addEnigmaBerryStrategy()
     {
-        this.__internal__unlockStrategySelection.push(
-            {
-                // Check if the berry is unlocked
-                isNeeded: function() { return !App.game.farming.unlockedBerries[BerryType.Enigma](); },
-                berryToUnlock: BerryType.Enigma,
-                harvestStrategy: this.__internal__harvestTimingType.RightBeforeWithering,
-                oakItemToEquip: null,
-                forbiddenOakItems: [],
-                requiredPokemon: null,
-                requiresDiscord: true,
-                action: function()
-                        {
-                            let neededBerries = EnigmaMutation.getReqs();
+        let neededBerries = EnigmaMutation.getReqs();
 
-                            for (const index of App.game.farming.plotList.keys())
-                            {
-                                if ([ 1, 13 ].includes(index))
-                                {
-                                    // North berry
-                                    Automation.Farm.__internal__tryPlantBerryAtIndex(index, neededBerries[0]);
-                                }
-                                else if ([ 5, 17 ].includes(index))
-                                {
-                                    // West berry
-                                    Automation.Farm.__internal__tryPlantBerryAtIndex(index, neededBerries[1]);
-                                }
-                                else if ([ 7, 19 ].includes(index))
-                                {
-                                    // East berry
-                                    Automation.Farm.__internal__tryPlantBerryAtIndex(index, neededBerries[2]);
-                                }
-                                else if ([ 11, 23 ].includes(index))
-                                {
-                                    // South berry
-                                    Automation.Farm.__internal__tryPlantBerryAtIndex(index, neededBerries[3]);
-                                }
-                                else
-                                {
-                                    Automation.Farm.__internal__tryPlantBerryAtIndex(index, BerryType.None);
-                                }
-                            }
-                        }
-            });
+        // This represents the following strategy
+        // | |a| | | |
+        // |b| |c| | |  with:  a : North berry
+        // | |d| |a| |         b : West berry
+        // | | |b| |c|         c : East berry
+        // | | | |d| |         d : South berry
+        let enigmaConfig = {};
+        enigmaConfig[neededBerries[0]] = [ 1, 13 ];
+        enigmaConfig[neededBerries[1]] = [ 5, 17 ];
+        enigmaConfig[neededBerries[2]] = [ 7, 19 ];
+        enigmaConfig[neededBerries[3]] = [ 11, 23 ];
+
+        this.__internal__addUnlockMutationStrategy(BerryType.Enigma, enigmaConfig);
+        this.__internal__unlockStrategySelection[this.__internal__unlockStrategySelection.length - 1].requiresDiscord = true;
     }
 
     /**
@@ -1691,23 +1249,23 @@ class AutomationFarm
     }
 
     /**
-     * @brief Adds an unlock strategy to unlock a berry using mutations
+     * @brief Adds an unlock strategy aiming at unlocking a berry using mutations
      *
      * @param berryType: The type of berry to unlock
-     * @param actionCallback: The action to perform if it's locked
+     * @param berriesIndexes: The berries to plant and their indexes ({ <berryType>: [ indexes... ], ... })
      * @param minimumRequiredBerry: The minimum of berries to hold required (Default: 1)
      * @param oakItemNeeded: The Oak item needed for the mutation to work (Default: None)
      * @param oakItemsToRemove: The Oak items list that might ruin the mutation and needs to be forbidden (Default: None)
      * @param requiredPokemonName: The name of the Pokemon needed for the mutation to occur (Default: None)
      */
     static __internal__addUnlockMutationStrategy(berryType,
-                                                 actionCallback,
+                                                 berriesIndexes,
                                                  minimumRequiredBerry = 1,
                                                  oakItemNeeded = null,
                                                  oakItemsToRemove = [],
                                                  requiredPokemonName = null)
     {
-        this.__internal__unlockStrategySelection.push(
+        let step =
             {
                 // Check if the berry is unlocked and the player has at least 1 of them in stock or planted
                 isNeeded: function()
@@ -1725,9 +1283,11 @@ class AutomationFarm
                 oakItemToEquip: oakItemNeeded,
                 forbiddenOakItems: oakItemsToRemove,
                 requiredPokemon: requiredPokemonName,
-                requiresDiscord: false,
-                action: actionCallback
-            });
+                requiresDiscord: false
+            };
+
+        this.__internal__setSlotConfigStrategy(step, berriesIndexes);
+        this.__internal__unlockStrategySelection.push(step);
     }
 
     /**
@@ -1993,5 +1553,83 @@ class AutomationFarm
         {
             Automation.Utils.sendNotif("Harvested " + this.__internal__harvestCount.toString() + " berries<br>" + details, "Farming");
         }
+    }
+
+    /**
+     * @brief Removes any unwanted berry from the plot at the given @p index
+     *
+     * @param {number} index: The index of the plot to clean
+     * @param expectedBerryType: The expected berry type, any other type would be cleaned
+     *
+     * @returns False if the plot still contains an unwanted berry, true otherwise
+     */
+    static __internal__removeAnyUnwantedBerry(index, expectedBerryType)
+    {
+        let plot = App.game.farming.plotList[index];
+
+        if (!plot.isUnlocked)
+        {
+            return false;
+        }
+
+        if (!plot.isEmpty())
+        {
+            // TODO (02/08/2022): We should add an option to use shovels in such case
+            if ((plot.berry !== expectedBerryType) && (plot.stage() == PlotStage.Berry))
+            {
+                this.__internal__harvestCount++;
+                App.game.farming.harvest(index);
+                return true;
+            }
+            else
+            {
+                return false
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @brief Sets the action callback of the provided @p step, according to @p berriesIndexes
+     *
+     * @param step: The step to set the action callback to
+     * @param berriesIndexes: The berries to plant and their indexes ({ <berryType>: [ indexes... ], ... })
+     */
+    static __internal__setSlotConfigStrategy(step, berriesIndexes)
+    {
+        // Sort berries from longer riping time to shorter
+        // We need to use parseInt here to convert the object key from string to int
+        let berriesOrder = [...Object.keys(berriesIndexes)].map(x => parseInt(x)).sort(
+            (a, b) => App.game.farming.berryData[b].growthTime[PlotStage.Bloom] - App.game.farming.berryData[a].growthTime[PlotStage.Bloom]);
+
+        // Compute config representation
+        let config = new Array(App.game.farming.plotList.length).fill(BerryType.None);
+        for (const berryType of berriesOrder)
+        {
+            for (const index of berriesIndexes[berryType])
+            {
+                config[index] = berryType;
+            }
+        }
+
+        // Register the callback
+        step.action = function()
+        {
+            // Remove any mutation that might have occured, as soon as possible
+            for (const [ index, berryType ] of config.entries())
+            {
+                this.__internal__removeAnyUnwantedBerry(index, berryType);
+            }
+
+            for (const berryType of berriesOrder)
+            {
+                for (const index of berriesIndexes[berryType])
+                {
+                    // We need to use parseInt here to convert the object key from string to int
+                    this.__internal__tryPlantBerryAtIndex(index, parseInt(berryType), false);
+                }
+            }
+        }.bind(this);
     }
 }


### PR DESCRIPTION
The more berries involved, the harder it becomes to trigger a mutation without synchronizing the berries timing.
This PR implements the ripe time synchronizing.

Main part of #88