### PR TITLE
Focus.Quests: Allow the user to disable quests

### DIFF
--- a/src/lib/Focus.js
+++ b/src/lib/Focus.js
@@ -224,6 +224,9 @@ class AutomationFocus
         titleDiv.style.marginBottom = "10px";
         focusSettingPanel.appendChild(titleDiv);
 
+        let focusSettingsTabsGroup = "automationFocusSettings";
+        let generalTabContainer = Automation.Menu.addTabElement(focusSettingPanel, "General", focusSettingsTabsGroup);
+
         /**********************\
         |*   Balls settings   *|
         \**********************/
@@ -235,7 +238,7 @@ class AutomationFocus
                                  + "already caught pokémon, when needed"
                                  + disclaimer;
         this.__internal__pokeballToUseSelectElem = this.__internal__addPokeballList(
-            "focusPokeballToUseSelection", focusSettingPanel, this.Settings.BallToUseToCatch, "Pokeball to use for catching :", pokeballToUseTooltip);
+            "focusPokeballToUseSelection", generalTabContainer, this.Settings.BallToUseToCatch, "Pokeball to use for catching :", pokeballToUseTooltip);
 
         // Default Pokeball for caught pokémons
         let defaultCaughtPokeballTooltip = "Defines which pokeball will be equipped to catch\n"
@@ -246,7 +249,7 @@ class AutomationFocus
                                          + disclaimer;
         this.__internal__defaultCaughtPokeballSelectElem =
             this.__internal__addPokeballList("focusDefaultCaughtBallSelection",
-                                             focusSettingPanel,
+                                             generalTabContainer,
                                              this.Settings.DefaultCaughtBall,
                                              "Default value for caught pokémon pokéball :",
                                              defaultCaughtPokeballTooltip,
@@ -257,14 +260,21 @@ class AutomationFocus
         \**********************/
 
         // Add some space
-        focusSettingPanel.appendChild(document.createElement("br"));
+        generalTabContainer.appendChild(document.createElement("br"));
 
         // OakItem loadout setting
         let disableOakItemTooltip = "Modifies the oak item loadout automatically";
         Automation.Menu.addLabeledAdvancedSettingsToggleButton("Optimize oak item loadout",
                                                                this.Settings.OakItemLoadoutUpdate,
                                                                disableOakItemTooltip,
-                                                               focusSettingPanel);
+                                                               generalTabContainer);
+
+        /*********************\
+        |*  Quests settings  *|
+        \*********************/
+
+        let questTabContainer = Automation.Menu.addTabElement(focusSettingPanel, "Quests", focusSettingsTabsGroup);
+        this.Quests.__buildAdvancedSettings(questTabContainer)
     }
 
     /**

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -226,8 +226,16 @@ class AutomationFocusQuests
         this.__internal__claimCompletedQuests();
         this.__internal__selectNewQuests();
 
-        this.__internal__workOnQuest();
-        this.__internal__workOnBackgroundQuests();
+        // Skip any unwanted quest
+        if (this.__internal__getFilteredCurrentQuests().length == 0)
+        {
+            this.__internal__skipRemainingQuests();
+        }
+        else
+        {
+            this.__internal__workOnQuest();
+            this.__internal__workOnBackgroundQuests();
+        }
     }
 
     /**
@@ -256,12 +264,17 @@ class AutomationFocusQuests
             return;
         }
 
+        // Only consider quests that:
+        //   - Are not already completed
+        //   - Are not already in progress
+        //   - Are not disabled by the user
         let availableQuests = App.game.quests.questList().filter(
-            (_, index) =>
+            quest =>
             {
-                return (!App.game.quests.questList()[index].isCompleted()
-                        && !App.game.quests.questList()[index].inProgress());
-            });
+                return (!quest.isCompleted()
+                        && !quest.inProgress()
+                        && (Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.QuestEnabled(quest.constructor.name)) == "true"));
+            }, this);
 
         // Sort quest to group the same type together
         availableQuests.sort(this.__internal__sortQuestByPriority, this);
@@ -273,6 +286,40 @@ class AutomationFocusQuests
                 quest.begin();
             }
         }
+    }
+
+    /**
+     * @brief Skips the remaining quest, if they were skipped by the user
+     */
+    static __internal__skipRemainingQuests()
+    {
+        // Make sure some quests were not completed (ie. excluded ones)
+        let availableQuests = App.game.quests.questList().filter(
+            (_, index) =>
+            {
+                let quest = App.game.quests.questList()[index];
+                return (!quest.isCompleted()
+                        && !quest.inProgress());
+            });
+        if (availableQuests.length == 0)
+        {
+            return;
+        }
+
+        // Make sure the player can afford the refresh
+        if (!App.game.quests.freeRefresh() && !App.game.quests.canAffordRefresh())
+        {
+            // Go farm some money
+            this.__internal__farmSomeMoney();
+            return;
+        }
+
+        let pokedollarsImage = '<img src="assets/images/currency/money.svg" height="25px">';
+        let refreshCost = App.game.quests.freeRefresh() ? "free" : `${App.game.quests.getRefreshCost().amount} ${pokedollarsImage}`;
+
+        App.game.quests.refreshQuests();
+
+        Automation.Utils.sendNotif(`Skipped disabled quests for ${refreshCost}`, "Focus > Quests");
     }
 
     /**
@@ -288,7 +335,7 @@ class AutomationFocusQuests
         }
         Automation.Dungeon.AutomationRequestedMode = Automation.Dungeon.InternalModes.None;
 
-        let currentQuests = App.game.quests.currentQuests();
+        let currentQuests = this.__internal__getFilteredCurrentQuests();
         if (currentQuests.length == 0)
         {
             return;
@@ -358,15 +405,8 @@ class AutomationFocusQuests
             }
             else if (currentQuests.some((quest) => quest instanceof GainMoneyQuest))
             {
-                this.__internal__equipOptimizedLoadout(Automation.Utils.OakItem.Setup.Money);
-
-                let bestGym = Automation.Utils.Gym.findBestGymForMoney();
-                if (bestGym.bestGymTown !== null)
-                {
-                    Automation.Utils.Route.moveToTown(bestGym.bestGymTown);
-                    Automation.Focus.__enableAutoGymFight(bestGym.bestGym);
-                    return;
-                }
+                this.__internal__farmSomeMoney();
+                return;
             }
             else
             {
@@ -378,13 +418,31 @@ class AutomationFocusQuests
     }
 
     /**
+     * @brief Equips the Money loadout and move to the best place to farm money
+     */
+    static __internal__farmSomeMoney()
+    {
+        this.__internal__equipOptimizedLoadout(Automation.Utils.OakItem.Setup.Money);
+
+        let bestGym = Automation.Utils.Gym.findBestGymForMoney();
+        if (bestGym.bestGymTown !== null)
+        {
+            Automation.Utils.Route.moveToTown(bestGym.bestGymTown);
+            Automation.Focus.__enableAutoGymFight(bestGym.bestGym);
+            return;
+        }
+
+        Automation.Utils.Route.moveToBestRouteForExp();
+    }
+
+    /**
      * @brief Performs action related to quests that can be done while other quests are being worked on.
      *
      * For example, planting some crops, or restoring energy for the mine [if enabled].
      */
     static __internal__workOnBackgroundQuests()
     {
-        let currentQuests = App.game.quests.currentQuests();
+        let currentQuests = this.__internal__getFilteredCurrentQuests();
 
         let isFarmingSpecificBerry = false;
 
@@ -599,7 +657,7 @@ class AutomationFocusQuests
         if (!enforceType)
         {
             // Choose the most optimal pokeball, based on the other quests
-            for (const quest of App.game.quests.currentQuests())
+            for (const quest of this.__internal__getFilteredCurrentQuests())
             {
                 if (quest instanceof UsePokeballQuest)
                 {
@@ -803,7 +861,7 @@ class AutomationFocusQuests
     {
         let optimumItems = [];
 
-        let currentQuests = App.game.quests.currentQuests();
+        let currentQuests = this.__internal__getFilteredCurrentQuests();
 
         // Always equip UseOakItemQuest items 1st
         let useOakItemQuests = currentQuests.filter((quest) => quest instanceof UseOakItemQuest)
@@ -832,5 +890,15 @@ class AutomationFocusQuests
         }
 
         Automation.Focus.__internal__equipLoadout(resultLoadout);
+    }
+
+    /**
+     * @returns The current quests list, without the user disabled ones
+     */
+    static __internal__getFilteredCurrentQuests()
+    {
+        return App.game.quests.currentQuests().filter(
+                (quest) => (Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.QuestEnabled(quest.constructor.name)) == "true")
+            , this);
     }
 }

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -39,11 +39,110 @@ class AutomationFocusQuests
             });
     }
 
+    /**
+     * @brief Builds the 'Focus on Quests' advanced settings tab, and initializes internal data
+     *
+     * @param {Element} parent: The parent div to add the settings to
+     */
+    static __buildAdvancedSettings(parent)
+    {
+        this.__internal__initializeQuestData();
+        this.__internal__buildAdvancedSettings(parent);
+    }
+
     /*********************************************************************\
     |***    Internal members, should never be used by other classes    ***|
     \*********************************************************************/
 
     static __internal__autoQuestLoop = null;
+    static __internal__questLabels = {};
+
+    static __internal__advancedSettings = {
+                                              QuestEnabled: function(questName) { return `Focus-${questName}-Enabled`; }
+                                          };
+
+    /**
+     * @brief Initializes the internal quest data
+     */
+    static __internal__initializeQuestData()
+    {
+        this.__internal__questLabels["DefeatPokemonsQuest"] = "Defeat <n> Pokémon on <Route>.";
+        this.__internal__questLabels["CapturePokemonsQuest"] = "Capture <n> Pokémon.";
+        this.__internal__questLabels["CapturePokemonTypesQuest"] = "Capture <n> <Type> Pokémon.";
+        this.__internal__questLabels["GainFarmPointsQuest"] = "Gain <n> Farm Points.";
+        this.__internal__questLabels["GainMoneyQuest"] = "Gain <n> Pokédollars.";
+        this.__internal__questLabels["GainTokensQuest"] = "Gain <n> Dungeon Tokens.";
+        this.__internal__questLabels["GainGemsQuest"] = "Gain <n> Fire gems.";
+        this.__internal__questLabels["HatchEggsQuest"] = "Hatch <n> Eggs.";
+        this.__internal__questLabels["MineLayersQuest"] = "Mine <n> layer in the Underground.";
+        this.__internal__questLabels["MineItemsQuest"] = "Mine <n> item in the Underground.";
+        this.__internal__questLabels["CatchShiniesQuest"] = "Catch 1 shiny Pokémon.";
+        this.__internal__questLabels["DefeatGymQuest"] = "Defeat <Gym leader> <n> times.";
+        this.__internal__questLabels["DefeatDungeonQuest"] = "Defeat the <Dungeon> <n> times.";
+        this.__internal__questLabels["UsePokeballQuest"] = "Use <n> <Balls type>.";
+        this.__internal__questLabels["UseOakItemQuest"] = "Equip the <Oak item> and <Action>.";
+        this.__internal__questLabels["HarvestBerriesQuest"] = "Harvest <n> <Berry type> Berries at the farm.";
+
+        // Generate default descriptions for any unknown quest
+        for (const quest in QuestHelper.quests)
+        {
+            if (!this.__internal__questLabels[quest])
+            {
+                let questClass = QuestHelper.quests[quest];
+                let args = questClass.generateData();
+                let questInstance = new questClass(...args);
+                this.__internal__questLabels[quest] = questInstance.description;
+            }
+        }
+    }
+
+    /**
+     * @brief Builds the 'Focus on Quests' advanced settings tab
+     *
+     * @param {Element} parent: The parent div to add the settings to
+     */
+    static __internal__buildAdvancedSettings(parent)
+    {
+        let tooltip = "Skipping quests can be cost-heavy"
+        let descriptionElem = document.createElement("span");
+        descriptionElem.textContent = "Choose which quest should be performed, or skipped. ⚠️";
+        descriptionElem.classList.add("hasAutomationTooltip");
+        descriptionElem.classList.add("rightMostAutomationTooltip");
+        descriptionElem.classList.add("shortTransitionAutomationTooltip");
+        descriptionElem.style.cursor = "help";
+        descriptionElem.setAttribute("automation-tooltip-text", tooltip);
+        parent.appendChild(descriptionElem);
+
+        let tableContainer = document.createElement("div");
+        tableContainer.classList.add("automationTabSubContent");
+        parent.appendChild(tableContainer);
+
+        let tableElem = document.createElement("table");
+        tableElem.style.width = "100%";
+        tableContainer.appendChild(tableElem);
+
+        for (const quest in QuestHelper.quests)
+        {
+            let rowElem = document.createElement("tr");
+            tableElem.appendChild(rowElem);
+
+            let labelCellElem = document.createElement("td");
+            let label = this.__internal__questLabels[quest];
+            label = label.replaceAll(/<([^>]+)>/g, "<i>&lt;$1&gt;</i>").replace(/.$/, "");
+            labelCellElem.innerHTML = label;
+            rowElem.appendChild(labelCellElem);
+
+            let toggleCellElem = document.createElement("td");
+            rowElem.appendChild(toggleCellElem);
+
+            let storageKey = this.__internal__advancedSettings.QuestEnabled(quest);
+            // Enable the quest by default
+            Automation.Utils.LocalStorage.setDefaultValue(storageKey, "true");
+
+            let toggleButton = Automation.Menu.addLocalStorageBoundToggleButton(storageKey);
+            toggleCellElem.appendChild(toggleButton);
+        }
+    }
 
     /**
      * @brief Starts the quests automation

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -562,6 +562,70 @@ class AutomationMenu
     }
 
     /**
+     * @brief Adds a new tab with the given @p label
+     *
+     * @param {Element} parentElem: The parent element to add the tab to
+     * @param {string} label: The tab's label
+     * @param {string} tabGroupName: The tab's group (needs to be unique for each menu)
+     *
+     * @returns The tab content div, where the user can add the new sub-menu content
+     */
+    static addTabElement(parentElem, label, tabGroupName)
+    {
+        let tabContainer = parentElem.getElementsByClassName("automationTabContainerDiv")[0];
+        let isFirstTab = !tabContainer;
+        let tabLabelContainer;
+        let tabContentContainer;
+
+        // Add the tab and content containers if not already added
+        if (isFirstTab)
+        {
+            tabContainer = document.createElement("div");
+            tabContainer.classList.add("automationTabContainerDiv");
+            parentElem.appendChild(tabContainer);
+
+            tabLabelContainer = document.createElement("div");
+            tabLabelContainer.classList.add("automationTabLabelContainer");
+            tabLabelContainer.style.textAlign = "left";
+            tabContainer.appendChild(tabLabelContainer);
+            tabContentContainer = document.createElement("div");
+            tabContentContainer.classList.add("automationTabContentContainer");
+            tabContainer.appendChild(tabContentContainer);
+        }
+        else
+        {
+            tabLabelContainer = tabContainer.getElementsByClassName("automationTabLabelContainer")[0];
+            tabContentContainer = tabContainer.getElementsByClassName("automationTabContentContainer")[0];
+        }
+
+        let currentTabIndex = tabLabelContainer.getElementsByClassName("automationTabLabel").length + 1;
+        let currentTabId = `automation-tab-${tabGroupName.replaceAll(" ", "-")}-${currentTabIndex}`;
+
+        // Add the input (the magic lies here)
+        let labelInputElem = document.createElement("input");
+        labelInputElem.classList.add("automationTabLabelButton");
+        labelInputElem.type = "radio";
+        labelInputElem.name = tabGroupName;
+        labelInputElem.id = currentTabId;
+        labelInputElem.checked = isFirstTab;
+        tabContainer.insertBefore(labelInputElem, tabLabelContainer);
+
+        // Add the label
+        let labelElem = document.createElement("label");
+        labelElem.classList.add("automationTabLabel");
+        labelElem.textContent = label;
+        labelElem.setAttribute("for", currentTabId);
+        tabLabelContainer.appendChild(labelElem);
+
+        // Add the content
+        let contentContainer = document.createElement("div");
+        contentContainer.classList.add("automationTabContent");
+        tabContentContainer.appendChild(contentContainer);
+
+        return contentContainer;
+    }
+
+    /**
      * @brief Sets the disable state of the given button
      *
      * A disabled button will be greyed-out and its clic action will be inhibited
@@ -672,6 +736,11 @@ class AutomationMenu
 
         const style = document.createElement('style');
         style.textContent = `
+
+            /****************\
+            |*   Tooltips   *|
+            \****************/
+
             .hasAutomationTooltip
             {
                 position: relative;
@@ -736,6 +805,11 @@ class AutomationMenu
             {
                 top: calc(100% + 2px);
             }
+
+            /***************\
+            |*   Setting   *|
+            \***************/
+
             .automationCategorie
             {
                 max-height: 500px;
@@ -879,6 +953,11 @@ class AutomationMenu
                 border-bottom-left-radius: 5px;
                 transition: left 0.3s;
             }
+
+            /*********************\
+            |*   Toogle button   *|
+            \*********************/
+
             .automation-toggle-button
             {
                 box-sizing: border-box;
@@ -962,6 +1041,11 @@ class AutomationMenu
                 right: 2px;
                 top: 6px;
             }
+
+            /*************\
+            |*   Input   *|
+            \*************/
+
             .automation-setting-input
             {
                 display: inline-block;
@@ -1007,6 +1091,11 @@ class AutomationMenu
                 top: -13px;
                 right: 15px;
             }
+
+            /*****************\
+            |*   Checkmark   *|
+            \*****************/
+
             .automation-checkmark-container
             {
                 display: inline-block;
@@ -1048,6 +1137,70 @@ class AutomationMenu
                     border-bottom: 4px solid #78b13f;
                     border-right: 4px solid #78b13f;
                 }
+            }
+
+            /***********\
+            |*   Tab   *|
+            \***********/
+
+            .automationTabLabelButton
+            {
+                display: none; /* hide radio buttons */
+            }
+            .automationTabContent
+            {
+                background-color: #333f55;
+                border-radius: 0 5px 5px 5px;
+
+                /* Hide but preserve width */
+                height: 0px;
+                overflow: hidden;
+                padding: 0px 10px;
+                border: 1px solid transparent;
+                border-bottom-width: 0px;
+                border-top-width: 0px;
+                margin-bottom: 0px;
+                margin-top: 0px;
+            }
+            .automationTabLabel
+            {
+                color: #cccccc;
+                display: inline-block;
+                border: 1px solid #526688;
+                background-color: #273142;
+                padding: 4px 12px;
+                border-radius: 5px 5px 0 0;
+                position: relative;
+                top: 1px;
+                margin: 0px;
+            }
+            .automationTabContentContainer
+            {
+                background-color: #333f55;
+                margin-bottom: 5px;
+            }
+            .automationTabLabelButton:nth-of-type(1):checked ~ .automationTabLabelContainer .automationTabLabel:nth-of-type(1),
+            .automationTabLabelButton:nth-of-type(2):checked ~ .automationTabLabelContainer .automationTabLabel:nth-of-type(2),
+            .automationTabLabelButton:nth-of-type(3):checked ~ .automationTabLabelContainer .automationTabLabel:nth-of-type(3),
+            .automationTabLabelButton:nth-of-type(4):checked ~ .automationTabLabelContainer .automationTabLabel:nth-of-type(4),
+            .automationTabLabelButton:nth-of-type(5):checked ~ .automationTabLabelContainer .automationTabLabel:nth-of-type(5)
+            {
+                border-bottom-color: #333f55;
+                background-color: #333f55;
+                color: #eeeeee;
+            }
+
+            /* The magic (up to 5 tabs) */
+            .automationTabLabelButton:nth-of-type(1):checked ~ .automationTabContentContainer .automationTabContent:nth-of-type(1),
+            .automationTabLabelButton:nth-of-type(2):checked ~ .automationTabContentContainer .automationTabContent:nth-of-type(2),
+            .automationTabLabelButton:nth-of-type(3):checked ~ .automationTabContentContainer .automationTabContent:nth-of-type(3),
+            .automationTabLabelButton:nth-of-type(4):checked ~ .automationTabContentContainer .automationTabContent:nth-of-type(4),
+            .automationTabLabelButton:nth-of-type(5):checked ~ .automationTabContentContainer .automationTabContent:nth-of-type(5)
+            {
+                height: unset;
+                overflow: unset;
+                padding: 10px;
+                border: 1px solid #526688;
             }`;
         document.head.append(style);
     }

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -1177,6 +1177,7 @@ class AutomationMenu
             }
             .automationTabLabel
             {
+                cursor: pointer;
                 color: #cccccc;
                 display: inline-block;
                 border: 1px solid #526688;
@@ -1198,6 +1199,7 @@ class AutomationMenu
             .automationTabLabelButton:nth-of-type(4):checked ~ .automationTabLabelContainer .automationTabLabel:nth-of-type(4),
             .automationTabLabelButton:nth-of-type(5):checked ~ .automationTabLabelContainer .automationTabLabel:nth-of-type(5)
             {
+                cursor: default;
                 border-bottom-color: #333f55;
                 background-color: #333f55;
                 color: #eeeeee;

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -759,9 +759,6 @@ class AutomationMenu
                 background-color: #222222;
                 color: #eeeeee;
                 text-align: center;
-                opacity: 0;
-                z-index: 9;
-                pointer-events: none;
             }
             .hasAutomationTooltip[automation-tooltip-disable-reason]::before
             {
@@ -778,9 +775,14 @@ class AutomationMenu
                 left: calc(100% - 30px);
                 border: 5px solid #222222;
                 border-color: transparent transparent #222222 transparent;
-                opacity: 0;
+            }
+            .hasAutomationTooltip::before, .hasAutomationTooltip::after
+            {
                 z-index: 9;
                 pointer-events: none;
+                transition-duration:.3s;
+                transition-property: opacity;
+                opacity: 0;
             }
             .hasAutomationTooltip:hover::before, .hasAutomationTooltip:hover::after
             {
@@ -789,6 +791,13 @@ class AutomationMenu
                 transition-property: opacity;
                 opacity: 1;
             }
+            .hasAutomationTooltip.shortTransitionAutomationTooltip::before,
+            .hasAutomationTooltip.shortTransitionAutomationTooltip::after,
+            .hasAutomationTooltip.shortTransitionAutomationTooltip:hover::before,
+            .hasAutomationTooltip.shortTransitionAutomationTooltip:hover::after
+            {
+                transition-delay: 0.5s;
+            }
             .hasAutomationTooltip.centeredAutomationTooltip::after
             {
                 left: calc(50%);
@@ -796,6 +805,10 @@ class AutomationMenu
             .hasAutomationTooltip.gotoAutomationTooltip::after
             {
                 left: calc(100% - 85px);
+            }
+            .hasAutomationTooltip.rightMostAutomationTooltip::after
+            {
+                left: calc(100% - 15px);
             }
             .hasAutomationTooltip.toggleAutomationTooltip::after
             {
@@ -901,7 +914,7 @@ class AutomationMenu
             .automation-setting-menu-container[automation-visible]
             {
                 max-width: 650px;
-                max-height: 500px;
+                max-height: 600px;
 
                 transition-property:        max-width, max-height;
                 transition-timing-function:   ease-in,    ease-in;
@@ -1201,6 +1214,15 @@ class AutomationMenu
                 overflow: unset;
                 padding: 10px;
                 border: 1px solid #526688;
+            }
+
+            .automationTabSubContent
+            {
+                margin-top: 4px;
+                border: 1px solid #6c7f9f;
+                background-color: #3e4c64;
+                border-radius: 5px;
+                padding: 4px;
             }`;
         document.head.append(style);
     }


### PR DESCRIPTION
The Focus advanced settings now have a Quests tab.
The list of every possible quest types are listed there, and the user can choose which one to enable and which one to skip.
By default, every quests are enabled.

If the user disabled a quest, it will not be automated, even if it's already in the active list.
If every enabled quests are completed, the list will automatically be refreshed.

Fixes #20
