### PR TITLE
Hatchery: Fixup pokerus spreading feature

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,6 +5,8 @@ Pokeclicker-automation aims at automating some recurring tasks that can be a bit
 This script collection does not aim at cheating.
 It will never perform actions that the game would not allow.
 
-Last known compatible pokeclicker version: 0.9.18
+Last known compatible pokeclicker version: 0.10.0
 
 For more details, please refer to the [wiki](../../wiki)
+
+For Pokeclicker Desktop app support, refer to [this repository](https://github.com/Farigh/pokeclicker-automation-desktop/releases)

--- a/src/lib/Hatchery.js
+++ b/src/lib/Hatchery.js
@@ -696,10 +696,10 @@ class AutomationHatchery
         for (const egg of App.game.breeding.eggList)
         {
             let currentEgg = egg();
-            if ((currentEgg.partyPokemon?.pokerus === GameConstants.Pokerus.Contagious)
-                || (currentEgg.partyPokemon?.pokerus === GameConstants.Pokerus.Resistant))
+            if ((currentEgg.partyPokemon()?.pokerus === GameConstants.Pokerus.Contagious)
+                || (currentEgg.partyPokemon()?.pokerus === GameConstants.Pokerus.Resistant))
             {
-                for (const type of pokemonMap[currentEgg.partyPokemon.id].type)
+                for (const type of pokemonMap[currentEgg.partyPokemon().id].type)
                 {
                     hatchingContagiousTypes.add(type);
                 }


### PR DESCRIPTION
The partyPokemon member access was changed to a KnockoutObservable by pokeclicker/pokeclicker@ad2555ee764c3ec4c8376c7a00adef8fa60c0cec

This resulted in not detecting currently breeding infected pokemons, which prevented corresponding pokemons to be added.

For some reason this was not caught by the tests, the behavior might be browser-dependent.

The member is now accessed properly

Fixes #153