### PR TITLE
Loader: Allow the user to choose to disable feature by default

### DIFF
--- a/Automation-UserScript.js
+++ b/Automation-UserScript.js
@@ -14,6 +14,9 @@
 // if you want to fix a set version of the script
 var releaseLabel = "master";
 
+// Set this to true if you want no feature to be enabled by default
+var disableFeaturesByDefault = false;
+
 var pokeclickerAutomationReleaseUrl = "https://raw.githubusercontent.com/Farigh/pokeclicker-automation/" + releaseLabel + "/";
 
 // Github only serves plain-text so we can't load it as a script object directly
@@ -28,7 +31,7 @@ xmlhttp.onreadystatechange = function()
             script.id = "pokeclicker-automation-component-loader";
             document.head.appendChild(script);
 
-            AutomationComponentLoader.loadFromUrl(pokeclickerAutomationReleaseUrl);
+            AutomationComponentLoader.loadFromUrl(pokeclickerAutomationReleaseUrl, disableFeaturesByDefault);
         }
     }
 

--- a/src/Automation.js
+++ b/src/Automation.js
@@ -28,8 +28,16 @@ class Automation
     /**************************/
     /*    PUBLIC INTERFACE    */
     /**************************/
-    static start()
+
+    /**
+     * @brief Automation entry point
+     *
+     * @param {boolean} disableFeaturesByDefault: True if every features needs to be disabeld by default, False otherwise
+     */
+    static start(disableFeaturesByDefault)
     {
+        this.Menu.DisableFeaturesByDefault = disableFeaturesByDefault;
+
         var timer = setInterval(function()
         {
             // Check if the game window has loaded

--- a/src/ComponentLoader.js
+++ b/src/ComponentLoader.js
@@ -15,11 +15,12 @@ class AutomationComponentLoader
     /**
      * @brief Loads the Automation classes from the given @p baseUrl
      *
-     * @param {string} baseUrl: The base URL to download the lib component files from
+     * @param {string}  baseUrl: The base URL to download the lib component files from
+     * @param {boolean} disableFeaturesByDefault: True if every features needs to be disabeld by default, False otherwise
      *
      * @warning This function should never change its prototype, otherwise it would break the API
      */
-    static loadFromUrl(baseUrl)
+    static loadFromUrl(baseUrl, disableFeaturesByDefault = false)
     {
         this.__baseUrl = baseUrl;
 
@@ -49,7 +50,7 @@ class AutomationComponentLoader
         this.__loadingOrder += 1;
         this.__addScript("src/Automation.js");
 
-        this.__setupAutomationRunner();
+        this.__setupAutomationRunner(disableFeaturesByDefault);
     }
 
     /**
@@ -112,8 +113,10 @@ class AutomationComponentLoader
     /**
      * @brief Sets a loading watcher which prevent loading the automation before the game components are fully up and running.
      *        Once all scripts are properly loaded, it runs the automation.
+     *
+     * @param {boolean} disableFeaturesByDefault: True if every features needs to be disabeld by default, False otherwise
      */
-    static __setupAutomationRunner()
+    static __setupAutomationRunner(disableFeaturesByDefault)
     {
         let currentLoadingOrder = -1;
 
@@ -146,7 +149,7 @@ class AutomationComponentLoader
                 clearInterval(watcher);
 
                 // Start the automation
-                Automation.start();
+                Automation.start(disableFeaturesByDefault);
             }.bind(this), 200); // Check every 200ms
     }
 }

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -137,7 +137,7 @@ class AutomationFocusQuests
 
             let storageKey = this.__internal__advancedSettings.QuestEnabled(quest);
             // Enable the quest by default
-            Automation.Utils.LocalStorage.setDefaultValue(storageKey, "true");
+            Automation.Utils.LocalStorage.setDefaultValue(storageKey, true);
 
             let toggleButton = Automation.Menu.addLocalStorageBoundToggleButton(storageKey);
             toggleCellElem.appendChild(toggleButton);

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -3,6 +3,7 @@
  */
 class AutomationMenu
 {
+    static DisableFeaturesByDefault = false;
     static TooltipSeparator = "\n─────────\n";
 
     static AutomationButtonsDiv;
@@ -125,8 +126,8 @@ class AutomationMenu
         }
         else
         {
-            // Enable automation by default, if not already set in local storage
-            Automation.Utils.LocalStorage.setDefaultValue(id, true);
+            // Set the automation default behaviour, if not already set in local storage
+            Automation.Utils.LocalStorage.setDefaultValue(id, !this.DisableFeaturesByDefault);
         }
 
         let buttonMainContainer = document.createElement("span");


### PR DESCRIPTION
The Loader now exposes a new variable allowing the user to disable every features by default.

If not set the value will be considered to be false (for backward compatibility purpose)

This variable is set to false by default

Fixes #152