### PR TITLE
Farm: Fix harvesting error when no-strategy is set

### DIFF
--- a/src/lib/Farm.js
+++ b/src/lib/Farm.js
@@ -287,19 +287,20 @@ class AutomationFarm
             }
 
             // Harvest berry in any of those cases:
+            //   - No strategy is currently active
             //   - The unlock feature is disabled
             //   - Another feature required force harvesting
             //   - The strategy requires to harvest as soon as possible
             //   - The berry is the target one
             //   - The berry is close to dying (less than 15s)
-            if ((this.__internal__currentStrategy.harvestStrategy !== this.__internal__harvestTimingType.LetTheBerryDie)
-                && ((Automation.Utils.LocalStorage.getValue(this.Settings.FocusOnUnlocks) === "false")
-                    || this.ForcePlantBerriesAsked
-                    || (this.__internal__currentStrategy === null)
-                    || (this.__internal__currentStrategy.harvestStrategy === this.__internal__harvestTimingType.AsSoonAsPossible)
-                    || ((this.__internal__currentStrategy.berryToUnlock !== undefined)
-                        && (this.__internal__currentStrategy.berryToUnlock == plot.berry))
-                    || ((plot.berryData.growthTime[PlotStage.Berry] - plot.age) < 15)))
+            if ((this.__internal__currentStrategy === null)
+                || ((this.__internal__currentStrategy.harvestStrategy !== this.__internal__harvestTimingType.LetTheBerryDie)
+                    && ((Automation.Utils.LocalStorage.getValue(this.Settings.FocusOnUnlocks) === "false")
+                        || this.ForcePlantBerriesAsked
+                        || (this.__internal__currentStrategy.harvestStrategy === this.__internal__harvestTimingType.AsSoonAsPossible)
+                        || ((this.__internal__currentStrategy.berryToUnlock !== undefined)
+                            && (this.__internal__currentStrategy.berryToUnlock == plot.berry))
+                        || ((plot.berryData.growthTime[PlotStage.Berry] - plot.age) < 15))))
             {
                 App.game.farming.harvest(index);
                 this.__internal__harvestCount++;


### PR DESCRIPTION
Bug introduced in c43c7e29a785e19b11065d5700884447d7dc4539

Currently, when farming is set to no strategy, the script fails when checking if it should harvest the berries or not, and farming no longer works at all

Feel free to reorder the conditionals in any other way, they are hard to understaund