### PR TITLE
Notifications: Split Notifications settings and add advanced options

### DIFF
--- a/src/Automation.js
+++ b/src/Automation.js
@@ -11,6 +11,7 @@ class Automation
     static Gym = AutomationGym;
     static Hatchery = AutomationHatchery;
     static Items = AutomationItems;
+    static Notifications = AutomationNotifications;
     static Menu = AutomationMenu;
     static Shop = AutomationShop;
     static Trivia = AutomationTrivia;
@@ -22,8 +23,6 @@ class Automation
         static BuildMenu = 0;
         static Finalize = 1;
     };
-
-    static Settings = { Notifications: "Notifications" };
 
     /**************************/
     /*    PUBLIC INTERFACE    */
@@ -63,6 +62,7 @@ class Automation
                     this.Farm.initialize(initStep);
                     this.Shop.initialize(initStep);
                     this.Items.initialize(initStep);
+                    this.Notifications.initialize(initStep);
 
                     // 'Trivia' panel
                     this.Trivia.initialize(initStep);
@@ -71,12 +71,6 @@ class Automation
                     this.Gym.initialize(initStep);
                     this.Dungeon.initialize(initStep);
                 }
-
-                // Add a notification button to the automation menu
-                this.Menu.addSeparator();
-
-                let notificationTooltip = "Enables automation-related notifications";
-                this.Menu.addAutomationButton("Notifications", this.Settings.Notifications, notificationTooltip);
 
                 // Log automation startup completion
                 console.log(`[${GameConstants.formatDate(new Date())}] %cAutomation started`, "color:#2ecc71;font-weight:900;");

--- a/src/ComponentLoader.js
+++ b/src/ComponentLoader.js
@@ -42,6 +42,7 @@ class AutomationComponentLoader
         this.__addScript("src/lib/Hatchery.js");
         this.__addScript("src/lib/Items.js");
         this.__addScript("src/lib/Menu.js");
+        this.__addScript("src/lib/Notifications.js");
         this.__addScript("src/lib/Shop.js");
         this.__addScript("src/lib/Trivia.js");
         this.__addScript("src/lib/Underground.js");

--- a/src/lib/Dungeon.js
+++ b/src/lib/Dungeon.js
@@ -241,7 +241,7 @@ class AutomationDungeon
             {
                 if (this.__internal__playerActionOccured)
                 {
-                    Automation.Utils.sendWarningNotif("User action detected, turning off the automation", "Dungeon");
+                    Automation.Notifications.sendWarningNotif("User action detected, turning off the automation", "Dungeon");
                 }
 
                 Automation.Menu.forceAutomationState(this.Settings.FeatureEnabled, false);

--- a/src/lib/Farm.js
+++ b/src/lib/Farm.js
@@ -1393,7 +1393,7 @@ class AutomationFarm
         if (this.__internal__currentStrategy === null)
         {
             this.__internal__disableAutoUnlock("No more automated unlock possible");
-            Automation.Utils.sendWarningNotif("No more automated unlock possible.\nDisabling the 'Auto unlock' feature", "Farming");
+            Automation.Notifications.sendWarningNotif("No more automated unlock possible.\nDisabling the 'Auto unlock' feature", "Farming");
             return;
         }
 
@@ -1564,7 +1564,7 @@ class AutomationFarm
     {
         if (this.__internal__plantedBerryCount > 0)
         {
-            Automation.Utils.sendNotif("Harvested " + this.__internal__harvestCount.toString() + " berries<br>" + details, "Farming");
+            Automation.Notifications.sendNotif("Harvested " + this.__internal__harvestCount.toString() + " berries<br>" + details, "Farming");
         }
     }
 

--- a/src/lib/Focus.js
+++ b/src/lib/Focus.js
@@ -63,7 +63,7 @@ class AutomationFocus
         if (Automation.Utils.isInInstanceState())
         {
             Automation.Menu.forceAutomationState(this.Settings.FeatureEnabled, false);
-            Automation.Utils.sendWarningNotif("Can't run while in an instance\nTurning the feature off", "Focus");
+            Automation.Notifications.sendWarningNotif("Can't run while in an instance\nTurning the feature off", "Focus");
             return false;
         }
 

--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -108,7 +108,7 @@ class AutomationFocusAchievements
             {
                 // No more achievements, stop the feature
                 Automation.Menu.forceAutomationState(Automation.Focus.Settings.FeatureEnabled, false);
-                Automation.Utils.sendWarningNotif("No more achievement to automate.\nTurning the feature off", "Focus");
+                Automation.Notifications.sendWarningNotif("No more achievement to automate.\nTurning the feature off", "Focus");
 
                 return;
             }

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -319,7 +319,7 @@ class AutomationFocusQuests
 
         App.game.quests.refreshQuests();
 
-        Automation.Utils.sendNotif(`Skipped disabled quests for ${refreshCost}`, "Focus > Quests");
+        Automation.Notifications.sendNotif(`Skipped disabled quests for ${refreshCost}`, "Focus", "Quests");
     }
 
     /**

--- a/src/lib/Hatchery.js
+++ b/src/lib/Hatchery.js
@@ -496,7 +496,7 @@ class AutomationHatchery
             while ((i < pokemonToBreed.length) && App.game.breeding.hasFreeEggSlot())
             {
                 App.game.breeding.addPokemonToHatchery(pokemonToBreed[i]);
-                Automation.Utils.sendNotif("Added " + pokemonToBreed[i].name + " to the Hatchery!", "Hatchery");
+                Automation.Notifications.sendNotif("Added " + pokemonToBreed[i].name + " to the Hatchery!", "Hatchery");
                 i++;
             }
         }
@@ -531,7 +531,7 @@ class AutomationHatchery
                                                     || (App.game.breeding.eggList[index]().pokemonType2 === pokemonType))))
             {
                 eggType.use();
-                Automation.Utils.sendNotif("Added a " + eggType.displayName + " to the Hatchery!", "Hatchery");
+                Automation.Notifications.sendNotif("Added a " + eggType.displayName + " to the Hatchery!", "Hatchery");
             }
         }
     }
@@ -570,7 +570,7 @@ class AutomationHatchery
             {
                 // Hatching a fossil is performed by selling it
                 Underground.sellMineItem(fossil.id);
-                Automation.Utils.sendNotif("Added a " + fossil.name + " to the Hatchery!", "Hatchery");
+                Automation.Notifications.sendNotif("Added a " + fossil.name + " to the Hatchery!", "Hatchery");
             }
 
             i++;

--- a/src/lib/Notifications.js
+++ b/src/lib/Notifications.js
@@ -1,0 +1,147 @@
+/**
+ * @class AutomationNotifications provides notification settings
+ */
+class AutomationNotifications
+{
+    static Settings = {
+                          FeatureEnabled: "Notifications-Enabled",
+
+                          // Notification types
+                          Farming: "Notifications-Farming",
+                          Hatchery: "Notifications-Hatchery",
+                          Shop: "Notifications-Shop",
+                          Mining: "Notifications-Mining",
+                          Focus: "Notifications-Focus",
+                      };
+
+    /**
+     * @brief Builds the menu
+     *
+     * @param initStep: The current automation init step
+     */
+    static initialize(initStep)
+    {
+        // Only consider the BuildMenu init step
+        if (initStep == Automation.InitSteps.BuildMenu)
+        {
+            this.__internal__buildMenu();
+        }
+    }
+
+    /**
+     * @brief Adds a pokeclicker notification using the given @p message
+     *        The notification is a blue one, without sound and with the "Automation" title
+     *
+     * @param {string} message: The notification message
+     * @param {string} module: [optional] The automation module name
+     * @param {string} subModule: [optional] The automation sub-module name
+     */
+    static sendNotif(message, module = null, subModule = null)
+    {
+        if ((Automation.Utils.LocalStorage.getValue(this.Settings.FeatureEnabled) == "true")
+            && (Automation.Utils.LocalStorage.getValue(this.Settings[module]) == "true"))
+        {
+            this.__internal__sendNotification(message, module, subModule, NotificationConstants.NotificationOption.primary, 3000);
+        }
+    }
+
+    /**
+     * @brief Adds a pokeclicker warning notification using the given @p message
+     *        The notification is a yellow one, without sound and with the "Automation" title
+     *
+     * @param {string} message: The warning notification message
+     * @param {string} module: [optional] The automation module name
+     * @param {string} subModule: [optional] The automation sub-module name
+     */
+    static sendWarningNotif(message, module = null, subModule = null)
+    {
+        // Don't filter warnings, even if the module notifications were disabled
+        if (Automation.Utils.LocalStorage.getValue(this.Settings.FeatureEnabled) == "true")
+        {
+            this.__internal__sendNotification(message, module, subModule, NotificationConstants.NotificationOption.warning, 10000);
+        }
+    }
+
+    /*********************************************************************\
+    |***    Internal members, should never be used by other classes    ***|
+    \*********************************************************************/
+
+    /**
+     * @brief Builds the menu
+     */
+    static __internal__buildMenu()
+    {
+        // Add the related button to the automation menu
+        let notificationContainer = document.createElement("div");
+        Automation.Menu.AutomationButtonsDiv.appendChild(notificationContainer);
+
+        Automation.Menu.addSeparator(notificationContainer);
+
+        let notificationTooltip = "Enables automation-related notifications";
+        Automation.Menu.addAutomationButton("Notifications", this.Settings.FeatureEnabled, notificationTooltip, notificationContainer);
+
+        // Build the advanced settings
+        this.__internal__buildAdvancedSettings(notificationContainer);
+    }
+
+    /**
+     * @brief Adds the Underground advanced settings panel
+     *
+     * @param parent: The div container to insert the settings to
+     */
+    static __internal__buildAdvancedSettings(parent)
+    {
+        // Build the advanced settings panel
+        let notificationsSettingPanel = Automation.Menu.addSettingPanel(parent);
+        notificationsSettingPanel.style.textAlign = "right";
+
+        let titleDiv = Automation.Menu.createTitleElement("Notifications advanced settings");
+        titleDiv.style.marginBottom = "10px";
+        notificationsSettingPanel.appendChild(titleDiv);
+
+        let focusQuestsLabel = 'Show Focus feature notifications';
+        Automation.Menu.addLabeledAdvancedSettingsToggleButton(focusQuestsLabel, this.Settings.Focus, "", notificationsSettingPanel);
+
+        let hatcheryLabel = 'Show Hatchery feature notifications';
+        Automation.Menu.addLabeledAdvancedSettingsToggleButton(hatcheryLabel, this.Settings.Hatchery, "", notificationsSettingPanel);
+
+        let miningLabel = 'Show Mining feature notifications';
+        Automation.Menu.addLabeledAdvancedSettingsToggleButton(miningLabel, this.Settings.Mining, "", notificationsSettingPanel);
+
+        let farmingLabel = 'Show Farming feature notifications';
+        Automation.Menu.addLabeledAdvancedSettingsToggleButton(farmingLabel, this.Settings.Farming, "", notificationsSettingPanel);
+
+        let shopLabel = 'Show Auto Shop feature notifications';
+        Automation.Menu.addLabeledAdvancedSettingsToggleButton(shopLabel, this.Settings.Shop, "", notificationsSettingPanel);
+    }
+
+    /**
+     * @brief Builds and sends a PokéClicker notification
+     *
+     * @param {string} message: The notification message
+     * @param {string} module: The automation module name
+     * @param {string} subModule: The automation sub-module name
+     * @param          type: The PokéClicker notification type
+     * @param {number} timeout: The notification display timeout
+     */
+    static __internal__sendNotification(message, module, subModule, type, timeout)
+    {
+        let titleStr = "Automation";
+        if (module !== null)
+        {
+            titleStr += " > " + module;
+
+            if (subModule !== null)
+            {
+                titleStr += " > " + subModule;
+            }
+        }
+
+        Notifier.notify({
+                            title: titleStr,
+                            message: message,
+                            type: type,
+                            timeout: timeout
+                        });
+    }
+}

--- a/src/lib/Shop.js
+++ b/src/lib/Shop.js
@@ -529,7 +529,7 @@ class AutomationShop
         if (totalSpent > 0)
         {
             let pokedollarsImage = '<img src="assets/images/currency/money.svg" height="25px">';
-            Automation.Utils.sendNotif(`Bought some items for a total of ${totalSpent.toLocaleString('en-US')} ${pokedollarsImage}`, "Shop");
+            Automation.Notifications.sendNotif(`Bought some items for a total of ${totalSpent.toLocaleString('en-US')} ${pokedollarsImage}`, "Shop");
         }
     }
 

--- a/src/lib/Underground.js
+++ b/src/lib/Underground.js
@@ -230,9 +230,9 @@ class AutomationUnderground
             {
                 if (this.__internal__actionCount > 0)
                 {
-                    Automation.Utils.sendNotif(`Performed mining actions ${this.__internal__actionCount.toString()} times,`
-                                             + ` energy left: ${Math.floor(App.game.underground.energy).toString()}!`,
-                                               "Mining");
+                    Automation.Notifications.sendNotif(`Performed mining actions ${this.__internal__actionCount.toString()} times,`
+                                                     + ` energy left: ${Math.floor(App.game.underground.energy).toString()}!`,
+                                                       "Mining");
                 }
                 clearInterval(this.__internal__innerMiningLoop);
                 this.__internal__innerMiningLoop = null;

--- a/src/lib/Utils.js
+++ b/src/lib/Utils.js
@@ -23,58 +23,6 @@ class AutomationUtils
     }
 
     /**
-     * @brief Adds a pokeclicker notification using the given @p message
-     *        The notification is a blue one, without sound and with the "Automation" title
-     *
-     * @param {string} message: The notification message
-     * @param {string} module: [optional] The automation module name
-     */
-    static sendNotif(message, module = null)
-    {
-        if (Automation.Utils.LocalStorage.getValue(Automation.Settings.Notifications) == "true")
-        {
-            let titleStr = "Automation";
-            if (module !== null)
-            {
-                titleStr += " > " + module;
-            }
-
-            Notifier.notify({
-                                title: titleStr,
-                                message: message,
-                                type: NotificationConstants.NotificationOption.primary,
-                                timeout: 3000,
-                            });
-        }
-    }
-
-    /**
-     * @brief Adds a pokeclicker warning notification using the given @p message
-     *        The notification is a yellow one, without sound and with the "Automation" title
-     *
-     * @param {string} message: The warning notification message
-     * @param {string} module: [optional] The automation module name
-     */
-    static sendWarningNotif(message, module = null)
-    {
-        if (Automation.Utils.LocalStorage.getValue(Automation.Settings.Notifications) == "true")
-        {
-            let titleStr = "Automation";
-            if (module !== null)
-            {
-                titleStr += " > " + module;
-            }
-
-            Notifier.notify({
-                                title: titleStr,
-                                message: message,
-                                type: NotificationConstants.NotificationOption.warning,
-                                timeout: 10000,
-                            });
-        }
-    }
-
-    /**
      * @brief Checks if the player is in an instance states
      *
      * Is considered an instance any state in which the player can't acces the map anymore.

--- a/tst/tests/Farm/UnlockStrategies.test.in.js
+++ b/tst/tests/Farm/UnlockStrategies.test.in.js
@@ -9,6 +9,7 @@ import "tst/stubs/Automation/Menu.stub.js";
 
 // Import current lib elements
 import "tst/imports/AutomationUtils.import.js";
+import "src/lib/Notifications.js";
 import "src/lib/Farm.js";
 
 import "tst/utils/PokemonLoader.utils.js";
@@ -27,6 +28,7 @@ class Automation
 {
     static Farm = AutomationFarm;
     static Menu = AutomationMenu;
+    static Notifications = AutomationNotifications;
     static Utils = AutomationUtils;
 
     static Settings = { Notifications: "Notifications" };

--- a/tst/tests/Hachery/AutoHatchery.test.in.js
+++ b/tst/tests/Hachery/AutoHatchery.test.in.js
@@ -10,6 +10,7 @@ import "tst/stubs/Automation/Menu.stub.js";
 // Import current lib elements
 import "tst/imports/AutomationUtils.import.js";
 import "src/lib/Hatchery.js";
+import "src/lib/Notifications.js";
 
 import "tst/utils/PokemonLoader.utils.js";
 import "tst/utils/hatchery.utils.js";
@@ -23,6 +24,7 @@ class Automation
 {
     static Hatchery = AutomationHatchery;
     static Menu = AutomationMenu;
+    static Notifications = AutomationNotifications;
     static Utils = AutomationUtils;
 
     static Settings = { Notifications: "Notifications" };


### PR DESCRIPTION
Allows having the notifications enabled but only for some modules.

By default, any notification whose module is not recognized will be shown.