### PR TITLE
Mine: Automatically trigger the trade when changing options

### DIFF
--- a/src/lib/Underground.js
+++ b/src/lib/Underground.js
@@ -503,7 +503,7 @@ class AutomationUnderground
             //   - The source is locked
             //   - The destination is not diamond-valued
             //   - The source is not diamond-valued and the player did not allow such trade
-            if (item1.sellLocked()
+            if ((item1.sellLocked && item1.sellLocked())
                 || (deal.item2.valueType != UndergroundItemValueType.Diamond)
                 || (!shouldTradeAll && (deal.item1.valueType != UndergroundItemValueType.Diamond)))
             {

--- a/src/lib/Underground.js
+++ b/src/lib/Underground.js
@@ -500,10 +500,12 @@ class AutomationUnderground
             const item1 = player.mineInventory()[item1Index];
 
             // Do not trade if either:
+            //   - The player does not own the source item
             //   - The source is locked
             //   - The destination is not diamond-valued
             //   - The source is not diamond-valued and the player did not allow such trade
-            if ((item1.sellLocked && item1.sellLocked())
+            if (!item1
+                || (item1.sellLocked && item1.sellLocked())
                 || (deal.item2.valueType != UndergroundItemValueType.Diamond)
                 || (!shouldTradeAll && (deal.item1.valueType != UndergroundItemValueType.Diamond)))
             {
@@ -536,8 +538,8 @@ class AutomationUnderground
         if (dealsDone > 0)
         {
             let diamondImage = '<img src="assets/images/currency/diamond.svg" height="25px">';
-            Automation.Utils.sendNotif(`Performed ${dealsDone} underground daily deals for a total profit of ${totalProfit} ${diamondImage}`,
-                                       "Mining");
+            Automation.Notifications.sendNotif(`Performed ${dealsDone} underground daily deals for a total profit of ${totalProfit} ${diamondImage}`,
+                                               "Mining");
         }
     }
 }

--- a/src/lib/Underground.js
+++ b/src/lib/Underground.js
@@ -66,6 +66,8 @@ class AutomationUnderground
             if (this.__internal__autoSellingLoop === null)
             {
                 this.__internal__autoSellingLoop = setInterval(this.__internal__tradeDiamondsLoop.bind(this), 5 * 60 * 1000); // Runs every 5 minutes
+                // Call it manually once to avoid waiting 5 minutes
+                this.__internal__tradeDiamondsLoop();
             }
         }
         else
@@ -168,8 +170,13 @@ class AutomationUnderground
                                  + Automation.Menu.TooltipSeparator
                                  + "Sell-locked items, in the Treasures tab, will never be sold,\n"
                                  + "but might be aquired through tradings.";
-        Automation.Menu.addLabeledAdvancedSettingsToggleButton(
+        const tradeDiamondsButton = Automation.Menu.addLabeledAdvancedSettingsToggleButton(
             tradeDiamondsLabel, this.Settings.TradeDiamonds, tradeDiamondsTooltip, miningSettingPanel);
+        tradeDiamondsButton.addEventListener("click",
+                                             function()
+                                             {
+                                                 this.__internal__tradeDiamondsIfMineEnabled(this.Settings.TradeDiamonds);
+                                             }.bind(this), false);
 
         /*******************************\
         |* Trade anything for diamonds *|
@@ -178,10 +185,15 @@ class AutomationUnderground
         // Disable this setting by default
         Automation.Utils.LocalStorage.setDefaultValue(this.Settings.TradeAnyToDiamonds, false);
 
-        let tradeAnythingDiamondsLabel = 'Enable trading items that do not have any diamond value';
-        let tradeAnythingDiamondsTooltip = "Enabling this will trade non-diamond-valued items for diamond-valued ones.";
-        Automation.Menu.addLabeledAdvancedSettingsToggleButton(
-            tradeAnythingDiamondsLabel, this.Settings.TradeAnyToDiamonds, tradeAnythingDiamondsTooltip, miningSettingPanel);
+        let tradeAnyToDiamondsLabel = 'Enable trading items that do not have any diamond value';
+        let tradeAnyToDiamondsTooltip = "Enabling this will trade non-diamond-valued items for diamond-valued ones.";
+        const tradeAnyToDiamondsButton = Automation.Menu.addLabeledAdvancedSettingsToggleButton(
+            tradeAnyToDiamondsLabel, this.Settings.TradeAnyToDiamonds, tradeAnyToDiamondsTooltip, miningSettingPanel);
+        tradeAnyToDiamondsButton.addEventListener("click",
+                                                  function()
+                                                  {
+                                                      this.__internal__tradeDiamondsIfMineEnabled(this.Settings.TradeAnyToDiamonds);
+                                                  }.bind(this), false);
     }
 
     /**
@@ -477,6 +489,22 @@ class AutomationUnderground
         }
 
         return itemsState;
+    }
+
+    /**
+     * @brief Performs a daily deals run if the feature is enabled
+     *        This is used as an advanced settings toggle buttons callback
+     *
+     * @param {string} eventSource: The setting button that was clicked
+     */
+    static __internal__tradeDiamondsIfMineEnabled(eventSource)
+    {
+        // Only trigger the trade if the feature is enabled, and the setting was turned on
+        if ((Automation.Utils.LocalStorage.getValue(this.Settings.FeatureEnabled) === "true")
+            && (Automation.Utils.LocalStorage.getValue(eventSource) === "true"))
+        {
+            this.__internal__tradeDiamondsLoop();
+        }
     }
 
     /**


### PR DESCRIPTION
As the timer is for 5 minutes, it may look to the users that the auto-trade option is not working.

Manually triggering it when the options are changed is an easy way to fix this usability problem