### PR TITLE
Fix for Elite4 Quests starting on wrong member

### DIFF
--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -541,22 +541,20 @@ class AutomationFocusQuests
             townToGoTo = GymList[townToGoTo].parent.name;
         }
 
-        // Move to the associated gym if needed
+        // Move to the associated gym town if needed
         if (!Automation.Utils.Route.isPlayerInTown(townToGoTo))
         {
             Automation.Utils.Route.moveToTown(townToGoTo);
         }
+        // Select the right gym to fight
+        else if (document.getElementById("selectedAutomationGym").value != quest.gymTown)
+        {
+            document.getElementById("selectedAutomationGym").value = quest.gymTown;
+        }
+        // Enable gym auto-fight feature if not already done
         else if (Automation.Utils.LocalStorage.getValue(Automation.Gym.Settings.FeatureEnabled) === "false")
         {
             Automation.Menu.forceAutomationState(Automation.Gym.Settings.FeatureEnabled, true);
-        }
-        else
-        {
-            // Select the right gym to fight
-            if (document.getElementById("selectedAutomationGym").value != quest.gymTown)
-            {
-                document.getElementById("selectedAutomationGym").value = quest.gymTown;
-            }
         }
     }
 


### PR DESCRIPTION
If Quest focus gains a quest targeting a later elite 4 member (or champion) it would move the player to the league and activate auto fight before selecting the correct member. This would result in these quests always doing a run through the first elite 4 member before switching to the correct member. Fixed by first selecting the right member before activating the autogym battle setting.