### PR TITLE
Improve Mining efficiency: Let Hammer consider revealed tiles

### DIFF
--- a/src/lib/Underground.js
+++ b/src/lib/Underground.js
@@ -360,9 +360,6 @@ class AutomationUnderground
             }
         }
 
-        // Only consider unrevealed tiles
-        nextTilesToMine = nextTilesToMine.filter((tile) => !tile.revealed);
-
         if (nextTilesToMine.length == 0)
         {
             return true;
@@ -378,8 +375,11 @@ class AutomationUnderground
         }
         else
         {
+            // Only consider unrevealed tiles
+            nextTilesToMine = nextTilesToMine.filter((tile) => !tile.revealed);
+
             result = (App.game.underground.energy >= Underground.CHISEL_ENERGY);
-            Mine.chisel(useToolX, useToolY);
+            Mine.chisel(nextTilesToMine[0].x, nextTilesToMine[0].y);
         }
 
         if (result)
@@ -412,12 +412,12 @@ class AutomationUnderground
             let reachableTilesAmount = 0;
             for (const other of nextTilesToMine)
             {
-                // Consider tiles in th range of the hammer only
+                // Consider tiles in the range of the hammer only
                 if (!other.revealed
-                    && other.x <= (tile.x + 1)
-                    && other.x >= (tile.x - 1)
-                    && other.y <= (tile.y + 1)
-                    && other.y >= (tile.y - 1))
+                    && (other.x <= (tile.x + 1))
+                    && (other.x >= (tile.x - 1))
+                    && (other.y <= (tile.y + 1))
+                    && (other.y >= (tile.y - 1)))
                 {
                     // If the tile is covered by an odd amount of layers, the hammer hit is equivalent to a chisel hit,
                     // otherwise the hammer hit is half as efficient


### PR DESCRIPTION
To improve general mining efficiency hammer logic should be allowed to hit already completely revealed tiles. An easy example, following tile setup:
111
101
111

With the current logic this would use the the equivalent of 2 hammer actions worth of energy, since currently the hammer cannot hit the already revealed central tile. With this change that tile would also be considered and only 1 hammer action would be necessary to completely reveal all tiles.