### PR TITLE
BattleCafe: Add battle café panel

### DIFF
--- a/src/Automation.js
+++ b/src/Automation.js
@@ -3,7 +3,8 @@
  */
 class Automation
 {
-    // Aliases on the other classes so every calls in the code can use the `Automation.Alias` form
+    // Aliases on the other classes so every calls in the code can use the `Automation.<Alias>` form
+    static BattleCafe = AutomationBattleCafe;
     static Click = AutomationClick;
     static Dungeon = AutomationDungeon;
     static Farm = AutomationFarm;
@@ -53,6 +54,12 @@ class Automation
 
                     this.Utils.initialize(initStep);
                     this.Menu.initialize(initStep);
+
+                    // Battle Café panel (Always put it first)
+                    this.BattleCafe.initialize(initStep);
+
+                    // Then add the main menu
+                    this.Menu.addMainAutomationPanel(initStep);
 
                     // 'Automation' panel
                     this.Click.initialize(initStep);

--- a/src/ComponentLoader.js
+++ b/src/ComponentLoader.js
@@ -34,6 +34,7 @@ class AutomationComponentLoader
         this.__addScript("src/lib/Utils/Route.js");
 
         this.__loadingOrder += 1;
+        this.__addScript("src/lib/BattleCafe.js");
         this.__addScript("src/lib/Click.js");
         this.__addScript("src/lib/Dungeon.js");
         this.__addScript("src/lib/Farm.js");

--- a/src/lib/BattleCafe.js
+++ b/src/lib/BattleCafe.js
@@ -1,0 +1,229 @@
+/**
+ * @class The AutomationBattleCafe regroups the BattleCafe panel elements
+ */
+class AutomationBattleCafe
+{
+    /**
+     * @brief Initializes the Battle Café components
+     *
+     * @param initStep: The current automation init step
+     */
+    static initialize(initStep)
+    {
+        if (initStep == Automation.InitSteps.BuildMenu)
+        {
+            this.__internal__buildMenu();
+        }
+        else if (initStep == Automation.InitSteps.Finalize)
+        {
+            // Set the div visibility and content watcher
+            setInterval(this.__internal__updateDivVisibilityAndContent.bind(this), 1000); // Refresh every 1s
+        }
+    }
+
+    /*********************************************************************\
+    |***    Internal members, should never be used by other classes    ***|
+    \*********************************************************************/
+
+    static __internal__battleCafePanel = null;
+    static __internal__battleCafeSweetContainers = [];
+    static __internal__currentlyVisibleSweet = null;
+    static __internal__caughtPokemonIndicators = new Map();
+
+    /**
+     * @brief Builds the 'Battle Café' menu panel
+     */
+    static __internal__buildMenu()
+    {
+        let battleCafeTitle = '☕ Battle Café ☕';
+        const battleCafeContainer = Automation.Menu.addCategory("automationBattleCafe", battleCafeTitle);
+        this.__internal__battleCafePanel = battleCafeContainer.parentElement;
+
+        // Always put it on top, so the user can interact with it while the game displays the modal overlay
+        this.__internal__battleCafePanel.style.position = "relative";
+        this.__internal__battleCafePanel.style.zIndex = "9999";
+
+        // Hide the battle café menu by default
+        this.__internal__battleCafePanel.hidden = true;
+
+        this.__internal__addInfo(null, -1, battleCafeContainer);
+
+        for (const sweetIndex in BattleCafeController.evolutions)
+        {
+            const sweetData = BattleCafeController.evolutions[sweetIndex];
+
+            const currentSweetContainer = document.createElement("div");
+            currentSweetContainer.hidden = true;
+            currentSweetContainer.style.textAlign = "left";
+            currentSweetContainer.style.marginLeft = "5px";
+            this.__internal__battleCafeSweetContainers.push(currentSweetContainer);
+
+            currentSweetContainer.appendChild(document.createElement("br"));
+            currentSweetContainer.appendChild(document.createTextNode("Day (5:00 → 19:00)"));
+            currentSweetContainer.appendChild(document.createElement("br"));
+            this.__internal__addInfo(sweetData, GameConstants.AlcremieSpins.dayClockwiseBelow5, currentSweetContainer);
+            this.__internal__addInfo(sweetData, GameConstants.AlcremieSpins.dayClockwiseAbove5, currentSweetContainer);
+            this.__internal__addInfo(sweetData, GameConstants.AlcremieSpins.dayCounterclockwiseBelow5, currentSweetContainer);
+            this.__internal__addInfo(sweetData, GameConstants.AlcremieSpins.dayCounterclockwiseAbove5, currentSweetContainer);
+
+            currentSweetContainer.appendChild(document.createElement("br"));
+            currentSweetContainer.appendChild(document.createTextNode("Dusk (19:00 → 20:00)"));
+            currentSweetContainer.appendChild(document.createElement("br"));
+            this.__internal__addInfo(sweetData, GameConstants.AlcremieSpins.at7Above10, currentSweetContainer);
+
+            currentSweetContainer.appendChild(document.createElement("br"));
+            currentSweetContainer.appendChild(document.createTextNode("Night (19:00 → 5:00)"));
+            currentSweetContainer.appendChild(document.createElement("br"));
+            this.__internal__addInfo(sweetData, GameConstants.AlcremieSpins.nightClockwiseBelow5, currentSweetContainer);
+            this.__internal__addInfo(sweetData, GameConstants.AlcremieSpins.nightClockwiseAbove5, currentSweetContainer);
+            this.__internal__addInfo(sweetData, GameConstants.AlcremieSpins.nightCounterclockwiseBelow5, currentSweetContainer);
+            this.__internal__addInfo(sweetData, GameConstants.AlcremieSpins.nightCounterclockwiseAbove5, currentSweetContainer);
+            battleCafeContainer.appendChild(currentSweetContainer);
+        }
+    }
+
+    /**
+     * @brief Adds the given @p spinType info to the panel
+     *
+     * @param sweetData: The battle café sweet data
+     * @param spinType: The spin type
+     * @param {Element} parent: The parent div
+     */
+    static __internal__addInfo(sweetData, spinType, parent)
+    {
+        let container = document.createElement("div");
+        parent.appendChild(container);
+
+        let summary = "";
+        let tooltip = "By spining "
+        let pokemonName = "Milcery (Cheesy)";
+        if (spinType == -1)
+        {
+            container.style.textAlign = "left";
+            summary = "Random"
+            container.style.marginLeft = "5px";
+            tooltip += "any sweet you can randomly get "
+        }
+        else
+        {
+            // Spin count info
+            container.style.marginLeft = "10px";
+            if (spinType == GameConstants.AlcremieSpins.at7Above10)
+            {
+                tooltip += "11 times or more "
+                summary += "11+";
+            }
+            else if ((spinType == GameConstants.AlcremieSpins.dayClockwiseAbove5)
+                     || (spinType == GameConstants.AlcremieSpins.nightClockwiseAbove5)
+                     || (spinType == GameConstants.AlcremieSpins.dayCounterclockwiseAbove5)
+                     || (spinType == GameConstants.AlcremieSpins.nightCounterclockwiseAbove5))
+            {
+                tooltip += "5 times or more "
+                summary += "5+";
+            }
+            else
+            {
+                tooltip += "from 1 to 4 times "
+                summary += "1→4";
+            }
+
+            // Spin direction info
+            if ((spinType == GameConstants.AlcremieSpins.dayClockwiseBelow5)
+                || (spinType == GameConstants.AlcremieSpins.dayClockwiseAbove5)
+                || (spinType == GameConstants.AlcremieSpins.nightClockwiseBelow5)
+                || (spinType == GameConstants.AlcremieSpins.nightClockwiseAbove5))
+            {
+                // Clockwise symbole
+                summary += " ↻";
+                tooltip += "clockwise"
+            }
+            else
+            {
+                // Counter clockwise symbole
+                summary += " ↺";
+                tooltip += "counter-clockwise"
+            }
+            pokemonName = sweetData[spinType].name;
+            tooltip += "\nyou can get "
+        }
+
+        let pokemonId = pokemonMap[pokemonName].id;
+        summary += ` : #${pokemonId}`;
+        tooltip += pokemonName;
+
+        // Set the tooltip
+        container.classList.add("hasAutomationTooltip");
+        container.classList.add("centeredAutomationTooltip");
+        container.classList.add("shortTransitionAutomationTooltip");
+        container.style.cursor = "help";
+        container.setAttribute("automation-tooltip-text", tooltip);
+
+        container.appendChild(document.createTextNode(summary));
+
+        // Add the caught status placeholder
+        const caughtIndicatorElem = document.createElement("span");
+        container.appendChild(caughtIndicatorElem);
+        this.__internal__caughtPokemonIndicators.set(
+            pokemonName, { container: caughtIndicatorElem, pokemonId: pokemonId, currentStatus: null });
+    }
+
+    /**
+     * @brief Toggle the 'Battle Café' category visibility based on the game state
+     *        It will refresh the selected sweet as well
+     *
+     * The category is only visible the player entered the Battle Café
+     */
+    static __internal__updateDivVisibilityAndContent()
+    {
+        const battleCafeModal = document.getElementById("battleCafeModal");
+        if (battleCafeModal.classList.contains("show"))
+        {
+            this.__internal__battleCafePanel.hidden = false;
+
+            const selectedSweet = BattleCafeController.selectedSweet();
+
+            // Refresh caught statuses
+            this.__internal__refreshCaughtStatus("Milcery (Cheesy)");
+            const currentRewards = BattleCafeController.evolutions[selectedSweet];
+            for (const rewardIndex in currentRewards)
+            {
+                this.__internal__refreshCaughtStatus(currentRewards[rewardIndex].name);
+            }
+
+            if (selectedSweet == this.__internal__currentlyVisibleSweet)
+            {
+                // Nothing changed
+                return;
+            }
+
+            if (this.__internal__currentlyVisibleSweet != null)
+            {
+                this.__internal__battleCafeSweetContainers[this.__internal__currentlyVisibleSweet].hidden = true;
+            }
+
+            this.__internal__battleCafeSweetContainers[selectedSweet].hidden = false;
+            this.__internal__currentlyVisibleSweet = selectedSweet;
+        }
+        else
+        {
+            this.__internal__battleCafePanel.hidden = true;
+        }
+    }
+
+    /**
+     * @brief Refreshes the caught status of the given @p pokemonName, if it changed
+     *
+     * @param {string} pokemonName: The name of the pokemon to refresh
+     */
+    static __internal__refreshCaughtStatus(pokemonName)
+    {
+        const internalData = this.__internal__caughtPokemonIndicators.get(pokemonName);
+        const caughtStatus = Automation.Utils.getPokemonCaughtStatus(internalData.pokemonId);
+
+        if (caughtStatus != internalData.currentStatus)
+        {
+            internalData.container.innerHTML = Automation.Menu.getCaughtStatusImage(caughtStatus);
+            internalData.currentStatus = caughtStatus;
+        }
+    }
+}

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -40,6 +40,15 @@ class AutomationMenu
         node.style.fontWeight = "400";
         node.id = "automationContainer";
         document.body.appendChild(node);
+    }
+
+    /**
+     * @brief Adds the Automation panel
+     */
+    static addMainAutomationPanel(initStep)
+    {
+        // Only consider the BuildMenu init step
+        if (initStep != Automation.InitSteps.BuildMenu) return;
 
         let boltImage = '<img src="assets/images/badges/Bolt.png" height="20px">';
         let automationTitle = `${boltImage}Automation${boltImage}`;
@@ -651,9 +660,28 @@ class AutomationMenu
         }
     }
 
+    /**
+     * @brief Gets the caught status image corresponding to the given @p caughtStatus
+     *
+     * @param caughtStatus: The pokeclicker's CaughtStatus
+     *
+     * @returns The corresponding image
+     */
+    static getCaughtStatusImage(caughtStatus)
+    {
+        return '<img class="pokeball-smallest" style="position: relative; top: 1px;"'
+             + ` src="assets/images/pokeball/${this.__internal__caughtStatusImageSwitch[caughtStatus]}.svg">`;
+    }
+
     /*********************************************************************\
     |***    Internal members, should never be used by other classes    ***|
     \*********************************************************************/
+
+    static __internal__caughtStatusImageSwitch = {
+                                                     [CaughtStatus.NotCaught]: "None",
+                                                     [CaughtStatus.Caught]: "Pokeball",
+                                                     [CaughtStatus.CaughtShiny]: "Pokeball-shiny"
+                                                 };
 
     /**
      * @brief Disables the given toggle @p button and updates its theme accordingly

--- a/src/lib/Trivia.js
+++ b/src/lib/Trivia.js
@@ -1,5 +1,5 @@
 /**
- * @class The AutomationMenu regroups the Trivia panel elements
+ * @class The AutomationTrivia regroups the Trivia panel elements
  */
 class AutomationTrivia
 {
@@ -48,7 +48,7 @@ class AutomationTrivia
     static __internal__buildMenu()
     {
         // Hide the gym and dungeon fight menus by default and disable auto fight
-        let triviaTitle = '<img src="assets/images/oakitems/Treasure_Scanner.png" height="20px" style="position:relative; bottom: 3px;">'
+        let triviaTitle = '<img src="assets/images/oakitems/Treasure_Scanner.png" style="position:relative; bottom: 3px;" height="20px">'
                         +     '&nbsp;Trivia&nbsp;'
                         + '<img src="assets/images/oakitems/Treasure_Scanner.png" style="position:relative; bottom: 3px;" height="20px">';
         let triviaDiv = Automation.Menu.addCategory("automationTrivia", triviaTitle);
@@ -373,7 +373,7 @@ class AutomationTrivia
             let tooltip = `The following pokémons are roaming '${routeName}':\n`;
             for (const [ index, pokemon ] of roamers.entries())
             {
-                const caughtStatus = this.__internal__getPokemonCaughtStatus(pokemon.pokemon.id);
+                const caughtStatus = Automation.Utils.getPokemonCaughtStatus(pokemon.pokemon.id);
                 tooltip += `[${caughtIndicator[caughtStatus]}] ${pokemon.pokemon.name} (#${pokemon.pokemon.id})\n`;
             }
 
@@ -386,30 +386,6 @@ class AutomationTrivia
     }
 
     /**
-     * @brief Gets the pokémon caught status
-     *
-     * @param {number} pokemonId: The pokemon id to get the status of
-     *
-     * @returns The caught status
-     */
-    static __internal__getPokemonCaughtStatus(pokemonId)
-    {
-        const partyPokemon = App.game.party.getPokemon(pokemonId);
-
-        if (!partyPokemon)
-        {
-            return CaughtStatus.NotCaught;
-        }
-
-        if (partyPokemon.shiny)
-        {
-            return CaughtStatus.CaughtShiny;
-        }
-
-        return CaughtStatus.Caught;
-    }
-
-    /**
      * @brief Updates the roamers caught status image, if needed
      *
      * @param {Array} roamers: The current sub-region Roamers list
@@ -419,7 +395,7 @@ class AutomationTrivia
         let overallCaughtStatus = CaughtStatus.CaughtShiny;
         for (const data of roamers)
         {
-            const caughtStatus = this.__internal__getPokemonCaughtStatus(data.pokemon.id);
+            const caughtStatus = Automation.Utils.getPokemonCaughtStatus(data.pokemon.id);
 
             overallCaughtStatus = Math.min(overallCaughtStatus, caughtStatus);
 
@@ -432,11 +408,7 @@ class AutomationTrivia
         // Only update if the status changed
         if (overallCaughtStatus !== this.__internal__displayedCaughtStatus)
         {
-            const imageSwitch = { [CaughtStatus.NotCaught]: "None", [CaughtStatus.Caught]: "Pokeball", [CaughtStatus.CaughtShiny]: "Pokeball-shiny" };
-
-            this.__internal__roamersCatchStatus.innerHTML = '<img class="pokeball-smallest" style="position: relative; top: 1px;"'
-                                                          + ` src="assets/images/pokeball/${imageSwitch[overallCaughtStatus]}.svg">`;
-
+            this.__internal__roamersCatchStatus.innerHTML = Automation.Menu.getCaughtStatusImage(overallCaughtStatus);
             this.__internal__displayedCaughtStatus = overallCaughtStatus;
         }
     }

--- a/src/lib/Utils.js
+++ b/src/lib/Utils.js
@@ -78,4 +78,28 @@ class AutomationUtils
         let result = parseInt(str);
         return isNaN(result) ? defaultValue : result;
     }
+
+    /**
+     * @brief Gets the pokémon caught status from its given @p pokemonId
+     *
+     * @param {number} pokemonId: The pokemon id to get the status of
+     *
+     * @returns The caught status
+     */
+    static getPokemonCaughtStatus(pokemonId)
+    {
+        const partyPokemon = App.game.party.getPokemon(pokemonId);
+
+        if (!partyPokemon)
+        {
+            return CaughtStatus.NotCaught;
+        }
+
+        if (partyPokemon.shiny)
+        {
+            return CaughtStatus.CaughtShiny;
+        }
+
+        return CaughtStatus.Caught;
+    }
 }


### PR DESCRIPTION
This new panel will be displayed before the main menu. It will only be shown while the battle café modal is visible.

It will display the available unlocks of the currently selected sweet and their caught status.

![image](https://user-images.githubusercontent.com/11090416/200174426-485da1bc-8a62-41ac-8f1f-011bbd30385d.png)

Hovering the text will give more details: 
![image](https://user-images.githubusercontent.com/11090416/200174446-adfe9a4d-695d-4307-aa6d-4a87b32ca9f3.png)


Fixes #181 