### PR TITLE
Shop: Fixup item name

### DIFF
--- a/src/lib/Shop.js
+++ b/src/lib/Shop.js
@@ -750,7 +750,7 @@ class AutomationShop
             return App.game.farming.mulchList[MulchType[item.name]]();
         }
 
-        return player.itemList[itemName]();
+        return player.itemList[item.name]();
     }
 
     /**


### PR DESCRIPTION
The value was not renamed properly, resulting in a crash:
`Uncaught ReferenceError: itemName is not defined`

The right name is now used