### PR TITLE
Shop: Fixup regression

### DIFF
--- a/src/lib/Shop.js
+++ b/src/lib/Shop.js
@@ -477,7 +477,7 @@ class AutomationShop
                                 const town = TownList[townName];
                                 return town.isUnlocked() && Automation.Utils.Route.canMoveToRegion(town.region);
                             });
-                };
+                }.bind(this);
 
             this.__internal__shopItems.push(shopItem);
         }


### PR DESCRIPTION
The following error was issued while having pokémart items enabled:
   Uncaught TypeError: this.__internal__isPokeMarkUnlocked is not a function

The class is now bound properly

Fixes  #184