### PR TITLE
Some improvements and bug fix

### DIFF
--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -23,10 +23,9 @@ class AutomationFocusAchievements
                        + "This feature handles the following achievements:\n"
                        + "Route Kill, Clear Gym and Clear Dungeon\n"
                        + "The achievements will be completed in region order.\n"
-                       + "The current achievement will be pinned to the tracker",
+                       + "The current achievement will be pinned to the tracker, if unlocked",
                 run: function (){ this.__internal__start(); }.bind(this),
                 stop: function (){ this.__internal__stop(); }.bind(this),
-                isUnlocked: function (){ return App.game.achievementTracker.canAccess(); },
                 refreshRateAsMs: Automation.Focus.__noFunctionalityRefresh
             });
     }
@@ -113,7 +112,11 @@ class AutomationFocusAchievements
                 return;
             }
 
-            App.game.achievementTracker.trackAchievement(this.__internal__currentAchievement);
+            // Track the achievement only if the tracker was unlocked
+            if (App.game.achievementTracker.canAccess())
+            {
+                App.game.achievementTracker.trackAchievement(this.__internal__currentAchievement);
+            }
         }
     }
 

--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -247,7 +247,7 @@ class AutomationFocusAchievements
                 // Only handle supported kinds of achievements, if achievable and not already completed
                 if (achievement.isCompleted()
                     || !achievement.achievable()
-                    || (achievement.region > player.highestRegion()))
+                    || (achievement.property.region > player.highestRegion()))
                 {
                     return false;
                 }
@@ -255,7 +255,7 @@ class AutomationFocusAchievements
                 // Consider RouteKill achievements, if the player can move to the target route
                 if (achievement.property instanceof RouteKillRequirement)
                 {
-                    return (Automation.Utils.Route.canMoveToRegion(achievement.region)
+                    return (Automation.Utils.Route.canMoveToRegion(achievement.property.region)
                             && MapHelper.accessToRoute(achievement.property.route, achievement.property.region));
                 }
 
@@ -271,7 +271,7 @@ class AutomationFocusAchievements
                         townName = GymList[townName].parent.name;
                     }
 
-                    return (Automation.Utils.Route.canMoveToRegion(achievement.region)
+                    return (Automation.Utils.Route.canMoveToRegion(achievement.property.region)
                             && MapHelper.accessToTown(townName)
                             && GymList[gymName].isUnlocked());
                 }
@@ -280,7 +280,7 @@ class AutomationFocusAchievements
                 if (achievement.property instanceof ClearDungeonRequirement)
                 {
                     let dungeonName = GameConstants.RegionDungeons.flat()[achievement.property.dungeonIndex];
-                    return (Automation.Utils.Route.canMoveToRegion(achievement.region)
+                    return (Automation.Utils.Route.canMoveToRegion(achievement.property.region)
                             && MapHelper.accessToTown(dungeonName));
                 }
 

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -624,6 +624,7 @@ class AutomationMenu
         let labelElem = document.createElement("label");
         labelElem.classList.add("automationTabLabel");
         labelElem.textContent = label;
+        labelElem.id = `${currentTabId}-label`;
         labelElem.setAttribute("for", currentTabId);
         tabLabelContainer.appendChild(labelElem);
 

--- a/src/lib/Utils/Route.js
+++ b/src/lib/Utils/Route.js
@@ -96,7 +96,8 @@ class AutomationUtilsRoute
     static canMoveToRegion(region)
     {
         // Not possible move
-        if (Automation.Utils.isInInstanceState()
+        if (isNaN(region)
+            || Automation.Utils.isInInstanceState()
             || (region > player.highestRegion())
             || (region < 0))
         {


### PR DESCRIPTION
Shop: Hide tabs with no items

Items are not displayed until they can actually be purchased.
Some tabs can have no items early game.

Tabs with no items are now disabled.

---

Focus.Achievements: Always display this feature

Achievements can be unlocked right away,
only the tracker needs to be unlocked.

The feature is now always available.
Only the tacker assignment is now conditioned.

---

Focus.Achievements: Fixup achievement never being selected

The achievement region was not retrieved using the right path.
The value would then be undefined.

If the given region was undefined, the canMoveToRegion would return
true on some browser.

The canMoveToRegion function now make sure the given region is a number
to ensure a consistent behaviour between browsers.

The region property is now accessed correctly.
