### PR TITLE
Menu: Only inverte colors for uncaught status image

### DIFF
--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -670,7 +670,9 @@ class AutomationMenu
      */
     static getCaughtStatusImage(caughtStatus)
     {
-        return '<img class="pokeball-smallest" style="position: relative; top: 1px; filter: invert(1) brightness(90%) !important;"'
+        const extraStyle = (caughtStatus == CaughtStatus.NotCaught) ? " filter: invert(1) brightness(90%) !important;" : "";
+
+        return `<img class="pokeball-smallest" style="position: relative; top: 1px;${extraStyle}"`
              + ` src="assets/images/pokeball/${this.__internal__caughtStatusImageSwitch[caughtStatus]}.svg">`;
     }
 


### PR DESCRIPTION
The color inversion is here to fit the dark theme, it's only relevant for the uncaught status image

The image was displayed this way : 
![image](https://user-images.githubusercontent.com/11090416/201174226-54fbeba4-e2c4-44c5-856d-4d54e153e9e3.png)

It's now only inverted for the uncaught status : 
![image](https://user-images.githubusercontent.com/11090416/201174000-48891afa-1959-4c21-9d10-89a414cc5885.png)
