### PR TITLE
Menu: Add an option to disables settings by default

### DIFF
--- a/Automation-UserScript.js
+++ b/Automation-UserScript.js
@@ -17,6 +17,9 @@ var releaseLabel = "master";
 // Set this to true if you want no feature to be enabled by default
 var disableFeaturesByDefault = false;
 
+// Set this to true if you want no setting to be enabled by default
+var disableSettingsByDefault = false;
+
 var pokeclickerAutomationReleaseUrl = "https://raw.githubusercontent.com/Farigh/pokeclicker-automation/" + releaseLabel + "/";
 
 // Github only serves plain-text so we can't load it as a script object directly
@@ -31,7 +34,7 @@ xmlhttp.onreadystatechange = function()
             script.id = "pokeclicker-automation-component-loader";
             document.head.appendChild(script);
 
-            AutomationComponentLoader.loadFromUrl(pokeclickerAutomationReleaseUrl, disableFeaturesByDefault);
+            AutomationComponentLoader.loadFromUrl(pokeclickerAutomationReleaseUrl, disableFeaturesByDefault, disableSettingsByDefault);
         }
     }
 

--- a/src/Automation.js
+++ b/src/Automation.js
@@ -32,11 +32,13 @@ class Automation
     /**
      * @brief Automation entry point
      *
-     * @param {boolean} disableFeaturesByDefault: True if every features needs to be disabeld by default, False otherwise
+     * @param {boolean} disableFeaturesByDefault: True if every features needs to be disabled by default, False otherwise
+     * @param {boolean} disableSettingsByDefault: True if every settings needs to be disabled by default, False otherwise
      */
-    static start(disableFeaturesByDefault)
+    static start(disableFeaturesByDefault, disableSettingsByDefault)
     {
         this.Menu.DisableFeaturesByDefault = disableFeaturesByDefault;
+        this.Menu.DisableSettingsByDefault = disableSettingsByDefault;
 
         var timer = setInterval(function()
         {

--- a/src/ComponentLoader.js
+++ b/src/ComponentLoader.js
@@ -16,11 +16,12 @@ class AutomationComponentLoader
      * @brief Loads the Automation classes from the given @p baseUrl
      *
      * @param {string}  baseUrl: The base URL to download the lib component files from
-     * @param {boolean} disableFeaturesByDefault: True if every features needs to be disabeld by default, False otherwise
+     * @param {boolean} disableFeaturesByDefault: True if every features needs to be disabled by default, False otherwise
+     * @param {boolean} disableSettingsByDefault: True if every settings needs to be disabled by default, False otherwise
      *
      * @warning This function should never change its prototype, otherwise it would break the API
      */
-    static loadFromUrl(baseUrl, disableFeaturesByDefault = false)
+    static loadFromUrl(baseUrl, disableFeaturesByDefault = false, disableSettingsByDefault = false)
     {
         this.__baseUrl = baseUrl;
 
@@ -52,7 +53,7 @@ class AutomationComponentLoader
         this.__loadingOrder += 1;
         this.__addScript("src/Automation.js");
 
-        this.__setupAutomationRunner(disableFeaturesByDefault);
+        this.__setupAutomationRunner(disableFeaturesByDefault, disableSettingsByDefault);
     }
 
     /**
@@ -116,9 +117,10 @@ class AutomationComponentLoader
      * @brief Sets a loading watcher which prevent loading the automation before the game components are fully up and running.
      *        Once all scripts are properly loaded, it runs the automation.
      *
-     * @param {boolean} disableFeaturesByDefault: True if every features needs to be disabeld by default, False otherwise
+     * @param {boolean} disableFeaturesByDefault: True if every features needs to be disabled by default, False otherwise
+     * @param {boolean} disableSettingsByDefault: True if every settings needs to be disabled by default, False otherwise
      */
-    static __setupAutomationRunner(disableFeaturesByDefault)
+    static __setupAutomationRunner(disableFeaturesByDefault, disableSettingsByDefault)
     {
         let currentLoadingOrder = -1;
 
@@ -151,7 +153,7 @@ class AutomationComponentLoader
                 clearInterval(watcher);
 
                 // Start the automation
-                Automation.start(disableFeaturesByDefault);
+                Automation.start(disableFeaturesByDefault, disableSettingsByDefault);
             }.bind(this), 200); // Check every 200ms
     }
 }

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -136,8 +136,8 @@ class AutomationFocusQuests
             rowElem.appendChild(toggleCellElem);
 
             const storageKey = this.__internal__advancedSettings.QuestEnabled(quest);
-            // Enable the quest by default
-            Automation.Utils.LocalStorage.setDefaultValue(storageKey, true);
+            // Enable the quest by default, unless the user chose to disable settings by default
+            Automation.Utils.LocalStorage.setDefaultValue(storageKey, !Automation.Menu.DisableSettingsByDefault);
 
             const toggleButton = Automation.Menu.addLocalStorageBoundToggleButton(storageKey);
             toggleCellElem.appendChild(toggleButton);

--- a/src/lib/Hatchery.js
+++ b/src/lib/Hatchery.js
@@ -383,8 +383,8 @@ class AutomationHatchery
         }
         else
         {
-            // Enable Pokérus spreading by default
-            Automation.Utils.LocalStorage.setDefaultValue(this.Settings.SpreadPokerus, true);
+            // Enable Pokérus spreading by default, unless the user chose to disable settings by default
+            Automation.Utils.LocalStorage.setDefaultValue(this.Settings.SpreadPokerus, !Automation.Menu.DisableSettingsByDefault);
         }
     }
 

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -213,8 +213,8 @@ class AutomationMenu
      */
     static addLabeledAdvancedSettingsToggleButton(label, id, tooltip = "", containingDiv = this.AutomationButtonsDiv)
     {
-        // Enable automation by default, if not already set in local storage
-        Automation.Utils.LocalStorage.setDefaultValue(id, true);
+        // Enable automation by default, if not already set in local storage, unless the user chose to disable settings by default
+        Automation.Utils.LocalStorage.setDefaultValue(id, !this.DisableSettingsByDefault);
 
         let buttonMainContainer = document.createElement("span");
         containingDiv.appendChild(buttonMainContainer);


### PR DESCRIPTION
This will allow the user to start with every single settings disabled by default.

---

Shop: Hide the menu until the player unlocks the map

No item can be purchased before that, so we should not display the
feature.

Fixes #194 