### PR TITLE
Hatchery: Fix mega evolution requirement check

### DIFF
--- a/src/lib/Hatchery.js
+++ b/src/lib/Hatchery.js
@@ -992,16 +992,19 @@ class AutomationHatchery
                 {
                     return false;
                 }
-                for (const evolution of partyPokemon.evolutions)
-                {
-                    if ((evolution.trigger === EvoTrigger.STONE)
-                        && (evolution?.stone == GameConstants.StoneType.Key_stone)
-                        && PokemonHelper.calcNativeRegion(evolution.evolvedPokemon) <= player.highestRegion())
+
+                const hasMegaEvolution = partyPokemon.evolutions.some((evolution) =>
                     {
-                        // Only consider mega evolution with an incomplete mega evolution requirement
-                        return !evolution.restrictions?.filter(e => Automation.Utils.isInstanceOf(e, "MegaEvolveRequirement"))[0]?.isCompleted();
-                    }
+                        return evolution.restrictions?.some(e => Automation.Utils.isInstanceOf(e, "MegaEvolveRequirement"));
+                    });
+
+                // Don't consider pokemon that does not have a mega evolution
+                if  (hasMegaEvolution)
+                {
+                    // Only consider pokemon with an incomplete mega-stone requirement (buid it since the pokemon might not have unlocked it yet)
+                    return !(new MegaStone(partyPokemon.id, partyPokemon.baseAttack, partyPokemon._attack).canEvolve());
                 }
+
                 return false;
             });
     }


### PR DESCRIPTION
While this removes using the megaStone to check for completion, it is necessary to actually perform the check

The issue that was (is) happening, is that when checking for a pokemon whose megaStone we do not have yet, calling `requirement.isCompleted()` will call `getProgress()`, which will return `App.game.party.getPokemonByName(this.name)?.megaStone?.canEvolve() ? 1 : 0;`. However, as the pokemon does not have the megaStone yet, the `canEvolve()` is never even called, and it always returns 0, never bothering to check.

Instead of checking for the hardcoded 100, we could create a new MegaStone object (without assigning it to the pokemon) and call the `canEvolve()` there, but that could make the scripts crash if the constructor is ever changed.

So we have two options to respond if this code changes. Either crash the automation, or report a value that could be wrong. I chose the second one.

If you want the other option, the line would be this:
`!(new MegaStone(partyPokemon.id, partyPokemon.baseAttack, partyPokemon._attack).canEvolve())`