### PR TITLE
Focus.Quests: Move to the appropriate place to farm money 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@ Pokeclicker-automation aims at automating some recurring tasks that can be a bit
 This script collection does not aim at cheating.
 It will never perform actions that the game would not allow.
 
-Last known compatible pokeclicker version: 0.10.4
+Last known compatible pokeclicker version: 0.10.6
 
 For more details, please refer to the [wiki](../../wiki)
 

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -450,7 +450,7 @@ class AutomationFocusQuests
     {
         this.__internal__equipOptimizedLoadout(Automation.Utils.OakItem.Setup.Money);
 
-        let bestGym = Automation.Utils.Gym.findBestGymForMoney();
+        const bestGym = Automation.Utils.Gym.findBestGymForMoney();
         if (bestGym.bestGymTown !== null)
         {
             Automation.Utils.Route.moveToTown(bestGym.bestGymTown);
@@ -648,13 +648,17 @@ class AutomationFocusQuests
      */
     static __internal__workOnUsePokeballQuest(ballType, enforceType = false)
     {
-        let hasBalls = this.__internal__selectBallToCatch(ballType, enforceType);
-        this.__internal__equipOptimizedLoadout(Automation.Utils.OakItem.Setup.PokemonCatch);
+        const hasBalls = this.__internal__selectBallToCatch(ballType, enforceType);
 
         if (hasBalls)
         {
+            this.__internal__equipOptimizedLoadout(Automation.Utils.OakItem.Setup.PokemonCatch);
             // Go to the highest route, for higher quest point income
             Automation.Utils.Route.moveToHighestDungeonTokenIncomeRoute(ballType);
+        }
+        else
+        {
+            this.__internal__farmSomeMoney();
         }
     }
 

--- a/src/lib/Hatchery.js
+++ b/src/lib/Hatchery.js
@@ -999,7 +999,7 @@ class AutomationHatchery
                     });
 
                 // Don't consider pokemon that does not have a mega evolution
-                if  (hasMegaEvolution)
+                if (hasMegaEvolution)
                 {
                     // Only consider pokemon with an incomplete mega-stone requirement (buid it since the pokemon might not have unlocked it yet)
                     return !(new MegaStone(partyPokemon.id, partyPokemon.baseAttack, partyPokemon._attack).canEvolve());

--- a/src/lib/Utils/Gym.js
+++ b/src/lib/Utils/Gym.js
@@ -90,7 +90,7 @@ class AutomationUtilsGym
         let bestGym = null;
         let bestGymTown = null;
         let bestGymRatio = 0;
-        let playerClickAttack = Automation.Utils.Battle.calculateClickAttack();
+        const playerClickAttack = Automation.Utils.Battle.calculateClickAttack();
         for (const key of Object.keys(GymList))
         {
             let gym = GymList[key];

--- a/src/lib/Utils/Route.js
+++ b/src/lib/Utils/Route.js
@@ -87,6 +87,19 @@ class AutomationUtilsRoute
     }
 
     /**
+     * @brief Checks if a subregion is Magikarp Jump
+     *
+     * @param {number} region: The region to check
+     * @param {number} subRegion: The subregion to check
+     *
+     * @returns True if the given sub-region matches Magikarp Jump
+     */
+    static isInMagikarpJumpIsland(region, subRegion)
+    {
+        return ((region == GameConstants.Region.alola) && (subRegion == GameConstants.AlolaSubRegions.MagikarpJump));
+    }
+
+    /**
      * @brief Checks if the player is allowed to move to the given @p region
      *
      * @param {number} region: The region number to move to
@@ -127,22 +140,22 @@ class AutomationUtilsRoute
             return;
         }
 
-        let playerClickAttack = Automation.Utils.Battle.calculateClickAttack();
+        const playerClickAttack = Automation.Utils.Battle.calculateClickAttack();
 
         // In case click attack is 0, use the pokemon attack instead (no-click challenge)
-        let playerSingleAttackByRegion = (playerClickAttack == 0)
-                                       ? Automation.Utils.Battle.getPlayerWorstAttackPerSecondForAllRegions(playerClickAttack)
-                                       : Array(GameConstants.MAX_AVAILABLE_REGION + 1).fill(playerClickAttack);
+        const playerSingleAttackByRegion = (playerClickAttack == 0)
+                                         ? Automation.Utils.Battle.getPlayerWorstAttackPerSecondForAllRegions(playerClickAttack)
+                                         : Array(GameConstants.MAX_AVAILABLE_REGION + 1).fill(playerClickAttack);
 
         // We need to find a new road if:
         //    - The highest region changed
         //    - The player attack decreased (this can happen if the rocky helmet item was unequipped)
         //    - We are currently on the highest route of the map
         //    - The next best route is still over-powered
-        let needsNewRoad = (this.__internal__lastHighestRegion !== player.highestRegion())
-                        || (this.__internal__lastBestRouteData.maxHealth > playerSingleAttackByRegion[this.__internal__lastBestRouteData.route.region])
-                        || ((this.__internal__lastNextBestRouteData != null)
-                            && (this.__internal__lastNextBestRouteData.maxHealth < playerSingleAttackByRegion[this.__internal__lastNextBestRouteData.route.region]));
+        const needsNewRoad = (this.__internal__lastHighestRegion !== player.highestRegion())
+                          || (this.__internal__lastBestRouteData.maxHealth > playerSingleAttackByRegion[this.__internal__lastBestRouteData.route.region])
+                          || ((this.__internal__lastNextBestRouteData != null)
+                              && (this.__internal__lastNextBestRouteData.maxHealth < playerSingleAttackByRegion[this.__internal__lastNextBestRouteData.route.region]));
 
         if (needsNewRoad)
         {
@@ -156,6 +169,13 @@ class AutomationUtilsRoute
                 // Skip any route that we can't access
                 if (!this.canMoveToRegion(routeData.route.region))
                 {
+                    continue;
+                }
+
+                // Skip Magikarp jump route, for now
+                if (Automation.Utils.Route.isInMagikarpJumpIsland(routeData.route.region, routeData.route.subRegion))
+                {
+                    // TODO: Compute magikarp worst attack instead
                     continue;
                 }
 
@@ -196,9 +216,9 @@ class AutomationUtilsRoute
         let bestRouteRegion = 0;
         let bestRouteIncome = 0;
 
-        let playerClickAttack = Automation.Utils.Battle.calculateClickAttack();
-        let totalAtkPerSecondByRegion = Automation.Utils.Battle.getPlayerWorstAttackPerSecondForAllRegions(playerClickAttack);
-        let catchTimeTicks = App.game.pokeballs.calculateCatchTime(ballTypeToUse) / 50;
+        const playerClickAttack = Automation.Utils.Battle.calculateClickAttack();
+        const totalAtkPerSecondByRegion = Automation.Utils.Battle.getPlayerWorstAttackPerSecondForAllRegions(playerClickAttack);
+        const catchTimeTicks = App.game.pokeballs.calculateCatchTime(ballTypeToUse) / 50;
 
         // The bonus is the same, no matter the amount
         const dungeonTokenBonus = App.game.wallet.calcBonus(new Amount(1, Currency.dungeonToken));
@@ -215,7 +235,14 @@ class AutomationUtilsRoute
                 continue;
             }
 
-            let pokemons = RouteHelper.getAvailablePokemonList(route.number, route.region);
+            // Skip Magikarp jump route, for now
+            if (Automation.Utils.Route.isInMagikarpJumpIsland(route.region, route.subRegion))
+            {
+                // TODO: Compute magikarp worst attack instead
+                continue;
+            }
+
+            const pokemons = RouteHelper.getAvailablePokemonList(route.number, route.region);
 
             let currentRouteRate = 0;
             for (const pokemon of pokemons)
@@ -228,8 +255,8 @@ class AutomationUtilsRoute
 
             let routeIncome = this.__internal__routeRawIncomeMap.get(route.region).get(route.number) * dungeonTokenBonus * (currentRouteRate / 100);
 
-            let routeAvgHp = PokemonFactory.routeHealth(route.number, route.region);
-            let nbGameTickToDefeat =
+            const routeAvgHp = PokemonFactory.routeHealth(route.number, route.region);
+            const nbGameTickToDefeat =
                 Automation.Utils.Battle.getGameTickCountNeededToDefeatPokemon(routeAvgHp, playerClickAttack, totalAtkPerSecondByRegion[route.region]);
             routeIncome = (routeIncome / (nbGameTickToDefeat + catchTimeTicks));
 
@@ -263,8 +290,8 @@ class AutomationUtilsRoute
         let bestRouteRegion = 0;
         let bestRouteRate = 0;
 
-        let playerClickAttack = Automation.Utils.Battle.calculateClickAttack();
-        let totalAtkPerSecondByRegion = Automation.Utils.Battle.getPlayerWorstAttackPerSecondForAllRegions(playerClickAttack);
+        const playerClickAttack = Automation.Utils.Battle.calculateClickAttack();
+        const totalAtkPerSecondByRegion = Automation.Utils.Battle.getPlayerWorstAttackPerSecondForAllRegions(playerClickAttack);
 
         // Fortunately routes are sorted by attack
         for (const route of Routes.regionRoutes)
@@ -275,7 +302,14 @@ class AutomationUtilsRoute
                 continue;
             }
 
-            let pokemons = RouteHelper.getAvailablePokemonList(route.number, route.region);
+            // Skip Magikarp jump route, for now
+            if (Automation.Utils.Route.isInMagikarpJumpIsland(route.region, route.subRegion))
+            {
+                // TODO: Compute magikarp worst attack instead
+                continue;
+            }
+
+            const pokemons = RouteHelper.getAvailablePokemonList(route.number, route.region);
 
             let currentRouteCount = 0;
             for (const pokemon of pokemons)
@@ -290,8 +324,8 @@ class AutomationUtilsRoute
 
             let currentRouteRate = currentRouteCount / pokemons.length;
 
-            let routeAvgHp = PokemonFactory.routeHealth(route.number, route.region);
-            let nbGameTickToDefeat =
+            const routeAvgHp = PokemonFactory.routeHealth(route.number, route.region);
+            const nbGameTickToDefeat =
                 Automation.Utils.Battle.getGameTickCountNeededToDefeatPokemon(routeAvgHp, playerClickAttack, totalAtkPerSecondByRegion[route.region]);
             currentRouteRate = currentRouteRate / nbGameTickToDefeat;
 

--- a/tst/imports/Pokeclicker.import.js
+++ b/tst/imports/Pokeclicker.import.js
@@ -88,6 +88,7 @@ import "tst/stubs/Weather/WeatherCondition.pokeclicker.stub.js"; // Used by Weat
 import "tst/stubs/Weather/Weather.pokeclicker.stub.js";
 
 // Import pokeclicker classes
+import "tst/stubs/AchievementHandler.pokeclicker.stub.js";
 import "tst/stubs/Challenges.pokeclicker.stub.js";
 import "tst/stubs/Discord.pokeclicker.stub.js";
 import "tst/stubs/MapHelper.pokeclicker.stub.js";

--- a/tst/stubs/AchievementHandler.pokeclicker.stub.js
+++ b/tst/stubs/AchievementHandler.pokeclicker.stub.js
@@ -1,0 +1,8 @@
+// Stub of https://github.com/pokeclicker/pokeclicker/blob/c7b4d269de98c064a22233d7a2076c777bb9d36c/src/scripts/achievements/AchievementHandler.ts
+class AchievementHandler
+{
+    static achievementBonus()
+    {
+        return 0;
+    }
+}

--- a/tst/stubs/Pokemon/Multiplier.pokeclicker.stub.js
+++ b/tst/stubs/Pokemon/Multiplier.pokeclicker.stub.js
@@ -6,6 +6,7 @@ class Multiplier
         this.__bonus = new Map();
 
         this.__bonus.set('pokemonAttack', 1);
+        this.__bonus.set('clickAttack', 1);
     }
 
     getBonus(type, useBonus = false)

--- a/tst/tests/Utils/Battle.test.in.js
+++ b/tst/tests/Utils/Battle.test.in.js
@@ -156,7 +156,7 @@ test('Check calculateClickAttack() output', () =>
 
     // Simulate the click loop being active by setting the loop to something different from null
     Automation.Click.__internal__autoClickLoop = "dummy";
-    expect(Automation.Utils.Battle.calculateClickAttack()).toEqual(App.game.party.calculateClickAttack());
+    expect(Automation.Utils.Battle.calculateClickAttack()).toEqual(684);
 
     // Simulate the no-click challenge being enabled
     App.game.challenges.list.disableClickAttack.__active = true;

--- a/tst/tests/Utils/Gym.test.in.js
+++ b/tst/tests/Utils/Gym.test.in.js
@@ -34,6 +34,9 @@ class Automation
     };
 }
 
+// Stub the calculateClickAttack method
+Automation.Utils.Battle.calculateClickAttack = function() { return App.game.party.calculateClickAttack(); };
+
 // Load some pokémons
 PokemonLoader.loadEggsPokemons();
 
@@ -95,7 +98,7 @@ describe(`${AutomationTestUtils.categoryPrefix}Check findBestGymForFarmingType()
 
     test('No-click challenge active', () =>
     {
-        App.game.party.__clickAttack = 10000; // Whatever number we put here shouldn't change anything
+        App.game.party.__clickAttack = 0; // Simulate no-click challenge
         App.game.challenges.list.disableClickAttack.__active = true;
 
         let result = Automation.Utils.Gym.findBestGymForFarmingType(PokemonType.Fighting);

--- a/tst/tests/Utils/Route.test.in.js
+++ b/tst/tests/Utils/Route.test.in.js
@@ -34,6 +34,9 @@ class Automation
     };
 }
 
+// Stub the calculateClickAttack method
+Automation.Utils.Battle.calculateClickAttack = function() { return App.game.party.calculateClickAttack(); };
+
 // Load some pokémons
 PokemonLoader.loadEggsPokemons();
 
@@ -99,7 +102,7 @@ describe(`${AutomationTestUtils.categoryPrefix}Check moveToBestRouteForExp() met
     test('No-click challenge active', () =>
     {
         player.region = 0;
-        App.game.party.__clickAttack = 95000; // Whatever number we put here shouldn't change anything
+        App.game.party.__clickAttack = 0; // Simulate no-click challenge
         App.game.challenges.list.disableClickAttack.__active = true;
 
         Automation.Utils.Route.moveToBestRouteForExp();
@@ -148,7 +151,7 @@ describe(`${AutomationTestUtils.categoryPrefix}Check moveToHighestDungeonTokenIn
 
     test('No-click challenge active', () =>
     {
-        App.game.party.__clickAttack = 10000; // Whatever number we put here shouldn't change anything
+        App.game.party.__clickAttack = 0; // Simulate no-click challenge
         App.game.challenges.list.disableClickAttack.__active = true;
 
         Automation.Utils.Route.moveToHighestDungeonTokenIncomeRoute(GameConstants.Pokeball.Ultraball);
@@ -186,7 +189,7 @@ describe(`${AutomationTestUtils.categoryPrefix}Check findBestRouteForFarmingType
 
     test('No-click challenge active', () =>
     {
-        App.game.party.__clickAttack = 10000; // Whatever number we put here shouldn't change anything
+        App.game.party.__clickAttack = 0; // Simulate no-click challenge
         App.game.challenges.list.disableClickAttack.__active = true;
 
         let result = Automation.Utils.Route.findBestRouteForFarmingType(PokemonType.Fighting);


### PR DESCRIPTION
When the player does not have balls anymore and needs to buy some
but does not have enough money to do so, it was still moved to the
pokemon catching place, with the corresponding loadout.

It will now move to the money farming place and equip the money
farming loadout.

---

Battle: Fixup clickattack computation

The click attack value is now different in one sub-region.
This would result in the game moving back and forth from one route/gym to another if the region switched to the Magikarp jump one in the process.

This new setting is now used properly.

---

Fixes #207