### PR TITLE
Shop: indicate when an item can't be bought

### DIFF
--- a/src/lib/Click.js
+++ b/src/lib/Click.js
@@ -27,7 +27,7 @@ class AutomationClick
     {
         if (initStep == Automation.InitSteps.BuildMenu)
         {
-           this.__internal__buildMenu();
+            this.__internal__buildMenu();
         }
         else if (initStep == Automation.InitSteps.Finalize)
         {
@@ -91,10 +91,10 @@ class AutomationClick
         this.__internal__container = document.createElement('div');
 
         // Add auto click button
-        let autoClickTooltip = "Attack clicks are performed every 50ms"
-                             + Automation.Menu.TooltipSeparator
-                             + "Applies to battle, gym and dungeon";
-        let autoClickButton =
+        const autoClickTooltip = "Attack clicks are performed every 50ms"
+                               + Automation.Menu.TooltipSeparator
+                               + "Applies to battle, gym and dungeon";
+        const autoClickButton =
             Automation.Menu.addAutomationButton("Auto attack", this.Settings.FeatureEnabled, autoClickTooltip, this.__internal__container);
         autoClickButton.addEventListener("click", this.toggleAutoClick.bind(this), false);
 
@@ -111,7 +111,7 @@ class AutomationClick
         // Add a watcher, in case the player changes the challenge configuration at some point
         if (this.__internal__container.hidden || (player.regionStarters[GameConstants.Region.kanto]() === GameConstants.Starter.None))
         {
-            let watcher = setInterval(function()
+            const watcher = setInterval(function()
                 {
                     if (App.game.challenges.list.disableClickAttack.active())
                     {

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -800,6 +800,18 @@ class AutomationMenu
         const style = document.createElement('style');
         style.textContent = `
 
+            .automationWarningIcon
+            {
+                position: relative;
+            }
+            .automationWarningIcon::before
+            {
+                position: absolute;
+                content: '⚠️';
+                top: 1px;
+                left: -15px;
+            }
+
             /****************\
             |*   Tooltips   *|
             \****************/
@@ -864,6 +876,16 @@ class AutomationMenu
             .hasAutomationTooltip.centeredAutomationTooltip::after
             {
                 left: calc(50%);
+            }
+            .hasAutomationTooltip.warningAutomationTooltip::before
+            {
+                transform: translateX(-30px);
+                top: calc(100% + 8px);
+            }
+            .hasAutomationTooltip.warningAutomationTooltip::after
+            {
+                left: -11px;
+                top: calc(100% + 2px);
             }
             .hasAutomationTooltip.shopItemAutomationTooltip::after
             {


### PR DESCRIPTION
When the player switches region, the previous regions shop are not available until the docks of the new region are unlocked.

A visual indicator is now displayed in front of each impacted items to inform the user.

![image](https://user-images.githubusercontent.com/11090416/210643125-7bce800b-cd62-4dbf-9cd6-5de0e033cf20.png)
