### PR TITLE
Utils.Gym: Do not consider trials as valid gyms

### DIFF
--- a/src/lib/Utils/Gym.js
+++ b/src/lib/Utils/Gym.js
@@ -49,6 +49,12 @@ class AutomationUtilsGym
                 continue;
             }
 
+            // Some gyms are trials linked to a dungeon, don't consider those
+            if (Automation.Utils.isInstanceOf(TownList[gymData.gymTown], "DungeonTown"))
+            {
+                continue;
+            }
+
             const currentGymClickAttack = Automation.Utils.Route.isInMagikarpJumpIsland(gymData.region, gymData.subRegion)
                                         ? magikarpPlayerClickAttack
                                         : playerClickAttack;


### PR DESCRIPTION
Trials are temporary gym fights that will only be available once.

They were correctly filtered in the findBestGymForMoney method
but not in the findBestGymForFarmingType one.

It's now filtered in both cases.

Fixes #211 