### PR TITLE
BattleCafé: Fixup regression from v0.10.7

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@ Pokeclicker-automation aims at automating some recurring tasks that can be a bit
 This script collection does not aim at cheating.
 It will never perform actions that the game would not allow.
 
-Last known compatible pokeclicker version: 0.10.6
+Last known compatible pokeclicker version: 0.10.7
 
 For more details, please refer to the [wiki](../../wiki)
 

--- a/src/lib/BattleCafe.js
+++ b/src/lib/BattleCafe.js
@@ -59,7 +59,7 @@ class AutomationBattleCafe
             this.__internal__battleCafeSweetContainers.push(currentSweetContainer);
 
             currentSweetContainer.appendChild(document.createElement("br"));
-            currentSweetContainer.appendChild(document.createTextNode("Day (5:00 → 19:00)"));
+            currentSweetContainer.appendChild(document.createTextNode("Day (6:00 → 18:00)"));
             currentSweetContainer.appendChild(document.createElement("br"));
             this.__internal__addInfo(sweetData, GameConstants.AlcremieSpins.dayClockwiseBelow5, currentSweetContainer);
             this.__internal__addInfo(sweetData, GameConstants.AlcremieSpins.dayClockwiseAbove5, currentSweetContainer);
@@ -67,12 +67,12 @@ class AutomationBattleCafe
             this.__internal__addInfo(sweetData, GameConstants.AlcremieSpins.dayCounterclockwiseAbove5, currentSweetContainer);
 
             currentSweetContainer.appendChild(document.createElement("br"));
-            currentSweetContainer.appendChild(document.createTextNode("Dusk (19:00 → 20:00)"));
+            currentSweetContainer.appendChild(document.createTextNode("Dusk (17:00 → 18:00)"));
             currentSweetContainer.appendChild(document.createElement("br"));
-            this.__internal__addInfo(sweetData, GameConstants.AlcremieSpins.at7Above10, currentSweetContainer);
+            this.__internal__addInfo(sweetData, GameConstants.AlcremieSpins.at5Above10, currentSweetContainer);
 
             currentSweetContainer.appendChild(document.createElement("br"));
-            currentSweetContainer.appendChild(document.createTextNode("Night (19:00 → 5:00)"));
+            currentSweetContainer.appendChild(document.createTextNode("Night (18:00 → 6:00)"));
             currentSweetContainer.appendChild(document.createElement("br"));
             this.__internal__addInfo(sweetData, GameConstants.AlcremieSpins.nightClockwiseBelow5, currentSweetContainer);
             this.__internal__addInfo(sweetData, GameConstants.AlcremieSpins.nightClockwiseAbove5, currentSweetContainer);


### PR DESCRIPTION
The battle café days used to be from 5h to 19h.
Since v0.10.7 they were normalized to be consistent with the rest of the game.
They are now from 6h to 18h.

Additionally, the Dusk time is now at 17h (19h before)

Fixup #216 