### PR TITLE
Focus: Add the Focus on Pokérus cure feature

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@ Pokeclicker-automation aims at automating some recurring tasks that can be a bit
 This script collection does not aim at cheating.
 It will never perform actions that the game would not allow.
 
-Last known compatible pokeclicker version: 0.10.8
+Last known compatible pokeclicker version: 0.10.9
 
 For more details, please refer to the [wiki](../../wiki)
 

--- a/src/ComponentLoader.js
+++ b/src/ComponentLoader.js
@@ -28,6 +28,7 @@ class AutomationComponentLoader
         // From the least dependant, to the most dependent
         this.__addScript("src/lib/Focus/Achievements.js");
         this.__addScript("src/lib/Focus/Quests.js");
+        this.__addScript("src/lib/Focus/PokerusCure.js");
         this.__addScript("src/lib/Utils/Battle.js");
         this.__addScript("src/lib/Utils/Gym.js");
         this.__addScript("src/lib/Utils/LocalStorage.js");

--- a/src/lib/Dungeon.js
+++ b/src/lib/Dungeon.js
@@ -245,7 +245,6 @@ class AutomationDungeon
                 this.__internal__userDefinedPokeballToRestore = null;
 
                 // Set auto-dungeon loop
-                this.__internal__dungeonFightLoop();
                 this.__internal__autoDungeonLoop = setInterval(this.__internal__dungeonFightLoop.bind(this), 50); // Runs every game tick
             }
         }

--- a/src/lib/Farm.js
+++ b/src/lib/Farm.js
@@ -66,8 +66,8 @@ class AutomationFarm
             if (this.__internal__farmingLoop === null)
             {
                 // Set auto-farm loop (run it once right away)
-                this.__internal__farmLoop();
                 this.__internal__farmingLoop = setInterval(this.__internal__farmLoop.bind(this), 10000); // Runs every 10 seconds
+                this.__internal__farmLoop();
             }
         }
         else

--- a/src/lib/Focus.js
+++ b/src/lib/Focus.js
@@ -370,14 +370,14 @@ class AutomationFocus
                 this.__internal__activeFocus =
                     this.__internal__functionalities.filter((functionality) => functionality.id === this.__internal__focusSelectElem.value)[0];
 
-                // First loop run (to avoid waiting too long before the first iteration, in case of long refresh rate)
-                this.__internal__activeFocus.run();
-
                 // Set focus loop if needed
                 if (this.__internal__activeFocus.refreshRateAsMs !== this.__noFunctionalityRefresh)
                 {
                     this.__internal__focusLoop = setInterval(this.__internal__activeFocus.run, this.__internal__activeFocus.refreshRateAsMs);
                 }
+
+                // First loop run (to avoid waiting too long before the first iteration, in case of long refresh rate)
+                this.__internal__activeFocus.run();
             }
         }
         else

--- a/src/lib/Focus.js
+++ b/src/lib/Focus.js
@@ -6,6 +6,7 @@ class AutomationFocus
     // Aliases on the other classes
     static Achievements = AutomationFocusAchievements;
     static Quests = AutomationFocusQuests;
+    static PokerusCure = AutomationFocusPokerusCure;
 
     static Settings = {
                           FeatureEnabled: "Focus-Enabled",
@@ -448,6 +449,7 @@ class AutomationFocus
 
         this.Quests.__registerFunctionalities(this.__internal__functionalities);
         this.Achievements.__registerFunctionalities(this.__internal__functionalities);
+        this.PokerusCure.__registerFunctionalities(this.__internal__functionalities);
 
         this.__internal__addGemsFocusFunctionalities();
     }

--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -61,7 +61,7 @@ class AutomationFocusAchievements
                                                                                           : Automation.Dungeon.InternalModes.None;
 
         Automation.Menu.forceAutomationState(Automation.Gym.Settings.FeatureEnabled, false);
-        App.game.pokeballs.alreadyCaughtSelection = Automation.Focus.__internal__defaultCaughtPokeballSelectElem.value;
+        App.game.pokeballs.alreadyCaughtSelection = Automation.Focus.__defaultCaughtPokeballSelectElem.value;
     }
 
     /**
@@ -126,7 +126,7 @@ class AutomationFocusAchievements
     static __internal__workOnAchievement()
     {
         // Reset any equipped pokeball
-        App.game.pokeballs.alreadyCaughtSelection = Automation.Focus.__internal__defaultCaughtPokeballSelectElem.value;
+        App.game.pokeballs.alreadyCaughtSelection = Automation.Focus.__defaultCaughtPokeballSelectElem.value;
 
         if (this.__internal__currentAchievement.property instanceof RouteKillRequirement)
         {
@@ -152,7 +152,7 @@ class AutomationFocusAchievements
     static __internal__workOnRouteKillRequirement()
     {
         // Equip the Oak item Exp loadout
-        Automation.Focus.__internal__equipLoadout(Automation.Utils.OakItem.Setup.PokemonExp);
+        Automation.Focus.__equipLoadout(Automation.Utils.OakItem.Setup.PokemonExp);
 
         // Move to the selected route
         Automation.Utils.Route.moveToRoute(this.__internal__currentAchievement.property.route, this.__internal__currentAchievement.property.region);

--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -8,7 +8,7 @@ class AutomationFocusAchievements
     \******************************************************************************/
 
     /**
-     * @brief Adds the Achivements functionality to the 'Focus on' list
+     * @brief Adds the Achievements functionality to the 'Focus on' list
      *
      * @param {Array} functionalitiesList: The list to add the functionality to
      */
@@ -75,7 +75,7 @@ class AutomationFocusAchievements
         // Already fighting, nothing to do for now
         if (Automation.Utils.isInInstanceState())
         {
-            // If the quest is not a ClearDungeonRequirement, or if it's completed, no instance should be in progress^M
+            // If the quest is not a ClearDungeonRequirement, or if it's completed, no instance should be in progress
             if ((this.__internal__currentAchievement === null)
                 || ((this.__internal__currentAchievement.property instanceof ClearDungeonRequirement)
                     && this.__internal__currentAchievement.isCompleted()))

--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -44,6 +44,7 @@ class AutomationFocusAchievements
     {
         // Set achievement loop
         this.__internal__achievementLoop = setInterval(this.__internal__focusOnAchievements.bind(this), 1000); // Runs every second
+        this.__internal__focusOnAchievements();
     }
 
     /**

--- a/src/lib/Focus/PokerusCure.js
+++ b/src/lib/Focus/PokerusCure.js
@@ -1,0 +1,228 @@
+/**
+ * @class The AutomationFocusPokerusCure regroups the 'Focus on' button's 'Pokérus cure' functionalities
+ */
+class AutomationFocusPokerusCure
+{
+    /******************************************************************************\
+    |***    Focus specific members, should only be used by focus sub-classes    ***|
+    \******************************************************************************/
+
+    /**
+     * @brief Adds the Pokérus cure functionality to the 'Focus on' list
+     *
+     * @param {Array} functionalitiesList: The list to add the functionality to
+     */
+    static __registerFunctionalities(functionalitiesList)
+    {
+        this.__internal__buildPokerusRouteList();
+
+        const isUnlockedCallback = function (){ return App.game.keyItems.hasKeyItem(KeyItemType.Pokerus_virus); };
+
+        functionalitiesList.push(
+            {
+                id: "PokerusCure",
+                name: "Pokérus cure",
+                tooltip: "Hunts for pokémons that are infected by the pokérus"
+                       + Automation.Menu.TooltipSeparator
+                       + "Pokémons get resistant to the pokérus once they reach 50 EV.\n"
+                       + "This focus will catch pokémons one route where infected\n"
+                       + "pokémons can be caught to increase their EV.",
+                run: function (){ this.__internal__start(); }.bind(this),
+                stop: function (){ this.__internal__stop(); }.bind(this),
+                isUnlocked: isUnlockedCallback,
+                refreshRateAsMs: Automation.Focus.__noFunctionalityRefresh
+            });
+    }
+
+    /*********************************************************************\
+    |***    Internal members, should never be used by other classes    ***|
+    \*********************************************************************/
+
+    static __internal__pokerusCureLoop = null;
+    static __internal__pokerusRouteData = [];
+    static __internal__pokeballToRestore = null;
+
+    static __internal__currentRouteData = null;
+
+    /**
+     * @brief Starts the achievements automation
+     */
+    static __internal__start()
+    {
+        // Set achievement loop
+        this.__internal__pokerusCureLoop = setInterval(this.__internal__focusOnPokerusCure.bind(this), 10000); // Runs every 10 seconds
+        this.__internal__focusOnPokerusCure();
+    }
+
+    /**
+     * @brief Stops the achievements automation
+     */
+    static __internal__stop()
+    {
+        this.__internal__currentRouteData = null;
+
+        // Unregister the loop
+        clearInterval(this.__internal__pokerusCureLoop);
+        this.__internal__pokerusCureLoop = null;
+
+        // Restore pokéball used to catch
+        if (this.__internal__pokeballToRestore != null)
+        {
+            App.game.pokeballs.alreadyCaughtContagiousSelection = this.__internal__pokeballToRestore;
+            this.__internal__pokeballToRestore = null;
+        }
+    }
+
+    /**
+     * @brief The achievement main loop
+     *
+     * @note If the user is in a state in which he cannot be moved, the feature is automatically disabled.
+     */
+    static __internal__focusOnPokerusCure()
+    {
+        // Already fighting, nothing to do for now
+        if (Automation.Utils.isInInstanceState())
+        {
+            Automation.Focus.__ensureNoInstanceIsInProgress();
+            return;
+        }
+
+        // Choose a new route, if needed
+        if ((this.__internal__currentRouteData == null)
+            || !this.__internal__doesAnyPokemonNeedCuring(this.__internal__currentRouteData.route, true))
+        {
+            this.__internal__setNextPokerusRoute();
+        }
+
+        if (this.__internal__currentRouteData == null)
+        {
+            // No more routes available, stop the focus
+            Automation.Menu.forceAutomationState(Automation.Focus.Settings.FeatureEnabled, false);
+            Automation.Notifications.sendWarningNotif("No more route available to cure pokémon from pokérus.\nTurning the feature off", "Focus");
+
+            return;
+        }
+
+        // Ensure that the player has some balls available
+        if (!Automation.Focus.__ensurePlayerHasEnoughBalls(Automation.Focus.__pokeballToUseSelectElem.value))
+        {
+            // Restore pokéball used to catch
+            if (this.__internal__pokeballToRestore != null)
+            {
+                App.game.pokeballs.alreadyCaughtContagiousSelection = this.__internal__pokeballToRestore;
+                this.__internal__pokeballToRestore = null;
+            }
+
+            return;
+        }
+
+        // Equip the Oak item catch loadout
+        Automation.Focus.__equipLoadout(Automation.Utils.OakItem.Setup.PokemonCatch);
+
+        // Equip an "Already caught contagious" pokeball
+        this.__internal__pokeballToRestore = App.game.pokeballs.alreadyCaughtContagiousSelection;
+        App.game.pokeballs.alreadyCaughtContagiousSelection = Automation.Focus.__pokeballToUseSelectElem.value;
+
+        // Move to the best route
+        Automation.Utils.Route.moveToRoute(this.__internal__currentRouteData.route.number, this.__internal__currentRouteData.route.region);
+    }
+
+    /**
+     * @brief Gets the next route to cure pokémon from pokérus
+     */
+    static __internal__setNextPokerusRoute()
+    {
+        // Remove the current route from the list if completed
+        if ((this.__internal__currentRouteData != null)
+            && !this.__internal__doesAnyPokemonNeedCuring(this.__internal__currentRouteData.route))
+        {
+            const index = this.__internal__pokerusRouteData.indexOf(this.__internal__currentRouteData);
+            this.__internal__pokerusRouteData.splice(index, 1);
+        }
+
+        // Set the next best route
+        this.__internal__currentRouteData = this.__internal__pokerusRouteData.find(
+            (data) => this.__internal__doesAnyPokemonNeedCuring(data.route), this);
+    }
+
+    /**
+     * @brief Builds the internal list of route with at least one infected pokémon
+     */
+    static __internal__buildPokerusRouteList()
+    {
+        for (const route of Routes.regionRoutes)
+        {
+            if (this.__internal__doesAnyPokemonNeedCuring(route))
+            {
+                this.__internal__pokerusRouteData.push({ route });
+            }
+        }
+    }
+
+    /**
+     * @brief Checks if any pokémon from the given @p route needs to be cured
+     *
+     * @param route: The route to check
+     * @param {boolean} considerOnlyAvailableInfectedPokemons: Whether only currently available and infected pokémon should be considered
+     *
+     * @returns True if every pokémons are cured, false otherwise
+     */
+    static __internal__doesAnyPokemonNeedCuring(route, considerOnlyAvailableInfectedPokemons = false)
+    {
+        const pokemonList = considerOnlyAvailableInfectedPokemons ? RouteHelper.getAvailablePokemonList(route.number, route.region)
+                                                                  : this.__internal__getEveryPokemonForRoute(route);
+
+        for (const pokemonName of pokemonList)
+        {
+            const pokemon = App.game.party.getPokemonByName(pokemonName);
+
+            // A pokémon is a candidate to catch if
+            //  - It's not already cured
+            //  - It's infected or we are listing every uncured pokemon
+            const isCandidatePokemon = (pokemon?.pokerus != GameConstants.Pokerus.Resistant)
+                                    && (!considerOnlyAvailableInfectedPokemons || (pokemon?.pokerus == GameConstants.Pokerus.Infected));
+
+            if (isCandidatePokemon)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @brief Gets the list of possible pokémon for a route, regardless of their conditions
+     *
+     * @param route: The route to get the pokémon of
+     *
+     * @returns The list of pokémon
+     */
+    static __internal__getEveryPokemonForRoute(route)
+    {
+        // Inspired from https://github.com/pokeclicker/pokeclicker/blob/f7d8db69c219a1a1e47be919f4b9b1f0de8cde9e/src/scripts/wildBattle/RouteHelper.ts#L15-L39
+
+        const possiblePokemons = Routes.getRoute(route.region, route.number)?.pokemon;
+        if (!possiblePokemons)
+        {
+            return ['Rattata'];
+        }
+
+        // Land Pokémon
+        let pokemonList = possiblePokemons.land;
+
+        // Water Pokémon
+        pokemonList = pokemonList.concat(possiblePokemons.water);
+
+        // Headbutt Pokémon
+        pokemonList = pokemonList.concat(possiblePokemons.headbutt);
+
+        // Special requirement Pokémon
+        pokemonList = pokemonList.concat(...possiblePokemons.special.map(p => p.pokemon));
+
+        // Filter duplicate entries
+        pokemonList.filter((item, index) => pokemonList.indexOf(item) === index);
+
+        return pokemonList;
+    }
+}

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -160,6 +160,7 @@ class AutomationFocusQuests
         {
             // Set auto-quest loop
             this.__internal__autoQuestLoop = setInterval(this.__internal__questLoop.bind(this), 1000); // Runs every second
+            this.__internal__questLoop();
 
             // Disable other modes button
             const disableReason = "The 'Focus on Quests' feature is enabled";

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -235,7 +235,7 @@ class AutomationFocusQuests
         Automation.Menu.setButtonDisabledState(Automation.Underground.Settings.FeatureEnabled, false);
 
         // Restore the ball to catch default value
-        this.__internal__selectBallToCatch(Automation.Focus.__internal__defaultCaughtPokeballSelectElem.value);
+        this.__internal__selectBallToCatch(Automation.Focus.__defaultCaughtPokeballSelectElem.value);
     }
 
     /**
@@ -248,7 +248,7 @@ class AutomationFocusQuests
     static __internal__questLoop()
     {
         // Make sure to always have some balls to catch pokemons
-        this.__internal__tryBuyBallIfUnderThreshold(Automation.Focus.__internal__pokeballToUseSelectElem.value, 10);
+        this.__internal__tryBuyBallIfUnderThreshold(Automation.Focus.__pokeballToUseSelectElem.value, 10);
 
         // Disable best route if needed
         Automation.Menu.forceAutomationState("bestRouteClickEnabled", false);
@@ -392,7 +392,7 @@ class AutomationFocusQuests
         if (Automation.Utils.isInstanceOf(quest, "CapturePokemonsQuest")
             || Automation.Utils.isInstanceOf(quest, "GainTokensQuest"))
         {
-            this.__internal__workOnUsePokeballQuest(Automation.Focus.__internal__pokeballToUseSelectElem.value);
+            this.__internal__workOnUsePokeballQuest(Automation.Focus.__pokeballToUseSelectElem.value);
         }
         else if (Automation.Utils.isInstanceOf(quest, "CapturePokemonTypesQuest"))
         {
@@ -425,12 +425,12 @@ class AutomationFocusQuests
         else // Other type of quest don't need much
         {
             // Disable catching pokemons if enabled
-            this.__internal__selectBallToCatch(Automation.Focus.__internal__defaultCaughtPokeballSelectElem.value);
+            this.__internal__selectBallToCatch(Automation.Focus.__defaultCaughtPokeballSelectElem.value);
 
             if (currentQuests.some((quest) => Automation.Utils.isInstanceOf(quest, "CatchShiniesQuest")))
             {
                 // Buy some ball to be prepared
-                this.__internal__tryBuyBallIfUnderThreshold(Automation.Focus.__internal__pokeballToUseSelectElem.value, 10);
+                this.__internal__tryBuyBallIfUnderThreshold(Automation.Focus.__pokeballToUseSelectElem.value, 10);
                 this.__internal__equipOptimizedLoadout(Automation.Utils.OakItem.Setup.PokemonCatch);
             }
             else if (currentQuests.some((quest) => Automation.Utils.isInstanceOf(quest, "GainMoneyQuest")))
@@ -504,7 +504,7 @@ class AutomationFocusQuests
     static __internal__workOnCapturePokemonTypesQuest(quest)
     {
         // Add a pokeball to the Caught type and set the PokemonCatch setup
-        let hasBalls = this.__internal__selectBallToCatch(Automation.Focus.__internal__pokeballToUseSelectElem.value);
+        let hasBalls = this.__internal__selectBallToCatch(Automation.Focus.__pokeballToUseSelectElem.value);
         this.__internal__equipOptimizedLoadout(Automation.Utils.OakItem.Setup.PokemonCatch);
 
         if (hasBalls)
@@ -530,11 +530,11 @@ class AutomationFocusQuests
         // If we don't have enough tokens, go farm some
         if (TownList[quest.dungeon].dungeon.tokenCost > App.game.wallet.currencies[Currency.dungeonToken]())
         {
-            this.__internal__workOnUsePokeballQuest(Automation.Focus.__internal__pokeballToUseSelectElem.value);
+            this.__internal__workOnUsePokeballQuest(Automation.Focus.__pokeballToUseSelectElem.value);
             return;
         }
 
-        this.__internal__selectBallToCatch(Automation.Focus.__internal__defaultCaughtPokeballSelectElem.value);
+        this.__internal__selectBallToCatch(Automation.Focus.__defaultCaughtPokeballSelectElem.value);
 
         // Move to dungeon if needed
         if (!Automation.Utils.Route.isPlayerInTown(quest.dungeon))
@@ -597,7 +597,7 @@ class AutomationFocusQuests
      */
     static __internal__workOnDefeatPokemonsQuest(quest)
     {
-        this.__internal__selectBallToCatch(Automation.Focus.__internal__defaultCaughtPokeballSelectElem.value);
+        this.__internal__selectBallToCatch(Automation.Focus.__defaultCaughtPokeballSelectElem.value);
         this.__internal__equipOptimizedLoadout(Automation.Utils.OakItem.Setup.PokemonExp);
 
         Automation.Utils.Route.moveToRoute(quest.route, quest.region);
@@ -612,10 +612,10 @@ class AutomationFocusQuests
      */
     static __internal__workOnGainGemsQuest(quest)
     {
-        this.__internal__selectBallToCatch(Automation.Focus.__internal__defaultCaughtPokeballSelectElem.value);
+        this.__internal__selectBallToCatch(Automation.Focus.__defaultCaughtPokeballSelectElem.value);
         this.__internal__equipOptimizedLoadout(Automation.Utils.OakItem.Setup.PokemonExp);
 
-        Automation.Focus.__internal__goToBestGymOrRouteForGem(quest.type);
+        Automation.Focus.__goToBestGymOrRouteForGem(quest.type);
     }
 
     /**
@@ -630,14 +630,14 @@ class AutomationFocusQuests
     {
         if (quest.item == OakItemType.Magic_Ball)
         {
-            this.__internal__workOnUsePokeballQuest(Automation.Focus.__internal__pokeballToUseSelectElem.value);
+            this.__internal__workOnUsePokeballQuest(Automation.Focus.__pokeballToUseSelectElem.value);
         }
         else
         {
             this.__internal__equipOptimizedLoadout(Automation.Utils.OakItem.Setup.PokemonExp);
 
             // Go kill some pokemon
-            this.__internal__selectBallToCatch(Automation.Focus.__internal__defaultCaughtPokeballSelectElem.value);
+            this.__internal__selectBallToCatch(Automation.Focus.__defaultCaughtPokeballSelectElem.value);
             Automation.Utils.Route.moveToBestRouteForExp();
         }
     }
@@ -724,7 +724,7 @@ class AutomationFocusQuests
             {
                 // No more balls, go farm to buy some
                 App.game.pokeballs.alreadyCaughtSelection = GameConstants.Pokeball.None;
-                Automation.Focus.__internal__equipLoadout(Automation.Utils.OakItem.Setup.Money);
+                Automation.Focus.__equipLoadout(Automation.Utils.OakItem.Setup.Money);
 
                 let bestGym = Automation.Utils.Gym.findBestGymForMoney();
 
@@ -921,7 +921,7 @@ class AutomationFocusQuests
             }
         }
 
-        Automation.Focus.__internal__equipLoadout(resultLoadout);
+        Automation.Focus.__equipLoadout(resultLoadout);
     }
 
     /**

--- a/src/lib/Hatchery.js
+++ b/src/lib/Hatchery.js
@@ -847,7 +847,7 @@ class AutomationHatchery
             return sortedPokemonCandidates;
         }
 
-        // Both Contagious and Cured pokemon spread the Pokérus
+        // Both Contagious and Resistant pokemon spread the Pokérus
         const contagiousPokemons = sortedPokemonCandidates.filter(pokemon => (pokemon?.pokerus === GameConstants.Pokerus.Contagious)
                                                                           || (pokemon?.pokerus === GameConstants.Pokerus.Resistant));
         const availableEggSlot = App.game.breeding.eggList.reduce((count, egg) => count + (egg().isNone() ? 1 : 0), 0)

--- a/src/lib/Hatchery.js
+++ b/src/lib/Hatchery.js
@@ -90,6 +90,7 @@ class AutomationHatchery
             {
                 // Set auto-hatchery loop
                 this.__internal__autoHatcheryLoop = setInterval(this.__internal__hatcheryLoop.bind(this), 1000); // Runs every second
+                this.__internal__hatcheryLoop();
             }
         }
         else

--- a/src/lib/Items.js
+++ b/src/lib/Items.js
@@ -158,6 +158,7 @@ class AutomationItems
             {
                 // Set auto-upgrade loop
                 this.__internal__autoOakUpgradeLoop = setInterval(this.__internal__oakItemUpgradeLoop.bind(this), 10000); // Runs every 10 seconds
+                this.__internal__oakItemUpgradeLoop();
             }
         }
         else
@@ -197,6 +198,7 @@ class AutomationItems
             {
                 // Set auto-upgrade loop
                 this.__internal__autoGemUpgradeLoop = setInterval(this.__internal__gemUpgradeLoop.bind(this), 10000); // Runs every 10 seconds
+                this.__internal__gemUpgradeLoop();
             }
         }
         else

--- a/src/lib/Shop.js
+++ b/src/lib/Shop.js
@@ -168,8 +168,8 @@ class AutomationShop
         {
             if (this.__internal__shopLoop === null)
             {
-                this.__internal__shop(); // Run once immediately
                 this.__internal__shopLoop = setInterval(this.__internal__shop.bind(this), 10000); // Then, runs every 10s
+                this.__internal__shop(); // Run once immediately
             }
         }
         else

--- a/src/lib/Underground.js
+++ b/src/lib/Underground.js
@@ -62,6 +62,7 @@ class AutomationUnderground
             {
                 // Set auto-mine loop
                 this.__internal__autoMiningLoop = setInterval(this.__internal__miningLoop.bind(this), 10000); // Runs every 10 seconds
+                this.__internal__miningLoop();
             }
             if (this.__internal__autoSellingLoop === null)
             {


### PR DESCRIPTION
This feature will automatically move to routes were there is at least
one infected pokémon that is not resistant to the pokérus.
It will equip the set pokémon catching pokéball and catch every
pokémon on that route until the full route is resistant.
It will then move to the next route.

---

Misc: improve interval delay

Always call the method once for long delay to avoid the
feature lag impression.

Always call the method AFTER the interval setting to avoid
side effects.

---
Focus: Fixup some element naming to match accessibility

Some internal data/function were accessed by other focus sub-classes.

The __internal part of those element was removed

Partially adresses #122  