### PR TITLE
Dungeon: Disable the flash strategy

### DIFF
--- a/src/lib/Dungeon.js
+++ b/src/lib/Dungeon.js
@@ -437,14 +437,7 @@ class AutomationDungeon
             }
 
             // If the flashight is unlocked, use it to avoid fighting every encounters
-            if (DungeonRunner.map.flash)
-            {
-                this.__internal__handleFlashPathing();
-            }
-            else
-            {
-                this.__internal__handleNormalPathing();
-            }
+            this.__internal__handleNormalPathing();
         }
         // Else hide the menu and turn off the feature, if we're not in the dungeon anymore
         else


### PR DESCRIPTION
The v0.10.9 introduced a new flash tier mechanics that broke the script. 
The flash strategy is disabled for now, it will be fixed in a later commit.

Fixes #231 