### PR TITLE
Dungeon: Don't stop anymore on user action when having the flash light

### DIFF
--- a/src/lib/Dungeon.js
+++ b/src/lib/Dungeon.js
@@ -687,12 +687,13 @@ class AutomationDungeon
 
         if (!this.__internal__isFirstMove)
         {
+            // Consider that an action occured is there is any not-visited cell in the room
             this.__internal__playerActionOccured = this.__internal__playerActionOccured
                                                 || !DungeonRunner.map.board()[currentFloor].every((row) => row.every((tile) => tile.isVisited));
         }
 
         // Every tile is visible, but the boss was not found (it is inaccessible). Check all squares
-        if (this.__internal__floorEndPosition == null && DungeonRunner.map.board()[currentFloor].flat().every(tile => tile.isVisible))
+        if ((this.__internal__floorEndPosition == null) && DungeonRunner.map.board()[currentFloor].flat().every(tile => tile.isVisible))
         {
             this.__internal__isRecovering = true;
         }
@@ -702,6 +703,9 @@ class AutomationDungeon
         {
             this.__internal__moveToCell(startingTile);
         }
+
+        // Don't bother with player action if the player got the flash-light
+        this.__internal__playerActionOccured &= !DungeonRunner.map.flash;
     }
 
     /**


### PR DESCRIPTION
To avoid breaking the regular dungeon strategy, user action had to be detected to ensure proper dungeon completion.

In case the user has the flash-light with at least the second update (introduced in v0.10.9), the user action detection can be triggered when the player did not do anything.
This check is not relevant and have been removed in such case.

Fixes #235 