### PR TITLE
Trivia: Filter locked mega-evolution listing

### DIFF
--- a/src/lib/Trivia.js
+++ b/src/lib/Trivia.js
@@ -498,6 +498,19 @@ class AutomationTrivia
         {
             for (const data of PartyController.getStoneEvolutionsCaughtData(pokemon.id, GameConstants.StoneType[stone]))
             {
+                // Some evolution might be locked with the folowing reason (as of v0.10.9):
+                //  - You must be in the <Region name>
+                //  - Your local part of the day must be <Time of day>
+                //  - Can't mega evolve <Pokémon name> yet
+                if (data.locked)
+                {
+                    // Only filter the mega-evolvable requirements
+                    if (data.lockHint.startsWith("Can't mega evolve"))
+                    {
+                        continue;
+                    }
+                }
+
                 hasCandidate |= (data.status == 0);
             }
         }


### PR DESCRIPTION
The v0.10.9 started listing the stone evolution that have unmet requirements.
To avoid bothering the player with such info, the mega-evolution ones are now filtered.

Fixes #229