### PR TITLE
Dungeon/Focus: Equip ball for contagious pokémon as well

### DIFF
--- a/src/lib/Dungeon.js
+++ b/src/lib/Dungeon.js
@@ -56,6 +56,7 @@ class AutomationDungeon
     static __internal__dungeonFightButton = null;
     static __internal__dungeonBossCatchPokeballSelectElem = null;
     static __internal__userDefinedPokeballToRestore = null;
+    static __internal__userDefinedContagiousPokeballToRestore = null;
 
     static __internal__isShinyCatchStopMode = false;
     static __internal__floorEndPosition = null;
@@ -165,7 +166,9 @@ class AutomationDungeon
 
         // Add the boss catch option
         const bossCatchPokeballTooltip = "Defines which pokeball will be equipped to catch\n"
-                                       + "pokémons, before fighting the dungeon boss";
+                                       + "pokémons, before fighting the dungeon boss"
+                                       + Automation.Menu.TooltipSeparator
+                                       + "Selecting 'None' will leave the in-game value unchanged";
         this.__internal__dungeonBossCatchPokeballSelectElem =
             Automation.Menu.addPokeballList("selectedDungeonBossCatchPokeball",
                                             dungeonSettingsPanel,
@@ -243,6 +246,7 @@ class AutomationDungeon
                 // Reset the currently used pokeball
                 // (as the player might switch the ball during the dungeon process, the value should only be saved right before the boss fight)
                 this.__internal__userDefinedPokeballToRestore = null;
+                this.__internal__userDefinedContagiousPokeballToRestore = null;
 
                 // Set auto-dungeon loop
                 this.__internal__autoDungeonLoop = setInterval(this.__internal__dungeonFightLoop.bind(this), 50); // Runs every game tick
@@ -258,6 +262,7 @@ class AutomationDungeon
             if (this.__internal__userDefinedPokeballToRestore != null)
             {
                 App.game.pokeballs.alreadyCaughtSelection = this.__internal__userDefinedPokeballToRestore;
+                Automation.Utils.Battle.setAlreadyCaughtContagiousSelection(this.__internal__userDefinedContagiousPokeballToRestore);
             }
         }
     }
@@ -323,6 +328,7 @@ class AutomationDungeon
                 if (this.__internal__userDefinedPokeballToRestore != null)
                 {
                     App.game.pokeballs.alreadyCaughtSelection = this.__internal__userDefinedPokeballToRestore;
+                    Automation.Utils.Battle.setAlreadyCaughtContagiousSelection(this.__internal__userDefinedContagiousPokeballToRestore);
                 }
             }
         }
@@ -421,8 +427,10 @@ class AutomationDungeon
                         {
                             // Save the currently used pokeball
                             this.__internal__userDefinedPokeballToRestore = App.game.pokeballs.alreadyCaughtSelection;
+                            this.__internal__userDefinedContagiousPokeballToRestore = App.game.pokeballs.alreadyCaughtContagiousSelection;
 
                             App.game.pokeballs.alreadyCaughtSelection = ballToCatchBoss;
+                            Automation.Utils.Battle.setAlreadyCaughtContagiousSelection(ballToCatchBoss);
                         }
 
                         DungeonRunner.startBossFight();

--- a/src/lib/Focus.js
+++ b/src/lib/Focus.js
@@ -98,6 +98,7 @@ class AutomationFocus
 
         // Equip an "Already caught" pokeball
         App.game.pokeballs.alreadyCaughtSelection = this.__pokeballToUseSelectElem.value;
+        Automation.Utils.Battle.setAlreadyCaughtContagiousSelection(this.__pokeballToUseSelectElem.value);
 
         // Move to the highest unlocked route
         Automation.Utils.Route.moveToHighestDungeonTokenIncomeRoute(this.__pokeballToUseSelectElem.value);
@@ -204,6 +205,15 @@ class AutomationFocus
         }
 
         return true;
+    }
+
+    /**
+     * @brief Resets the player's ball selection according to the settings
+     */
+    static __resetBallSelection()
+    {
+        App.game.pokeballs.alreadyCaughtSelection = this.__defaultCaughtPokeballSelectElem.value;
+        Automation.Utils.Battle.setAlreadyCaughtContagiousSelection(this.__defaultContagiousCaughtPokeballSelectElem.value);
     }
 
     /*********************************************************************\
@@ -497,8 +507,7 @@ class AutomationFocus
                 stop: function ()
                     {
                         Automation.Menu.forceAutomationState(Automation.Gym.Settings.FeatureEnabled, false);
-                        App.game.pokeballs.alreadyCaughtSelection = this.__defaultCaughtPokeballSelectElem.value;
-                        App.game.pokeballs.alreadyCaughtContagiousSelection = this.__defaultContagiousCaughtPokeballSelectElem.value;
+                        this.__resetBallSelection();
                     }.bind(this),
                 refreshRateAsMs: 3000 // Refresh every 3s
             });

--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -94,6 +94,7 @@ class AutomationFocusAchievements
 
         Automation.Menu.forceAutomationState(Automation.Gym.Settings.FeatureEnabled, false);
         App.game.pokeballs.alreadyCaughtSelection = Automation.Focus.__defaultCaughtPokeballSelectElem.value;
+        App.game.pokeballs.alreadyCaughtContagiousSelection = Automation.Focus.__defaultContagiousCaughtPokeballSelectElem.value;
     }
 
     /**
@@ -159,6 +160,7 @@ class AutomationFocusAchievements
     {
         // Reset any equipped pokeball
         App.game.pokeballs.alreadyCaughtSelection = Automation.Focus.__defaultCaughtPokeballSelectElem.value;
+        App.game.pokeballs.alreadyCaughtContagiousSelection = Automation.Focus.__defaultContagiousCaughtPokeballSelectElem.value;
 
         if (Automation.Utils.isInstanceOf(this.__internal__currentAchievement.property, "RouteKillRequirement"))
         {

--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -93,8 +93,9 @@ class AutomationFocusAchievements
                                                                                           : Automation.Dungeon.InternalModes.None;
 
         Automation.Menu.forceAutomationState(Automation.Gym.Settings.FeatureEnabled, false);
-        App.game.pokeballs.alreadyCaughtSelection = Automation.Focus.__defaultCaughtPokeballSelectElem.value;
-        App.game.pokeballs.alreadyCaughtContagiousSelection = Automation.Focus.__defaultContagiousCaughtPokeballSelectElem.value;
+
+        // Restore the ball to catch default value
+        Automation.Focus.__resetBallSelection();
     }
 
     /**
@@ -159,8 +160,7 @@ class AutomationFocusAchievements
     static __internal__workOnAchievement()
     {
         // Reset any equipped pokeball
-        App.game.pokeballs.alreadyCaughtSelection = Automation.Focus.__defaultCaughtPokeballSelectElem.value;
-        App.game.pokeballs.alreadyCaughtContagiousSelection = Automation.Focus.__defaultContagiousCaughtPokeballSelectElem.value;
+        Automation.Focus.__resetBallSelection();
 
         if (Automation.Utils.isInstanceOf(this.__internal__currentAchievement.property, "RouteKillRequirement"))
         {

--- a/src/lib/Focus/PokerusCure.js
+++ b/src/lib/Focus/PokerusCure.js
@@ -68,7 +68,7 @@ class AutomationFocusPokerusCure
         // Restore pokéball used to catch
         if (this.__internal__pokeballToRestore != null)
         {
-            App.game.pokeballs.alreadyCaughtContagiousSelection = this.__internal__pokeballToRestore;
+            Automation.Utils.Battle.setAlreadyCaughtContagiousSelection(this.__internal__pokeballToRestore);
             this.__internal__pokeballToRestore = null;
         }
     }
@@ -109,7 +109,7 @@ class AutomationFocusPokerusCure
             // Restore pokéball used to catch
             if (this.__internal__pokeballToRestore != null)
             {
-                App.game.pokeballs.alreadyCaughtContagiousSelection = this.__internal__pokeballToRestore;
+                Automation.Utils.Battle.setAlreadyCaughtContagiousSelection(this.__internal__pokeballToRestore);
                 this.__internal__pokeballToRestore = null;
             }
 
@@ -121,7 +121,7 @@ class AutomationFocusPokerusCure
 
         // Equip an "Already caught contagious" pokeball
         this.__internal__pokeballToRestore = App.game.pokeballs.alreadyCaughtContagiousSelection;
-        App.game.pokeballs.alreadyCaughtContagiousSelection = Automation.Focus.__pokeballToUseSelectElem.value;
+        Automation.Utils.Battle.setAlreadyCaughtContagiousSelection(Automation.Focus.__pokeballToUseSelectElem.value);
 
         // Move to the best route
         Automation.Utils.Route.moveToRoute(this.__internal__currentRouteData.route.number, this.__internal__currentRouteData.route.region);

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -236,7 +236,8 @@ class AutomationFocusQuests
         Automation.Menu.setButtonDisabledState(Automation.Underground.Settings.FeatureEnabled, false);
 
         // Restore the ball to catch default value
-        this.__internal__selectBallToCatch(Automation.Focus.__defaultCaughtPokeballSelectElem.value);
+        App.game.pokeballs.alreadyCaughtSelection = Automation.Focus.__defaultCaughtPokeballSelectElem.value;
+        App.game.pokeballs.alreadyCaughtContagiousSelection = Automation.Focus.__defaultContagiousCaughtPokeballSelectElem.value;
     }
 
     /**

--- a/src/lib/Utils/Battle.js
+++ b/src/lib/Utils/Battle.js
@@ -202,6 +202,22 @@ class AutomationUtilsBattle
         return worstAtk;
     }
 
+    /**
+     * @brief Only sets the already caught pokéball if the player has unlocked the feature in-game
+     *
+     * @param pokeballType: The pokéball type to set
+     */
+    static setAlreadyCaughtContagiousSelection(pokeballType)
+    {
+        if (App.game.keyItems.hasKeyItem(KeyItemType.Pokerus_virus))
+        {
+            App.game.pokeballs.alreadyCaughtContagiousSelection = pokeballType;
+
+            // Don't check the condition next time
+            this.setAlreadyCaughtContagiousSelection = function(type) { App.game.pokeballs.alreadyCaughtContagiousSelection = type; };
+        }
+    }
+
     /*********************************************************************\
     |***    Internal members, should never be used by other classes    ***|
     \*********************************************************************/


### PR DESCRIPTION
The contagious pokémon ball needs to be set as well as the already
caught pokémon one.
It's now the case.

---

Add a setting for already caught contagious ball to use

Since the introduction, in-game, of the already caught contagious
pokémon pokéball selection, the user could want to restore different
ball for each cases.

Fixes #255