### PR TITLE
Farm: Add floating panel to the in-game modal

### DIFF
--- a/src/lib/BattleCafe.js
+++ b/src/lib/BattleCafe.js
@@ -26,7 +26,6 @@ class AutomationBattleCafe
     \*********************************************************************/
 
     static __internal__battleCafeInGameModal = null;
-    static __internal__battleCafePanel = null;
     static __internal__battleCafeSweetContainers = [];
     static __internal__currentlyVisibleSweet = null;
     static __internal__caughtPokemonIndicators = new Map();
@@ -42,7 +41,6 @@ class AutomationBattleCafe
         let battleCafeTitle = '☕ Battle Café ☕';
         const battleCafeContainer =
             Automation.Menu.addFloatingCategory("automationBattleCafe", battleCafeTitle, this.__internal__battleCafeInGameModal);
-        this.__internal__battleCafePanel = battleCafeContainer.parentElement;
 
         this.__internal__addInfo(null, -1, battleCafeContainer);
 

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -114,6 +114,32 @@ class AutomationMenu
         // Doing so will automatically hide/show it at the same time as the targeted modal
         ingameModal.appendChild(container);
 
+        // Initialize the floating panel resize observer, if needed
+        if (this.__internal__floatingPanelResizeObserver == null)
+        {
+            // Add a resize observer that updates the floating panel top property so it will always be positionned correctly
+            this.__internal__floatingPanelResizeObserver = new ResizeObserver(function(entries)
+                {
+                    for (const entry of entries)
+                    {
+                        const panelDiv = entry.target;
+
+                        // When the in-game modal is hidden, the div size will be 0
+                        if (panelDiv.offsetHeight == 0)
+                        {
+                            // Don't compute
+                            return;
+                        }
+
+                        // Position it at least 30px and at most 200px from the top, with at least a 30px bottom margin to match the in-game ones
+                        panelDiv.style.top = `max(30px, min(200px, 100vh - ${panelDiv.offsetHeight}px - 30px))`;
+                    }
+                });
+        }
+
+        // Add the new category to the observer
+        this.__internal__floatingPanelResizeObserver.observe(container);
+
         return contentDiv;
     }
 
@@ -819,6 +845,7 @@ class AutomationMenu
     \*********************************************************************/
 
     static __internal__automationContainer = null;
+    static __internal__floatingPanelResizeObserver = null;
     static __internal__lockedBalls = [];
     static __internal__pokeballListElems = [];
 
@@ -1005,8 +1032,7 @@ class AutomationMenu
             }
             .automationFloatingCategory
             {
-                top: 50%;
-                transform: translateY(-50%);
+                top: 50px;
                 left: calc(50% + 400px);
                 border-top-left-radius: 0px;
                 border-bottom-left-radius: 0px;

--- a/src/lib/Underground.js
+++ b/src/lib/Underground.js
@@ -454,7 +454,7 @@ class AutomationUnderground
      *    - If the item is revealed (at least one tile is revealed)
      *    - The status of each tile of the item:
      *        - Its x and y coordinates
-     *        - Wether it's revealed
+     *        - Whether it's revealed
      *        - How many layers it's covered with
      *
      * @returns The gathered information

--- a/src/lib/Utils/Gym.js
+++ b/src/lib/Utils/Gym.js
@@ -203,7 +203,7 @@ class AutomationUtilsGym
                 {
                     let gemTypeData = this.__internal__gymGemTypeMap.get(type);
 
-                    if ((gemTypeData.length == 0) || gemTypeData[gemTypeData.length - 1].gymName != gymName)
+                    if ((gemTypeData.length == 0) || gemTypeData.at(-1).gymName != gymName)
                     {
                         let gymTown = gym.town;
                         // If a ligue champion is the target, the gymTown points to the champion instead of the town
@@ -229,7 +229,7 @@ class AutomationUtilsGym
                     }
                     else
                     {
-                        gemTypeData[gemTypeData.length - 1].pokemonMathingType += 1;
+                        gemTypeData.at(-1).pokemonMathingType += 1;
                     }
                 }
             }

--- a/tst/stubs/document.browser.stub.js
+++ b/tst/stubs/document.browser.stub.js
@@ -1,0 +1,15 @@
+function __test__stubs__getHTMLElementStub()
+{
+    return {
+        innerHTML: "",
+        style: {},
+        appendChild: function() {}
+    };
+}
+
+// Stub of the browser document object that does nothing
+document =
+{
+    createTextNode: function() { return __test__stubs__getHTMLElementStub(); },
+    createElement: function() { return __test__stubs__getHTMLElementStub(); }
+};

--- a/tst/tests/Farm/UnlockStrategies.test.in.js
+++ b/tst/tests/Farm/UnlockStrategies.test.in.js
@@ -1,5 +1,8 @@
 import "tst/utils/tests.utils.js";
 
+// Browser document object stub
+import "tst/stubs/document.browser.stub.js";
+
 // Import pokéclicker App
 import "tst/imports/Pokeclicker.import.js";
 
@@ -39,6 +42,10 @@ class Automation
         static Finalize = 1;
     };
 }
+
+// Set a stub object for the tests
+Automation.Farm.__internal__contentFloatingContainer = __test__stubs__getHTMLElementStub();
+Automation.Farm.__internal__contentFloatingContentContainer = __test__stubs__getHTMLElementStub();
 
 // Disable warning notifications
 Automation.Notifications.sendWarningNotif = function() {};
@@ -218,11 +225,11 @@ function checkMutationLayoutRotation(expectedConfig, expectedOrder)
         }
         else if (currentBerryTime != lastBerryTime)
         {
-            berryPlantOrder.push([...berryPlantOrder[berryPlantOrder.length - 1]]);
+            berryPlantOrder.push([...berryPlantOrder.at(-1)]);
         }
         lastBerryTime = currentBerryTime;
 
-        berryPlantOrder[berryPlantOrder.length - 1].push(berryType);
+        berryPlantOrder.at(-1).push(berryType);
     }
 
     const targetAge = App.game.farming.berryData[expectedOrder[0]].growthTime[PlotStage.Bloom];


### PR DESCRIPTION
This new floating panel will give the user more information about
the current automation state

![image](https://user-images.githubusercontent.com/11090416/218189806-a54df9af-63df-4340-b75e-8e7ece447723.png)

This panel will only be visible when:
  - The farm in-game modal is visible
  - The farming automation is enabled

---

Menu: Improve floating panel position

The floating panels can now no longer go past 200px from the top
to avoid weird positioning on high-res screens.

The panels will now be moved on screen resize with a 30px margin
from the bottom, to match the in-game modal.