### PR TITLE
Focus: Handle magikarp jump region for gym gem farming

### DIFF
--- a/src/lib/Utils/Battle.js
+++ b/src/lib/Utils/Battle.js
@@ -3,6 +3,8 @@
  */
 class AutomationUtilsBattle
 {
+    static SpecialRegion = { MagikarpJump: "MagikarpJump" };
+
     /**
      * @brief Initializes the class members
      *
@@ -73,6 +75,13 @@ class AutomationUtilsBattle
         let attack = 0;
         for (const pokemon of App.game.party.caughtPokemon)
         {
+            // Magikarp Jump only considers magikarps
+            if ((region == this.SpecialRegion.MagikarpJump)
+                && (Math.floor(pokemon.id) != 129))
+            {
+                continue;
+            }
+
             if (!this.__internal__PokemonAttackMap.has(pokemon.id))
             {
                 continue;
@@ -162,16 +171,20 @@ class AutomationUtilsBattle
      *
      * @param {number} playerClickAttack: The current player click attack
      *
-     * @returns The list of lowest possible attack for each region
+     * @returns The map of lowest possible attack for each region
      */
     static getPlayerWorstAttackPerSecondForAllRegions(playerClickAttack)
     {
-        let worstAtks = [];
+        // Populate the list with pokeclicker regular regions
+        let regionList = Array.from(Array(GameConstants.MAX_AVAILABLE_REGION + 1).keys());
 
-        // Populate the list
-        for (let regionId = GameConstants.Region.kanto; regionId <= GameConstants.MAX_AVAILABLE_REGION; regionId++)
+        // Add the MagikarpJump special region
+        regionList.push(this.SpecialRegion.MagikarpJump);
+
+        let worstAtks = new Map();
+        for (const regionId of regionList)
         {
-            worstAtks.push((20 * playerClickAttack) + this.getPlayerWorstPokemonAttack(regionId));
+            worstAtks.set(regionId, (20 * playerClickAttack) + this.getPlayerWorstPokemonAttack(regionId));
         }
 
         return worstAtks;
@@ -188,7 +201,8 @@ class AutomationUtilsBattle
     {
         let worstAtk = Number.MAX_SAFE_INTEGER;
 
-        let weatherType = Weather.regionalWeather[region]();
+        const weatherType = (region == this.SpecialRegion.MagikarpJump) ? Weather.regionalWeather[GameConstants.Region.alola]()
+                                                                        : Weather.regionalWeather[region]();
 
         for (const type of Array(Gems.nTypes).keys())
         {

--- a/src/lib/Utils/Gym.js
+++ b/src/lib/Utils/Gym.js
@@ -55,9 +55,12 @@ class AutomationUtilsGym
                 continue;
             }
 
-            const currentGymClickAttack = Automation.Utils.Route.isInMagikarpJumpIsland(gymData.region, gymData.subRegion)
-                                        ? magikarpPlayerClickAttack
-                                        : playerClickAttack;
+            const isMagikarpJump = Automation.Utils.Route.isInMagikarpJumpIsland(gymData.region, gymData.subRegion);
+            const gymRegion = isMagikarpJump ? Automation.Utils.Battle.SpecialRegion.MagikarpJump
+                                             : gymData.region;
+
+            const currentGymClickAttack = isMagikarpJump ? magikarpPlayerClickAttack
+                                                         : playerClickAttack;
 
             let currentGymGemPerTick = 0;
             for (const pokemon of gym.pokemons)
@@ -69,7 +72,7 @@ class AutomationUtilsGym
                 }
 
                 const currentPokemonTickToDefeat = Automation.Utils.Battle.getGameTickCountNeededToDefeatPokemon(
-                    pokemon.maxHealth, currentGymClickAttack, totalAtkPerSecondByRegion[gymData.region]);
+                    pokemon.maxHealth, currentGymClickAttack, totalAtkPerSecondByRegion.get(gymRegion));
                 currentGymGemPerTick += (GameConstants.GYM_GEMS / currentPokemonTickToDefeat);
             }
 

--- a/tst/tests/Utils/Battle.test.in.js
+++ b/tst/tests/Utils/Battle.test.in.js
@@ -236,9 +236,10 @@ test('Check getPlayerWorstAttackPerSecondForAllRegions() output', () =>
     let playerClickAttack = 1000;
     let result = Automation.Utils.Battle.getPlayerWorstAttackPerSecondForAllRegions(playerClickAttack);
 
-    expect(result.length).toEqual(GameConstants.MAX_AVAILABLE_REGION + 1);
+    expect(result.size).toEqual(GameConstants.MAX_AVAILABLE_REGION + 2);
 
-    let expectedResult = [ 22452, 22012, 22216, 22175, 21903, 21598, 21709 ];
+    let expectedResult = new Map([ [ 0, 22452 ], [ 1, 22012 ], [ 2, 22216 ], [ 3, 22175 ], [ 4, 21903 ], [ 5, 21598 ], [ 6, 21709 ],
+                                   [ Automation.Utils.Battle.SpecialRegion.MagikarpJump, 20000 ] ]);
 
     // Check consistency
     expect(result).toBeEqualToRange(expectedResult);
@@ -251,7 +252,8 @@ test('Check getPlayerWorstAttackPerSecondForAllRegions() output', () =>
 
     // Ensure the values were updated
     result = Automation.Utils.Battle.getPlayerWorstAttackPerSecondForAllRegions(playerClickAttack);
-    expectedResult = [ 22452, 22012, 22217, 22175, 21904, 21598, 21709 ];
+    expectedResult = new Map([ [ 0, 22452 ], [ 1, 22012 ], [ 2, 22217 ], [ 3, 22175 ], [ 4, 21904 ], [ 5, 21598 ], [ 6, 21709 ],
+                               [ Automation.Utils.Battle.SpecialRegion.MagikarpJump, 20000 ] ]);
     expect(result).toBeEqualToRange(expectedResult);
 });
 

--- a/tst/utils/jest.extensions.utils.js
+++ b/tst/utils/jest.extensions.utils.js
@@ -7,7 +7,7 @@ expect.extend(
 
         for (const [ index, data ] of received.entries())
         {
-            let expectedData = expected[index];
+            let expectedData = (expected instanceof Map) ? expected.get(index) : expected[index];
             if (expectedData != data)
             {
                 errorBuffer += `Data at index '${index}' does not match\n`


### PR DESCRIPTION
The magikarp jump region could be selected to farm gems in case were it's not relevant.

This commit introduces the MagikarpJump special region to the `getPlayerWorstAttackPerSecondForAllRegions` method results.

Fixes #260

Part of #209