### PR TITLE
Focus.PokerusCure: Add support for UltraBeast pokémons

### DIFF
--- a/src/lib/Focus.js
+++ b/src/lib/Focus.js
@@ -336,6 +336,13 @@ class AutomationFocus
 
         const achievementsTabContainer = Automation.Menu.addTabElement(focusSettingPanel, "Achievements", focusSettingsTabsGroup);
         this.Achievements.__buildAdvancedSettings(achievementsTabContainer);
+
+        /***************************\
+        |*  Pokérus Cure settings  *|
+        \***************************/
+
+        const pokerusCureTabContainer = Automation.Menu.addTabElement(focusSettingPanel, "Pokérus Cure", focusSettingsTabsGroup);
+        this.PokerusCure.__buildAdvancedSettings(pokerusCureTabContainer);
     }
 
     /**


### PR DESCRIPTION
Such pokémons can only be caught using a Beastball. Those can only be bought using quest points.
An advanced setting was added to allow capturing UltraBeasts.

![image](https://user-images.githubusercontent.com/11090416/219454871-0906873d-9d8e-4e4a-86bd-cc0f7335840b.png)

If the player did not enable this new setting or has no Beastball left, UltraBeast pokémons will be ignored.

Part of #122