### PR TITLE
Farm: Don't use the in-game selected berry anymore

### DIFF
--- a/src/lib/Farm.js
+++ b/src/lib/Farm.js
@@ -10,7 +10,8 @@ class AutomationFarm
                           FeatureEnabled: "Farming-Enabled",
                           FocusOnUnlocks: "Farming-FocusOnUnlocks",
                           OakItemLoadoutUpdate: "Farming-OakItemLoadoutUpdate",
-                          HarvestLate: "Farming-HarvestLate"
+                          HarvestLate: "Farming-HarvestLate",
+                          SelectedBerryToPlant: "Farming-SelectedBerryToPlant"
                       };
 
     // The berry type forced to plant by other features
@@ -26,6 +27,7 @@ class AutomationFarm
         if (initStep == Automation.InitSteps.BuildMenu)
         {
             Automation.Utils.LocalStorage.setDefaultValue(this.Settings.HarvestLate, false);
+            Automation.Utils.LocalStorage.setDefaultValue(this.Settings.SelectedBerryToPlant, BerryType.Cheri);
 
             this.__internal__buildMenu();
         }
@@ -100,7 +102,10 @@ class AutomationFarm
     static __internal__farmingContainer = null;
     static __internal__contentFloatingContainer = null;
     static __internal__contentFloatingContentContainer = null;
+    static __internal__berriesDropdownList = null;
     static __internal__farmInGameModal = null;
+
+    static __internal__lockedBerries = [];
 
     static __internal__farmingLoop = null;
 
@@ -210,7 +215,102 @@ class AutomationFarm
                                            }
                                       }.bind(this), false);
 
+        // Selected berry drop-down list
+        this.__internal__buildBerryDropdownList(farmingSettingPanel);
+
         this.__internal__buildFloatingModal();
+    }
+
+    /**
+     * @brief Builds the advanced setting berry selection dropdown list
+     *
+     * @param {Element} parent: The parent div
+     */
+    static __internal__buildBerryDropdownList(parent)
+    {
+        const selectOptions = [];
+
+        let savedSelectedBerry = parseInt(Automation.Utils.LocalStorage.getValue(this.Settings.SelectedBerryToPlant));
+
+        // It should never happen, but we never know
+        if (!App.game.farming.unlockedBerries[savedSelectedBerry]())
+        {
+            // If a locked berry was saved, fallback to the Cheri one
+            Automation.Utils.LocalStorage.setValue(this.Settings.SelectedBerryToPlant, BerryType.Cheri);
+            savedSelectedBerry = BerryType.Cheri;
+        }
+
+        // Make a copy, to avoid tempering with the ingame data, since sort is performed inplace
+        const berryListCopy = [...FarmController.berryListFiltered()];
+        // Sort the berries alphabetically
+        berryListCopy.sort((a, b) => (BerryType[a] < BerryType[b]) ? -1 : 1);
+
+        // Add each berries
+        for (const berryId of berryListCopy)
+        {
+            const berryName = BerryType[berryId];
+
+            const element = document.createElement("div");
+
+            // Add berry image
+            const image = document.createElement("img");
+            image.src = `assets/images/items/berry/${berryName}.png`;
+            image.style.height = "22px";
+            image.style.marginRight = "5px";
+            image.style.marginLeft = "5px";
+            element.appendChild(image);
+
+            // Hide any berry that is not yet unlocked
+            if (!App.game.farming.unlockedBerries[berryId]())
+            {
+                this.__internal__lockedBerries.push({ berryId, element });
+                element.hidden = true;
+            }
+
+            // Add berry name
+            element.appendChild(document.createTextNode(berryName));
+
+            selectOptions.push({ value: berryId, element, selected: (berryId == savedSelectedBerry) });
+        }
+
+        const tooltip = "Choose which berry the automation should farm.\n"
+                      + "This setting is ignored if the berry/plot unlock is enabled.";
+        this.__internal__berriesDropdownList = Automation.Menu.createDropdownListWithHtmlOptions(selectOptions, "Berry to farm", tooltip);
+        this.__internal__berriesDropdownList.getElementsByTagName('button')[0].style.width = "118px";
+
+        this.__internal__berriesDropdownList.onValueChange = function()
+            {
+                Automation.Utils.LocalStorage.setValue(this.Settings.SelectedBerryToPlant, this.__internal__berriesDropdownList.selectedValue);
+            }.bind(this);
+
+        parent.appendChild(this.__internal__berriesDropdownList);
+
+        // Set a watcher in case some barries are not unlocked yet
+        if (this.__internal__lockedBerries.length != 0)
+        {
+            const watcher = setInterval(function()
+            {
+                // Reverse iterate to avoid any problem that would be cause by element removal
+                for (var i = this.__internal__lockedBerries.length - 1; i >= 0; i--)
+                {
+                    const barryData = this.__internal__lockedBerries[i];
+                    if (App.game.farming.unlockedBerries[barryData.berryId]())
+                    {
+                        // Make the element visible
+                        barryData.element.hidden = false;
+
+                        // Remove the pokéball from the locked list
+                        this.__internal__lockedBerries.splice(i, 1);
+                    }
+                }
+
+                if (this.__internal__lockedBerries.length == 0)
+                {
+                    // No more missing berries, unregister the loop
+                    clearInterval(watcher);
+                }
+            }.bind(this), 5000); // Refresh every 5s
+        }
     }
 
     /**
@@ -286,7 +386,7 @@ class AutomationFarm
         this.__internal__updateFloatingPanel();
 
         // Otherwise, fallback to planting berries
-        const berryToPlant = this.ForcePlantBerriesAsked ?? FarmController.selectedBerry();
+        const berryToPlant = this.ForcePlantBerriesAsked ?? parseInt(Automation.Utils.LocalStorage.getValue(this.Settings.SelectedBerryToPlant));
         this.__internal__plantAllBerries(berryToPlant);
 
         if (this.__internal__currentStrategy !== null)
@@ -318,7 +418,7 @@ class AutomationFarm
         }
 
         // Only update the floating content panel if needed
-        const selectedBerryType = FarmController.selectedBerry();
+        const selectedBerryType = parseInt(Automation.Utils.LocalStorage.getValue(this.Settings.SelectedBerryToPlant));
         if (this.__internal__lastFarmingBerryType != selectedBerryType)
         {
             const textPrefix = document.createTextNode("Currently planting ");
@@ -1451,7 +1551,7 @@ class AutomationFarm
                 // If not unlocked, then farm some needed berries
                 action: function()
                 {
-                    let berryToPlant = berryType
+                    let berryToPlant = berryType;
                     if (App.game.farming.plotBerryCost(slotIndex).amount <= App.game.farming.berryList[berryType]())
                     {
                         // Not enough farm point, lets plant some Cheri berries to get some fast

--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -8,8 +8,8 @@ class AutomationFocusAchievements
     \******************************************************************************/
 
     static __internal__advancedSettings = {
-        DoMagikarpJumpLast: "Focus-Achievements-DoMagikarpIslandLast"
-    };
+                                              DoMagikarpJumpLast: "Focus-Achievements-DoMagikarpIslandLast"
+                                          };
 
     /**
      * @brief Adds the Achievements functionality to the 'Focus on' list

--- a/src/lib/Focus/PokerusCure.js
+++ b/src/lib/Focus/PokerusCure.js
@@ -49,10 +49,10 @@ class AutomationFocusPokerusCure
                       + Automation.Menu.TooltipSeparator
                       + "If this option is disabled, or you don't have Beastballs,\n"
                       + "UltraBeast pokémons will be ignored.";
-        const button = Automation.Menu.addLabeledAdvancedSettingsToggleButton("Use Beastballs to catch UltraBeast pokémons",
-                                                                              this.__internal__advancedSettings.AllowBeastBallUsage,
-                                                                              tooltip,
-                                                                              parent);
+        Automation.Menu.addLabeledAdvancedSettingsToggleButton("Use Beastballs to catch UltraBeast pokémons",
+                                                               this.__internal__advancedSettings.AllowBeastBallUsage,
+                                                               tooltip,
+                                                               parent);
     }
 
     /*********************************************************************\
@@ -60,8 +60,8 @@ class AutomationFocusPokerusCure
     \*********************************************************************/
 
     static __internal__advancedSettings = {
-        AllowBeastBallUsage: "Focus-PokerusCure-AllowBeastBallUsage"
-    };
+                                              AllowBeastBallUsage: "Focus-PokerusCure-AllowBeastBallUsage"
+                                          };
 
     static __internal__pokerusCureLoop = null;
     static __internal__pokerusRouteData = [];

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -191,8 +191,7 @@ class AutomationFocusQuests
             Automation.Menu.setButtonDisabledState(Automation.Farm.Settings.FocusOnUnlocks, true, disableReason);
 
             // Select cheri berry to avoid long riping time
-            Automation.Farm.ForcePlantBerriesAsked = true;
-            FarmController.selectedBerry(BerryType.Cheri);
+            Automation.Farm.ForcePlantBerriesAsked = BerryType.Cheri;
 
             Automation.Farm.toggleAutoFarming(true);
         }
@@ -201,7 +200,7 @@ class AutomationFocusQuests
             // Reset farming automation user-selected state
             Automation.Farm.toggleAutoFarming();
 
-            Automation.Farm.ForcePlantBerriesAsked = false;
+            Automation.Farm.ForcePlantBerriesAsked = null;
             Automation.Menu.setButtonDisabledState(Automation.Farm.Settings.FeatureEnabled, false);
             Automation.Menu.setButtonDisabledState(Automation.Farm.Settings.FocusOnUnlocks, false);
         }
@@ -217,7 +216,7 @@ class AutomationFocusQuests
         this.__internal__autoQuestLoop = null;
 
         // Reset demands
-        Automation.Farm.ForcePlantBerriesAsked = false;
+        Automation.Farm.ForcePlantBerriesAsked = null;
         Automation.Dungeon.AutomationRequestedMode = Automation.Dungeon.InternalModes.None;
 
         // Reset other modes status
@@ -483,14 +482,14 @@ class AutomationFocusQuests
         {
             if (Automation.Utils.isInstanceOf(quest, "HarvestBerriesQuest"))
             {
-                this.__internal__enableFarmingForBerryType(quest.berryType);
+                Automation.Farm.ForcePlantBerriesAsked = quest.berryType;
                 isFarmingSpecificBerry = true;
             }
             else if (Automation.Utils.isInstanceOf(quest, "GainFarmPointsQuest")
                      && !isFarmingSpecificBerry)
             {
                 let bestBerry = this.__internal__getMostSuitableBerryForQuest(quest);
-                this.__internal__enableFarmingForBerryType(bestBerry);
+                Automation.Farm.ForcePlantBerriesAsked = bestBerry;
             }
         }
     }
@@ -751,17 +750,6 @@ class AutomationFocusQuests
         }
 
         return true;
-    }
-
-    /**
-     * @brief Sets the game's selected berry to @p berryType
-     *
-     * @see AutomationFarm for the use of such value
-     */
-    static __internal__enableFarmingForBerryType(berryType)
-    {
-        // Select the berry type to farm
-        FarmController.selectedBerry(berryType);
     }
 
     /**

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -380,7 +380,7 @@ class AutomationMenu
      *
      * @param {Array}  options: The options to register, the following data is expected { element, value, selected }
      * @param {string} label: The text label to place before the list
-     * @param {string} tooltip: The tooltip text to display upon hovering the list or the label (leave blank to disable)
+     * @param {string} tooltip: The tooltip text to display upon hovering the label (leave blank to disable)
      *
      * @returns The created element container (It's the caller's responsibility to add it to the DOM at some point)
      */
@@ -391,14 +391,16 @@ class AutomationMenu
         container.style.paddingLeft = "10px";
         container.style.paddingRight = "10px";
 
+        // Add the list label
+        const labelElem = document.createElement("span");
+        labelElem.innerText = `${label} :`;
+        container.appendChild(labelElem);
+
         if (tooltip != "")
         {
-            container.classList.add("hasAutomationTooltip");
-            container.setAttribute("automation-tooltip-text", tooltip);
+            labelElem.classList.add("hasAutomationTooltip");
+            labelElem.setAttribute("automation-tooltip-text", tooltip);
         }
-
-        // Add the list label
-        container.appendChild(document.createTextNode(`${label} :`));
 
         // Add the list container
         const listContainer = document.createElement("div");
@@ -896,8 +898,8 @@ class AutomationMenu
 
         this.__internal__populatePokeballOptions(savedValue, selectElem, addNoneOption);
 
-        // Set a watcher in case some balls are not unloced yet
-        if (this.__internal__pokeballListElems.length == 0)
+        // Set a watcher in case some balls are not unlocked yet
+        if (this.__internal__lockedBalls.length != 0)
         {
             const watcher = setInterval(function()
             {

--- a/tst/stubs/Farming/FarmController.pokeclicker.stub.js
+++ b/tst/stubs/Farming/FarmController.pokeclicker.stub.js
@@ -17,21 +17,4 @@ class FarmController
 
         plot.__isEmpty = true;
     }
-
-    static selectedBerry(selectBerry = null)
-    {
-        if (selectBerry != null)
-        {
-            this.__selectedBerry = selectBerry;
-        }
-
-        return this.__selectedBerry;
-    }
-
-    /***************************\
-    |*   Test-only interface   *|
-    \***************************/
-
-    // Select Cheri berry by default
-    static __selectedBerry = BerryType.Cheri;
 }

--- a/tst/tests/Farm/UnlockStrategies.test.in.js
+++ b/tst/tests/Farm/UnlockStrategies.test.in.js
@@ -417,6 +417,9 @@ beforeAll(() =>
         // Expect the farming loop to not be set
         expect(Automation.Farm.__internal__farmingLoop).toBe(null);
 
+        // Simulate the selected berry to being defaulted to the Cheri one
+        Automation.Utils.LocalStorage.setValue(Automation.Farm.Settings.SelectedBerryToPlant, BerryType.Cheri);
+
         // Simulate Farming feature being enabled by default (done in the Automation.InitSteps.BuildMenu)
         Automation.Utils.LocalStorage.setValue(Automation.Farm.Settings.FeatureEnabled, true);
         expect(Automation.Utils.LocalStorage.getValue(Automation.Farm.Settings.FeatureEnabled)).toBe("true");


### PR DESCRIPTION
The in-game selected berry should not be used for the automation.
This value can be tempered with easily, by simply navigating between
pages for example.

Moreover, this data is reset each time the app is closed,
it's not persisted.

An advanced setting is now used for that purpose.
![image](https://user-images.githubusercontent.com/11090416/219823666-f32a5502-ed58-4e2d-b26f-d4e02c42534a.png)

---

Farm: Don't use the selectedBerry to force berry planting

Forcing a berry planting would override the in-game user-selected
berry.

The ForcePlantBerriesAsked now contains the berry type directly,
this value is then used to plant berries insteadn of using
`FarmController.selectedBerry()`.

---

Menu: Add custom dropdown list creation method

Regular HTML select element can only contain options with text content

The `createDropdownListWithHtmlOptions` method can be used to create
dropdown lists containing elements accepting any HTML Elements as
content.

This is mainly usefull to add images to the content.
