### PR TITLE
Focus.PokerusCure: Perform Magikarp Jump routes last

### DIFF
--- a/src/lib/Farm.js
+++ b/src/lib/Farm.js
@@ -251,6 +251,7 @@ class AutomationFarm
             const berryName = BerryType[berryId];
 
             const element = document.createElement("div");
+            element.style.paddingTop = "1px";
 
             // Add berry image
             const image = document.createElement("img");
@@ -258,6 +259,8 @@ class AutomationFarm
             image.style.height = "22px";
             image.style.marginRight = "5px";
             image.style.marginLeft = "5px";
+            image.style.position = "relative";
+            image.style.bottom = "1px";
             element.appendChild(image);
 
             // Hide any berry that is not yet unlocked

--- a/src/lib/Focus/PokerusCure.js
+++ b/src/lib/Focus/PokerusCure.js
@@ -189,6 +189,18 @@ class AutomationFocusPokerusCure
                 this.__internal__pokerusRouteData.push({ route });
             }
         }
+
+        // Put Magikarp jump last
+        this.__internal__pokerusRouteData.sort((routeA, routeB) =>
+            {
+                const isAmagikarp = Automation.Utils.Route.isInMagikarpJumpIsland(routeA.route.region, routeA.route.subRegion);
+                const isBmagikarp = Automation.Utils.Route.isInMagikarpJumpIsland(routeB.route.region, routeB.route.subRegion);
+
+                if (isAmagikarp && !isBmagikarp) return 1;
+                if (isBmagikarp && !isAmagikarp) return -1;
+
+                return 0;
+            });
     }
 
     /**


### PR DESCRIPTION
The Magikarp Jump can bit a bit tedious to farm, it's now considered last.