### PR TITLE
BattleCafe: Fixup Dusk spin description

### DIFF
--- a/src/lib/BattleCafe.js
+++ b/src/lib/BattleCafe.js
@@ -104,7 +104,7 @@ class AutomationBattleCafe
         {
             // Spin count info
             container.style.marginLeft = "10px";
-            if (spinType == GameConstants.AlcremieSpins.at7Above10)
+            if (spinType == GameConstants.AlcremieSpins.at5Above10)
             {
                 tooltip += "11 times or more "
                 summary += "11+";


### PR DESCRIPTION
It was displaying '1-4 counter-clockwise' were it's actually '11+ counter-clockwise'.

Fixes #271 