### PR TITLE
Farm: Fixup the floating panel not refreshing in some cases

### DIFF
--- a/src/lib/Farm.js
+++ b/src/lib/Farm.js
@@ -1597,7 +1597,7 @@ class AutomationFarm
                 requiresDiscord: false,
                 setFoatingPanelContent: function()
                     {
-                        const isberryUnlocked = App.game.farming.unlockedBerries[berryType]();
+                        const isberryUnlocked = !!App.game.farming.unlockedBerries[berryType]();
 
                         if (this.__internal__floatingPanelStateData == isberryUnlocked)
                         {


### PR DESCRIPTION
The in-game `App.game.farming.unlockedBerries` function can return `undefined` when the berry has not been unlocked yet.

This would collide with the default value,
resulting in the panel not being updated.

The value is now converted to a boolean to avoid such case.