### PR TITLE
BattleCafe: Add pokérus status to the floating panel

### DIFF
--- a/src/lib/BattleCafe.js
+++ b/src/lib/BattleCafe.js
@@ -29,6 +29,7 @@ class AutomationBattleCafe
     static __internal__battleCafeSweetContainers = [];
     static __internal__currentlyVisibleSweet = null;
     static __internal__caughtPokemonIndicators = new Map();
+    static __internal__pokemonPokerusIndicators = new Map();
 
     /**
      * @brief Builds the 'Battle Café' menu panel
@@ -41,6 +42,11 @@ class AutomationBattleCafe
         let battleCafeTitle = '☕ Battle Café ☕';
         const battleCafeContainer =
             Automation.Menu.addFloatingCategory("automationBattleCafe", battleCafeTitle, this.__internal__battleCafeInGameModal);
+
+        // Update the style to fit the width according to the panel content
+        const mainContainer = battleCafeContainer.parentElement;
+        mainContainer.style.width = "unset";
+        mainContainer.style.minWidth = "145px";
 
         this.__internal__addInfo(null, -1, battleCafeContainer);
 
@@ -161,6 +167,13 @@ class AutomationBattleCafe
         container.appendChild(caughtIndicatorElem);
         this.__internal__caughtPokemonIndicators.set(
             pokemonName, { container: caughtIndicatorElem, pokemonId: pokemonId, currentStatus: null });
+
+        // Add the pokérus status placeholder
+        const pokerusIndicatorElem = document.createElement("span");
+        pokerusIndicatorElem.style.marginRight = "4px";
+        container.appendChild(pokerusIndicatorElem);
+        this.__internal__pokemonPokerusIndicators.set(
+            pokemonName, { container: pokerusIndicatorElem, pokemonId: pokemonId, currentStatus: null });
     }
 
     /**
@@ -206,13 +219,25 @@ class AutomationBattleCafe
      */
     static __internal__refreshCaughtStatus(pokemonName)
     {
-        const internalData = this.__internal__caughtPokemonIndicators.get(pokemonName);
-        const caughtStatus = Automation.Utils.getPokemonCaughtStatus(internalData.pokemonId);
+        // Refresh the caught status
+        const internalCaughtData = this.__internal__caughtPokemonIndicators.get(pokemonName);
+        const caughtStatus = Automation.Utils.getPokemonCaughtStatus(internalCaughtData.pokemonId);
 
-        if (caughtStatus != internalData.currentStatus)
+        if (caughtStatus != internalCaughtData.currentStatus)
         {
-            internalData.container.innerHTML = Automation.Menu.getCaughtStatusImage(caughtStatus);
-            internalData.currentStatus = caughtStatus;
+            internalCaughtData.container.innerHTML = Automation.Menu.getCaughtStatusImage(caughtStatus);
+            internalCaughtData.currentStatus = caughtStatus;
+        }
+
+        // Refresh the pokérus status
+        const internalPokerusData = this.__internal__pokemonPokerusIndicators.get(pokemonName);
+        const pokerusStatus = Automation.Utils.getPokemonPokerusStatus(internalPokerusData.pokemonId);
+
+        if (pokerusStatus != internalPokerusData.currentStatus)
+        {
+            internalPokerusData.container.innerHTML = Automation.Menu.getPokerusStatusImage(pokerusStatus);
+            internalPokerusData.container.style.paddingLeft = (internalPokerusData.container.innerHTML == "") ? "0px" : "3px";
+            internalPokerusData.currentStatus = pokerusStatus;
         }
     }
 }

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -978,6 +978,26 @@ class AutomationMenu
              + ` src="assets/images/pokeball/${this.__internal__caughtStatusImageSwitch[caughtStatus]}.svg">`;
     }
 
+    /**
+     * @brief Gets the pokérus status image corresponding to the given @p pokerusStatus
+     *
+     * @note The Uninfected status has no image
+     *
+     * @param pokerusStatus: The pokeclicker's pokérus status
+     *
+     * @returns The corresponding image
+     */
+    static getPokerusStatusImage(pokerusStatus)
+    {
+        if (pokerusStatus == GameConstants.Pokerus.Uninfected)
+        {
+            return "";
+        }
+
+        return `<img style="position: relative; bottom: 1px; height: 12px;"`
+             + ` src="assets/images/breeding/pokerus/${GameConstants.Pokerus[pokerusStatus]}.png">`;
+    }
+
     /*********************************************************************\
     |***    Internal members, should never be used by other classes    ***|
     \*********************************************************************/

--- a/src/lib/Utils.js
+++ b/src/lib/Utils.js
@@ -118,6 +118,25 @@ class AutomationUtils
     }
 
     /**
+     * @brief Gets the pokémon pokérus status from its given @p pokemonId
+     *
+     * @param {number} pokemonId: The pokemon id to get the status of
+     *
+     * @returns The pokérus status
+     */
+    static getPokemonPokerusStatus(pokemonId)
+    {
+        const partyPokemon = App.game.party.getPokemon(pokemonId);
+
+        if (!partyPokemon || !partyPokemon.pokerus)
+        {
+            return GameConstants.Pokerus.Uninfected;
+        }
+
+        return partyPokemon.pokerus;
+    }
+
+    /**
      * @brief Checks if the given @p obj is an instance of @p instanceName as javascripts `instanceof` would,
      *        but without requiring the class to be accessible.
      *        This is usefull if the class was created in a module and the object is not accessible from the document.


### PR DESCRIPTION
The panel now shows the pokérus status when available : 
![image](https://user-images.githubusercontent.com/11090416/227316188-11e9b8ab-aadc-4f4f-b02f-532e36a13183.png)

Fixes #279