### PR TITLE
Hatchery: Add an option to keep farming for mega requirement

### DIFF
--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -372,7 +372,7 @@ class AutomationFocusQuests
             return;
         }
 
-        // Sort quest to work on the most relevent one
+        // Sort quest to work on the most relevant one
         currentQuests.sort(this.__internal__sortQuestByPriority, this);
 
         // Filter the quests that do not need specific action

--- a/src/lib/Trivia.js
+++ b/src/lib/Trivia.js
@@ -502,7 +502,7 @@ class AutomationTrivia
                 // Some evolution might be locked with the folowing reason (as of v0.10.10):
                 //  - You must be in the <Region name>
                 //  - Your local part of the day must be <Time of day>
-                //  - <Pokémon name> holds no Mega Stone (or a more detailed hint)).
+                //  - <Pokémon name> holds no Mega Stone (or a more detailed hint).
                 if (data.locked)
                 {
                     // Keep region or time of day evolution restrictions, as the player can satisfy those pretty easily

--- a/src/lib/Utils.js
+++ b/src/lib/Utils.js
@@ -139,7 +139,7 @@ class AutomationUtils
     /**
      * @brief Checks if the given @p obj is an instance of @p instanceName as javascripts `instanceof` would,
      *        but without requiring the class to be accessible.
-     *        This is usefull if the class was created in a module and the object is not accessible from the document.
+     *        This is useful if the class was created in a module and the object is not accessible from the document.
      *
      * @param obj: The object to check
      * @param {string} instanceName: The name of the class to expect


### PR DESCRIPTION
The mega-evolution requirements need to be reached twice:
  - The 1st time to mega-evol the pokémon (resulting in loosing the required stat on the base pokémon)
  - A 2nd time to allow EV farming

An advanced setting is now available to set the wanted behaviour. 
![image](https://user-images.githubusercontent.com/11090416/228912682-0aeab641-2b3a-445e-92dc-915d9eafea7c.png)

Since this behaviour is only relevant in real evolution challenge, the setting will only be shown in this case.

Fixes #283 