### PR TITLE
Utils: Implement automation pokeball filter

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@ Pokeclicker-automation aims at automating some recurring tasks that can be a bit
 This script collection does not aim at cheating.
 It will never perform actions that the game would not allow.
 
-Last known compatible pokeclicker version: 0.10.10
+Last known compatible pokeclicker version: 0.10.11
 
 For more details, please refer to the [wiki](../../wiki)
 

--- a/src/ComponentLoader.js
+++ b/src/ComponentLoader.js
@@ -33,6 +33,7 @@ class AutomationComponentLoader
         this.__addScript("src/lib/Utils/Gym.js");
         this.__addScript("src/lib/Utils/LocalStorage.js");
         this.__addScript("src/lib/Utils/OakItem.js");
+        this.__addScript("src/lib/Utils/Pokeball.js");
         this.__addScript("src/lib/Utils/Route.js");
 
         this.__loadingOrder += 1;

--- a/src/lib/Dungeon.js
+++ b/src/lib/Dungeon.js
@@ -56,8 +56,6 @@ class AutomationDungeon
     static __internal__pokedexSwitch = null;
     static __internal__dungeonFightButton = null;
     static __internal__dungeonBossCatchPokeballSelectElem = null;
-    static __internal__userDefinedPokeballToRestore = null;
-    static __internal__userDefinedContagiousPokeballToRestore = null;
 
     static __internal__isShinyCatchStopMode = false;
     static __internal__floorEndPosition = null;
@@ -244,11 +242,6 @@ class AutomationDungeon
                 this.__internal__playerActionOccured = false;
                 this.__internal__resetSavedStates();
 
-                // Reset the currently used pokeball
-                // (as the player might switch the ball during the dungeon process, the value should only be saved right before the boss fight)
-                this.__internal__userDefinedPokeballToRestore = null;
-                this.__internal__userDefinedContagiousPokeballToRestore = null;
-
                 // Set auto-dungeon loop
                 this.__internal__autoDungeonLoop = setInterval(this.__internal__dungeonFightLoop.bind(this), 50); // Runs every game tick
             }
@@ -259,12 +252,8 @@ class AutomationDungeon
             clearInterval(this.__internal__autoDungeonLoop);
             this.__internal__autoDungeonLoop = null;
 
-            // Restore the pokeball used to catch pokémons
-            if (this.__internal__userDefinedPokeballToRestore != null)
-            {
-                App.game.pokeballs.alreadyCaughtSelection = this.__internal__userDefinedPokeballToRestore;
-                Automation.Utils.Battle.setAlreadyCaughtContagiousSelection(this.__internal__userDefinedContagiousPokeballToRestore);
-            }
+            // Disable automation filter
+            Automation.Utils.Pokeball.disableAutomationFilter();
         }
     }
 
@@ -328,12 +317,8 @@ class AutomationDungeon
                 this.__internal__resetSavedStates();
                 DungeonRunner.initializeDungeon(player.town().dungeon);
 
-                // Restore the pokeball used to catch pokémons
-                if (this.__internal__userDefinedPokeballToRestore != null)
-                {
-                    App.game.pokeballs.alreadyCaughtSelection = this.__internal__userDefinedPokeballToRestore;
-                    Automation.Utils.Battle.setAlreadyCaughtContagiousSelection(this.__internal__userDefinedContagiousPokeballToRestore);
-                }
+                // Disable automation filter
+                Automation.Utils.Pokeball.disableAutomationFilter();
             }
         }
         else if (App.game.gameState === GameConstants.GameState.dungeon)
@@ -429,12 +414,7 @@ class AutomationDungeon
                         const ballToCatchBoss = this.__internal__dungeonBossCatchPokeballSelectElem.value;
                         if (ballToCatchBoss != GameConstants.Pokeball.None)
                         {
-                            // Save the currently used pokeball
-                            this.__internal__userDefinedPokeballToRestore = App.game.pokeballs.alreadyCaughtSelection;
-                            this.__internal__userDefinedContagiousPokeballToRestore = App.game.pokeballs.alreadyCaughtContagiousSelection;
-
-                            App.game.pokeballs.alreadyCaughtSelection = ballToCatchBoss;
-                            Automation.Utils.Battle.setAlreadyCaughtContagiousSelection(ballToCatchBoss);
+                            Automation.Utils.Pokeball.catchEverythingWith(ballToCatchBoss);
                         }
 
                         DungeonRunner.startBossFight();

--- a/src/lib/Focus.js
+++ b/src/lib/Focus.js
@@ -46,8 +46,6 @@ class AutomationFocus
 
     static __noFunctionalityRefresh = -1;
     static __pokeballToUseSelectElem = null;
-    static __defaultCaughtPokeballSelectElem = null;
-    static __defaultContagiousCaughtPokeballSelectElem = null;
 
     /**
      * @brief Makes sure no instance is in progress
@@ -97,8 +95,7 @@ class AutomationFocus
         this.__equipLoadout(Automation.Utils.OakItem.Setup.PokemonCatch);
 
         // Equip an "Already caught" pokeball
-        App.game.pokeballs.alreadyCaughtSelection = this.__pokeballToUseSelectElem.value;
-        Automation.Utils.Battle.setAlreadyCaughtContagiousSelection(this.__pokeballToUseSelectElem.value);
+        Automation.Utils.Pokeball.catchEverythingWith(this.__pokeballToUseSelectElem.value);
 
         // Move to the highest unlocked route
         Automation.Utils.Route.moveToHighestDungeonTokenIncomeRoute(this.__pokeballToUseSelectElem.value);
@@ -205,15 +202,6 @@ class AutomationFocus
         }
 
         return true;
-    }
-
-    /**
-     * @brief Resets the player's ball selection according to the settings
-     */
-    static __resetBallSelection()
-    {
-        App.game.pokeballs.alreadyCaughtSelection = this.__defaultCaughtPokeballSelectElem.value;
-        Automation.Utils.Battle.setAlreadyCaughtContagiousSelection(this.__defaultContagiousCaughtPokeballSelectElem.value);
     }
 
     /*********************************************************************\
@@ -364,54 +352,6 @@ class AutomationFocus
                                             this.Settings.BallToUseToCatch,
                                             "Pokeball to use for catching :",
                                             pokeballToUseTooltip);
-
-        // Default Pokeball for caught pokémons
-        const defaultCaughtPokeballTooltip = "Defines which pokeball will be equipped to catch\n"
-                                           + "already caught pokémon, when no catching is needed"
-                                           + Automation.Menu.TooltipSeparator
-                                           + "This setting will not be taken into account while focusing on quests.\n"
-                                           + "In this case no pokéball will be equipped to complete quests faster"
-                                           + disclaimer;
-        this.__defaultCaughtPokeballSelectElem =
-            Automation.Menu.addPokeballList("focusDefaultCaughtBallSelection",
-                                            generalTabContainer,
-                                            this.Settings.DefaultCaughtBall,
-                                            "Default value for caught pokémon pokéball :",
-                                            defaultCaughtPokeballTooltip,
-                                            true);
-
-        // Default Pokeball for contatgious caught pokémons
-        const defaultContagiousCaughtPokeballTooltip = "Defines which pokeball will be equipped to catch already\n"
-                                                     + "caught contagious pokémon, when no catching is needed"
-                                                     + Automation.Menu.TooltipSeparator
-                                                     + "This setting will not be taken into account while focusing on quests.\n"
-                                                     + "In this case no pokéball will be equipped to complete quests faster"
-                                                     + disclaimer;
-        this.__defaultContagiousCaughtPokeballSelectElem =
-            Automation.Menu.addPokeballList("focusDefaultContagiousCaughtBallSelection",
-                                            generalTabContainer,
-                                            this.Settings.DefaultContagiousCaughtBall,
-                                            "Default value for contagious caught pokémon pokéball :",
-                                            defaultContagiousCaughtPokeballTooltip,
-                                            true);
-
-        // Hide it by default if the player did not unlock the in-game option
-        this.__defaultContagiousCaughtPokeballSelectElem.parentElement.hidden = !App.game.keyItems.hasKeyItem(KeyItemType.Pokerus_virus);
-
-        // Set an interval to make the option visible once unlocked
-        if (this.__defaultContagiousCaughtPokeballSelectElem.parentElement.hidden)
-        {
-            const watcher = setInterval(function()
-                {
-                    if (App.game.keyItems.hasKeyItem(KeyItemType.Pokerus_virus))
-                    {
-                        this.__defaultContagiousCaughtPokeballSelectElem.parentElement.hidden = false;
-
-                        // Feature unlocked, unregister the loop
-                        clearInterval(watcher);
-                    }
-                }.bind(this), 5000); // Refresh every 5s
-        }
     }
 
     /**
@@ -514,7 +454,7 @@ class AutomationFocus
                 stop: function ()
                     {
                         Automation.Menu.forceAutomationState(Automation.Gym.Settings.FeatureEnabled, false);
-                        this.__resetBallSelection();
+                        Automation.Utils.Pokeball.disableAutomationFilter();
                     }.bind(this),
                 refreshRateAsMs: 3000 // Refresh every 3s
             });

--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -94,8 +94,8 @@ class AutomationFocusAchievements
 
         Automation.Menu.forceAutomationState(Automation.Gym.Settings.FeatureEnabled, false);
 
-        // Restore the ball to catch default value
-        Automation.Focus.__resetBallSelection();
+        // Restore pokéball filters
+        Automation.Utils.Pokeball.disableAutomationFilter();
     }
 
     /**
@@ -159,8 +159,8 @@ class AutomationFocusAchievements
      */
     static __internal__workOnAchievement()
     {
-        // Reset any equipped pokeball
-        Automation.Focus.__resetBallSelection();
+        // Restore pokéball filters
+        Automation.Utils.Pokeball.disableAutomationFilter();
 
         if (Automation.Utils.isInstanceOf(this.__internal__currentAchievement.property, "RouteKillRequirement"))
         {

--- a/src/lib/Focus/PokerusCure.js
+++ b/src/lib/Focus/PokerusCure.js
@@ -111,8 +111,8 @@ class AutomationFocusPokerusCure
         clearInterval(this.__internal__pokerusCureLoop);
         this.__internal__pokerusCureLoop = null;
 
-        // Restore pokéballs
-        Automation.Focus.__resetBallSelection();
+        // Restore pokéball filters
+        Automation.Utils.Pokeball.disableAutomationFilter();
 
         // Reset other modes status
         Automation.Click.toggleAutoClick();
@@ -188,7 +188,7 @@ class AutomationFocusPokerusCure
         // Ensure that the player has some balls available
         if (!Automation.Focus.__ensurePlayerHasEnoughBalls(Automation.Focus.__pokeballToUseSelectElem.value))
         {
-            Automation.Utils.Battle.setAlreadyCaughtContagiousSelection(Automation.Focus.__defaultContagiousCaughtPokeballSelectElem.value);
+            Automation.Utils.disableAutomationFilter();
             return;
         }
 
@@ -196,7 +196,7 @@ class AutomationFocusPokerusCure
         if ((this.__internal__currentDungeonData != null)
             && App.game.wallet.currencies[GameConstants.Currency.dungeonToken]() < this.__internal__currentDungeonData.dungeon.tokenCost)
         {
-            Automation.Utils.Battle.setAlreadyCaughtContagiousSelection(Automation.Focus.__defaultContagiousCaughtPokeballSelectElem.value);
+            Automation.Utils.disableAutomationFilter();
             Automation.Focus.__goToBestRouteForDungeonToken();
             return;
         }
@@ -207,8 +207,8 @@ class AutomationFocusPokerusCure
         // Equip an "Already caught contagious" pokeball
         const pokeballToUse = (currentLocationData.needsBeastBall) ? GameConstants.Pokeball.Beastball
                                                                    : Automation.Focus.__pokeballToUseSelectElem.value;
-        Automation.Utils.Battle.setAlreadyCaughtContagiousSelection(pokeballToUse);
-        App.game.pokeballs.alreadyCaughtSelection = GameConstants.Pokeball.None;
+
+        Automation.Utils.Pokeball.onlyCatchContagiousWith(pokeballToUse);
 
         if (this.__internal__currentRouteData)
         {

--- a/src/lib/Utils.js
+++ b/src/lib/Utils.js
@@ -8,6 +8,7 @@ class AutomationUtils
     static Gym = AutomationUtilsGym;
     static LocalStorage = AutomationUtilsLocalStorage;
     static OakItem = AutomationUtilsOakItem;
+    static Pokeball = AutomationUtilsPokeball;
     static Route = AutomationUtilsRoute;
 
     /**
@@ -20,6 +21,7 @@ class AutomationUtils
         this.Battle.initialize(initStep);
         this.Gym.initialize(initStep);
         this.Route.initialize(initStep);
+        this.Pokeball.initialize(initStep);
     }
 
     /**

--- a/src/lib/Utils/Battle.js
+++ b/src/lib/Utils/Battle.js
@@ -216,22 +216,6 @@ class AutomationUtilsBattle
         return worstAtk;
     }
 
-    /**
-     * @brief Only sets the already caught pokéball if the player has unlocked the feature in-game
-     *
-     * @param pokeballType: The pokéball type to set
-     */
-    static setAlreadyCaughtContagiousSelection(pokeballType)
-    {
-        if (App.game.keyItems.hasKeyItem(KeyItemType.Pokerus_virus))
-        {
-            App.game.pokeballs.alreadyCaughtContagiousSelection = pokeballType;
-
-            // Don't check the condition next time
-            this.setAlreadyCaughtContagiousSelection = function(type) { App.game.pokeballs.alreadyCaughtContagiousSelection = type; };
-        }
-    }
-
     /*********************************************************************\
     |***    Internal members, should never be used by other classes    ***|
     \*********************************************************************/

--- a/src/lib/Utils/Pokeball.js
+++ b/src/lib/Utils/Pokeball.js
@@ -1,0 +1,163 @@
+/**
+ * @class The AutomationUtilsPokeball regroups helpers related to pokeclicker ball filters
+ */
+class AutomationUtilsPokeball
+{
+    /**
+     * @brief Initializes the class members
+     *
+     * @param initStep: The current automation init step
+     */
+    static initialize(initStep)
+    {
+        // Only consider the Finalize init step
+        if (initStep != Automation.InitSteps.Finalize) return;
+
+        // Initialize the automation pokeball filter
+        this.__internal__initAutomationFilter();
+
+        // Disable it by default
+        this.disableAutomationFilter();
+    }
+
+    /**
+     * @brief Disables the automation filter
+     */
+    static disableAutomationFilter()
+    {
+        this.__internal__automationFilter.enabled(false);
+    }
+
+    /**
+     * @brief Enables the automation filter
+     */
+    static enableAutomationFilter()
+    {
+        this.__internal__automationFilter.enabled(true);
+    }
+
+    /**
+     * @brief Sets the pokéball to use without any filter
+     *
+     * @param pokeballType: The pokéball type to use
+     */
+    static catchEverythingWith(pokeballType)
+    {
+        this.__internal__resetFilter(pokeballType);
+
+        this.enableAutomationFilter();
+    }
+
+    /**
+     * @brief Sets the pokéball to use only to catch Contagious pokémons
+     *
+     * @param pokeballType: The pokéball type to use
+     */
+    static onlyCatchContagiousWith(pokeballType)
+    {
+        this.__internal__resetFilter(pokeballType);
+
+        // Only consider Contagious pokémons
+        this.__internal__automationFilter.options.pokerus = pokeballFilterOptions.pokerus.createSetting();
+        this.__internal__automationFilter.options.pokerus.observableValue(Pokerus.Contagious);
+
+        this.enableAutomationFilter();
+    }
+
+    /**
+     * @brief Restricts the pokemon filter to the given @p pokemonType
+     *
+     * @param pokemonType: The pokemon type to capture
+     */
+    static restrictCaptureToPokemonType(pokemonType)
+    {
+        this.__internal__automationFilter.options.pokemonType = pokeballFilterOptions.pokemonType.createSetting();
+        this.__internal__automationFilter.options.pokemonType.observableValue(pokemonType);
+    }
+
+    /*********************************************************************\
+    |***    Internal members, should never be used by other classes    ***|
+    \*********************************************************************/
+
+    static __internal__automationFilterName = "Automation";
+    static __internal__automationFilter = null;
+
+    /**
+     * @brief Initializes the internal pokéball filter
+     */
+    static __internal__initAutomationFilter()
+    {
+        // Look for the automation filter
+        this.__internal__automationFilter = App.game.pokeballFilters.getFilterByName(this.__internal__automationFilterName);
+
+        if (this.__internal__automationFilter)
+        {
+            return;
+        }
+
+        // No Automation filter, create one
+        const existingFilterIds = App.game.pokeballFilters.list().map((filter) => filter.uuid);
+        App.game.pokeballFilters.createFilter();
+        this.__internal__automationFilter = App.game.pokeballFilters.list().filter((filter) => !existingFilterIds.includes(filter.uuid))[0];
+
+        // Rename the filter so we can retrieve it next time
+        this.__internal__automationFilter._name(this.__internal__automationFilterName);
+
+        // Make sure it has priority over other filters
+        this.__internal__prioritizeAutomationFiler();
+    }
+
+    /**
+     * @brief Makes sure the filter is still registered and has the right name and priority
+     */
+    static __internal__ensureFilterConsistency()
+    {
+        // Make sure it was not removed by the user
+        if (App.game.pokeballFilters.list().filter((filter) => filter.uuid == Automation.Utils.Pokeball.__internal__automationFilter.uuid).length == 0)
+        {
+            App.game.pokeballFilters.list.push(Automation.Utils.Pokeball.__internal__automationFilter);
+        }
+
+        // Make sure it has the right name
+        if (!this.__internal__automationFilter._name() == this.__internal__automationFilterName)
+        {
+            this.__internal__automationFilter._name(this.__internal__automationFilterName);
+        }
+
+        // Make sure it is the last filter
+        if (App.game.pokeballFilters.list().at(-1).uuid != Automation.Utils.Pokeball.__internal__automationFilter.uuid)
+        {
+            this.__internal__prioritizeAutomationFiler();
+        }
+    }
+
+    /**
+     * @brief Resets the automation filter and sets the pokéball to use
+     *
+     * @param pokeballType: The pokéball type to use
+     */
+    static __internal__resetFilter(pokeballType)
+    {
+        // Disable the filter to avoid any unwanted behaviour while configuring
+        this.disableAutomationFilter();
+
+        // In case the player removed our filter
+        this.__internal__ensureFilterConsistency();
+
+        // Reset options
+        this.__internal__automationFilter.options = {};
+
+        // Set the pokéball
+        this.__internal__automationFilter.ball(pokeballType);
+    }
+
+    /**
+     * @brief Puts the filter last so it has priority over other filters
+     */
+    static __internal__prioritizeAutomationFiler()
+    {
+        // Move the filter last to make sure it has priority over other filters
+        const newOrder = App.game.pokeballFilters.list().sort((filter) => (filter.uuid == this.__internal__automationFilter.uuid) ? 1 : -1);
+        App.game.pokeballFilters.list(newOrder);
+    }
+}

--- a/tst/imports/AutomationUtils.import.js
+++ b/tst/imports/AutomationUtils.import.js
@@ -3,5 +3,6 @@ import "src/lib/Utils/Battle.js";
 import "src/lib/Utils/LocalStorage.js";
 import "src/lib/Utils/Gym.js";
 import "src/lib/Utils/OakItem.js";
+import "src/lib/Utils/Pokeball.js";
 import "src/lib/Utils/Route.js";
 import "src/lib/Utils.js";


### PR DESCRIPTION
The v0.10.11 reworked pokéball selection filter to allow custom filters 
This broke the automation ball selection mechanism.

This commit adds an automation filter, that will be disabled by default 
The automation will now configure the filter proper and enable it when it's needed.

Default pokéball value settings are not relevant anymore, they've been removed.

---

The Focus.Quests now restrict the filter pokémon type when focusing on a `CapturePokemonTypesQuest`.

Fixes #293 