### PR TITLE
Focus.Pokerus: Fixup dungeon catch logic

### DIFF
--- a/src/lib/Dungeon.js
+++ b/src/lib/Dungeon.js
@@ -317,8 +317,11 @@ class AutomationDungeon
                 this.__internal__resetSavedStates();
                 DungeonRunner.initializeDungeon(player.town().dungeon);
 
-                // Disable automation filter
-                Automation.Utils.Pokeball.disableAutomationFilter();
+                // Disable automation filter, unless it's an automation process
+                if (!forceDungeonProcessing)
+                {
+                    Automation.Utils.Pokeball.disableAutomationFilter();
+                }
             }
         }
         else if (App.game.gameState === GameConstants.GameState.dungeon)


### PR DESCRIPTION
The automation filter was always disabled while running a dungeon automation.
It's now only disabled if not automation process was asked for.