### PR TITLE
Dungeon: Fixup v0.10.12 regression

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@ Pokeclicker-automation aims at automating some recurring tasks that can be a bit
 This script collection does not aim at cheating.
 It will never perform actions that the game would not allow.
 
-Last known compatible pokeclicker version: 0.10.11
+Last known compatible pokeclicker version: 0.10.12
 
 For more details, please refer to the [wiki](../../wiki)
 

--- a/src/lib/Dungeon.js
+++ b/src/lib/Dungeon.js
@@ -387,7 +387,7 @@ class AutomationDungeon
                         this.__internal__chestPositions = [];
                         this.__internal__floorEndPosition = null;
                         // Do not call DungeonRunner.nextFloor() directly, as it has no checks
-                        DungeonRunner.handleClick();
+                        DungeonRunner.handleInteraction();
                     }
                     else
                     {


### PR DESCRIPTION
The `handleClick` method was renamed `handleInteraction` in the new version

Introduced by [this commit](https://github.com/pokeclicker/pokeclicker/commit/066f72ce014517a460daf54aa39288641683b368)

Fixes #305 