### PR TITLE
Focus.Quest: Add support for the new BattleFrontier quest

### DIFF
--- a/src/lib/BattleFrontier.js
+++ b/src/lib/BattleFrontier.js
@@ -40,6 +40,21 @@
         }
     }
 
+    /**
+     * @brief Forces the automation to stop
+     */
+    static ForceStop()
+    {
+        // Stop the automation
+        this.__internal__toggleBattleFrontierFight(false);
+
+        // Exit the battle frontier
+        BattleFrontierRunner.end();
+
+        // Leave the menu
+        App.game.battleFrontier.leave();
+    }
+
     /*********************************************************************\
     |***    Internal members, should never be used by other classes    ***|
     \*********************************************************************/
@@ -110,7 +125,7 @@
             return;
         }
 
-        // Start a new run, using the checkpoint if available
+        // Start a new run, using the last checkpoint if available
         BattleFrontierRunner.start(true);
     }
 

--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -255,7 +255,7 @@ class AutomationFocusAchievements
         {
             Automation.Utils.Route.moveToTown(targetedDungeonName);
 
-            // Let a tick to the menu to show up
+            // Let a tick for the menu to show up
             return;
         }
 

--- a/src/lib/Focus/PokerusCure.js
+++ b/src/lib/Focus/PokerusCure.js
@@ -222,7 +222,7 @@ class AutomationFocusPokerusCure
             {
                 Automation.Utils.Route.moveToTown(this.__internal__currentDungeonData.dungeon.name);
 
-                // Let a tick to the menu to show up
+                // Let a tick for the menu to show up
                 return;
             }
 

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -1471,7 +1471,7 @@ class AutomationMenu
             .automation-setting-menu-container[automation-visible]
             {
                 max-width: 650px;
-                max-height: 600px;
+                max-height: 650px;
 
                 transition-property:        max-width, max-height;
                 transition-timing-function:   ease-in,    ease-in;


### PR DESCRIPTION
v0.10.14 introduced ClearBattleFrontier quests.

When this quest is active, it will be picked after any other handled type of quests.
The player will be moved to Battle Frontier town.
The BattleFrontier mode will be entered and the session will start automatically (from the last checkpoint, if any).

When the quest objective is met, or the automation is turned off, the BattleFrontier mode will be left.

Fixes #312 