### PR TITLE
Focus: Fixup dungeon not stopping on exit

### DIFF
--- a/src/lib/Dungeon.js
+++ b/src/lib/Dungeon.js
@@ -233,6 +233,12 @@ class AutomationDungeon
             enable = (Automation.Utils.LocalStorage.getValue(this.Settings.FeatureEnabled) === "true");
         }
 
+        // Cleanup StopAfterThisRun internal mode that was set while the dungeon was not running
+        if (this.AutomationRequestedMode == this.InternalModes.StopAfterThisRun)
+        {
+            this.AutomationRequestedMode = this.InternalModes.None;
+        }
+
         if (enable)
         {
             // Only set a loop if there is none active

--- a/src/lib/Focus.js
+++ b/src/lib/Focus.js
@@ -398,8 +398,8 @@ class AutomationFocus
             {
                 if (this.__internal__activeFocus.stop !== undefined)
                 {
-                    // Reset any dungeon request that might have occured using __ensureNoInstanceIsInProgress
-                    Automation.Dungeon.AutomationRequestedMode = Automation.Dungeon.InternalModes.None;
+                    // Reset any dungeon request that might have occured
+                    Automation.Dungeon.AutomationRequestedMode = Automation.Dungeon.InternalModes.StopAfterThisRun;
 
                     this.__internal__activeFocus.stop();
                 }

--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -89,8 +89,7 @@ class AutomationFocusAchievements
         clearInterval(this.__internal__achievementLoop);
         this.__internal__achievementLoop = null;
 
-        Automation.Dungeon.AutomationRequestedMode = Automation.Utils.isInInstanceState() ? Automation.Dungeon.InternalModes.StopAfterThisRun
-                                                                                          : Automation.Dungeon.InternalModes.None;
+        Automation.Dungeon.AutomationRequestedMode = Automation.Dungeon.InternalModes.StopAfterThisRun;
 
         Automation.Menu.forceAutomationState(Automation.Gym.Settings.FeatureEnabled, false);
 
@@ -164,12 +163,12 @@ class AutomationFocusAchievements
 
         if (Automation.Utils.isInstanceOf(this.__internal__currentAchievement.property, "RouteKillRequirement"))
         {
-            Automation.Dungeon.AutomationRequestedMode = Automation.Dungeon.InternalModes.None;
+            Automation.Dungeon.AutomationRequestedMode = Automation.Dungeon.InternalModes.StopAfterThisRun;
             this.__internal__workOnRouteKillRequirement();
         }
         else if (Automation.Utils.isInstanceOf(this.__internal__currentAchievement.property, "ClearGymRequirement"))
         {
-            Automation.Dungeon.AutomationRequestedMode = Automation.Dungeon.InternalModes.None;
+            Automation.Dungeon.AutomationRequestedMode = Automation.Dungeon.InternalModes.StopAfterThisRun;
             this.__internal__workOnClearGymRequirement();
         }
         else if (Automation.Utils.isInstanceOf(this.__internal__currentAchievement.property, "ClearDungeonRequirement"))

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -217,7 +217,7 @@ class AutomationFocusQuests
 
         // Reset demands
         Automation.Farm.ForcePlantBerriesAsked = null;
-        Automation.Dungeon.AutomationRequestedMode = Automation.Dungeon.InternalModes.None;
+        Automation.Dungeon.AutomationRequestedMode = Automation.Dungeon.InternalModes.StopAfterThisRun;
 
         // Reset other modes status
         Automation.Click.toggleAutoClick();
@@ -374,7 +374,6 @@ class AutomationFocusQuests
             Automation.Dungeon.AutomationRequestedMode = Automation.Dungeon.InternalModes.StopAfterThisRun;
             return;
         }
-        Automation.Dungeon.AutomationRequestedMode = Automation.Dungeon.InternalModes.None;
 
         // Sort quest to work on the most relevant one
         currentQuests.sort(this.__internal__sortQuestByPriority, this);


### PR DESCRIPTION
The dungeon automation did not stop when disabling Focus automation. The Focus now always set the StopAfterThisRun flag on exit.

If the Dungeon automation starts with such flag, it will automatically switch to the default None mode.