### PR TITLE
Focus.ShadowPurification: Implement this new feature

### DIFF
--- a/src/ComponentLoader.js
+++ b/src/ComponentLoader.js
@@ -29,6 +29,7 @@ class AutomationComponentLoader
         this.__addScript("src/lib/Focus/Achievements.js");
         this.__addScript("src/lib/Focus/Quests.js");
         this.__addScript("src/lib/Focus/PokerusCure.js");
+        this.__addScript("src/lib/Focus/ShadowPurification.js");
         this.__addScript("src/lib/Utils/Battle.js");
         this.__addScript("src/lib/Utils/Gym.js");
         this.__addScript("src/lib/Utils/LocalStorage.js");

--- a/src/lib/Dungeon.js
+++ b/src/lib/Dungeon.js
@@ -294,7 +294,7 @@ class AutomationDungeon
             this.AutomationRequestedMode = this.InternalModes.None;
             this.__internal__stopAfterThisRun = false;
 
-            // Disable automation filter
+            // Disable automation catch filter
             Automation.Utils.Pokeball.disableAutomationFilter();
         }
     }

--- a/src/lib/Dungeon.js
+++ b/src/lib/Dungeon.js
@@ -49,10 +49,23 @@ class AutomationDungeon
 
     /**
      * @brief Asks the Dungeon automation to stop after the current run
+     *
+     * @note This will reset any "after run" callback
      */
     static stopAfterThisRun()
     {
         this.__internal__stopAfterThisRun = true;
+        this.__internal__beforeNewRunCallBack = function (){};
+    }
+
+    /**
+     * @brief Sets the @p callback to call before running a new dungeon run
+     *
+     * @param {function} callback: The function to call
+     */
+    static setBeforeNewRunCallBack(callback)
+    {
+        this.__internal__beforeNewRunCallBack = callback;
     }
 
     /*********************************************************************\
@@ -60,6 +73,7 @@ class AutomationDungeon
     \*********************************************************************/
 
     static __internal__stopAfterThisRun = false;
+    static __internal__beforeNewRunCallBack = function (){};
 
     static __internal__CatchModes = {
         Uncaught: { id: 0, shiny: false, shadow: false },
@@ -356,6 +370,8 @@ class AutomationDungeon
             }
             else
             {
+                this.__internal__beforeNewRunCallBack();
+
                 this.__internal__resetSavedStates();
                 DungeonRunner.initializeDungeon(player.town().dungeon);
 

--- a/src/lib/Focus.js
+++ b/src/lib/Focus.js
@@ -7,6 +7,7 @@ class AutomationFocus
     static Achievements = AutomationFocusAchievements;
     static Quests = AutomationFocusQuests;
     static PokerusCure = AutomationFocusPokerusCure;
+    static ShadowPurification = AutomationFocusShadowPurification;
 
     static Settings = {
                           FeatureEnabled: "Focus-Enabled",
@@ -462,6 +463,7 @@ class AutomationFocus
         this.Quests.__registerFunctionalities(this.__internal__functionalities);
         this.Achievements.__registerFunctionalities(this.__internal__functionalities);
         this.PokerusCure.__registerFunctionalities(this.__internal__functionalities);
+        this.ShadowPurification.__registerFunctionalities(this.__internal__functionalities);
 
         this.__internal__addGemsFocusFunctionalities();
     }

--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -93,7 +93,7 @@ class AutomationFocusAchievements
 
         Automation.Menu.forceAutomationState(Automation.Gym.Settings.FeatureEnabled, false);
 
-        // Restore pokéball filters
+        // Disable automation catch filter
         Automation.Utils.Pokeball.disableAutomationFilter();
     }
 
@@ -158,7 +158,7 @@ class AutomationFocusAchievements
      */
     static __internal__workOnAchievement()
     {
-        // Restore pokéball filters
+        // Disable automation catch filter
         Automation.Utils.Pokeball.disableAutomationFilter();
 
         if (Automation.Utils.isInstanceOf(this.__internal__currentAchievement.property, "RouteKillRequirement"))

--- a/src/lib/Focus/PokerusCure.js
+++ b/src/lib/Focus/PokerusCure.js
@@ -83,11 +83,11 @@ class AutomationFocusPokerusCure
     static __internal__currentDungeonData = null;
 
     /**
-     * @brief Starts the achievements automation
+     * @brief Starts the pokérus cure automation
      */
     static __internal__start()
     {
-        // Set achievement loop
+        // Set pokérus cure loop
         this.__internal__pokerusCureLoop = setInterval(this.__internal__focusOnPokerusCure.bind(this), 10000); // Runs every 10 seconds
         this.__internal__focusOnPokerusCure();
 
@@ -100,7 +100,7 @@ class AutomationFocusPokerusCure
     }
 
     /**
-     * @brief Stops the achievements automation
+     * @brief Stops the pokérus cure automation
      */
     static __internal__stop()
     {
@@ -111,7 +111,7 @@ class AutomationFocusPokerusCure
         clearInterval(this.__internal__pokerusCureLoop);
         this.__internal__pokerusCureLoop = null;
 
-        // Restore pokéball filters
+        // Disable automation catch filter
         Automation.Utils.Pokeball.disableAutomationFilter();
 
         // Reset other modes status
@@ -122,7 +122,7 @@ class AutomationFocusPokerusCure
     }
 
     /**
-     * @brief The achievement main loop
+     * @brief The pokérus cure main loop
      *
      * @note If the user is in a state in which he cannot be moved, the feature is automatically disabled.
      */
@@ -222,7 +222,8 @@ class AutomationFocusPokerusCure
             {
                 Automation.Utils.Route.moveToTown(this.__internal__currentDungeonData.dungeon.name);
 
-                // Let a tick for the menu to show up
+                // Let a second for the menu to show up
+                setTimeout(this.__internal__captureInfectedPokemons.bind(this), 1000);
                 return;
             }
 
@@ -265,7 +266,7 @@ class AutomationFocusPokerusCure
      */
     static __internal__setNextPokerusDungeon()
     {
-        // Remove the current route from the list if completed
+        // Remove the current dungeon from the list if completed
         if ((this.__internal__currentDungeonData != null)
             && !this.__internal__doesDungeonHaveAnyPokemonNeedingCure(this.__internal__currentDungeonData.dungeon))
         {
@@ -273,7 +274,7 @@ class AutomationFocusPokerusCure
             this.__internal__pokerusDungeonData.splice(index, 1);
         }
 
-        // Set the next best route
+        // Set the next best dungeon
         this.__internal__currentDungeonData = this.__internal__pokerusDungeonData.find(
             (data) => this.__internal__doesDungeonHaveAnyPokemonNeedingCure(data.dungeon, true)
                       // Don't consider dungeon that the player can't access yet
@@ -343,7 +344,6 @@ class AutomationFocusPokerusCure
      * @brief Checks if any pokémon from the given @p route needs to be cured
      *
      * @param route: The route to check
-     *
      * @param {boolean} onlyConsiderAvailableContagiousPokemons: Whether only currently available and contagious pokémon should be considered
      *
      * @returns True if every pokémons are cured, false otherwise
@@ -359,7 +359,6 @@ class AutomationFocusPokerusCure
      * @brief Checks if any pokémon from the given @p dungeon needs to be cured
      *
      * @param dungeon: The dungeon to check
-     *
      * @param {boolean} onlyConsiderAvailableContagiousPokemons: Whether only currently available and contagious pokémon should be considered
      *
      * @returns True if every pokémons are cured, false otherwise
@@ -529,7 +528,7 @@ class AutomationFocusPokerusCure
      */
     static __internal__getEveryPokemonForDungeon(dungeon, onlyConsiderAvailablePokemons)
     {
-        const pokemonList = dungeon.pokemonList;
+        let pokemonList = dungeon.pokemonList;
 
         // Add pokemon bosses
         for (const boss of dungeon.bossList)

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -239,7 +239,7 @@ class AutomationFocusQuests
         Automation.Menu.setButtonDisabledState(Automation.Farm.Settings.FocusOnUnlocks, false);
         Automation.Menu.setButtonDisabledState(Automation.Underground.Settings.FeatureEnabled, false);
 
-        // Restore pokéball filters
+        // Disable automation catch filter
         Automation.Utils.Pokeball.disableAutomationFilter();
     }
 
@@ -445,7 +445,7 @@ class AutomationFocusQuests
         }
         else // Other type of quest don't need much
         {
-            // Restore pokéball filters
+            // Disable automation catch filter
             Automation.Utils.Pokeball.disableAutomationFilter();
 
             if (currentQuests.some((quest) => Automation.Utils.isInstanceOf(quest, "CatchShiniesQuest")))
@@ -597,7 +597,7 @@ class AutomationFocusQuests
         }
         else
         {
-            // Disable pokéball filters
+            // Disable automation catch filter
             Automation.Utils.Pokeball.disableAutomationFilter();
         }
 
@@ -707,7 +707,7 @@ class AutomationFocusQuests
             this.__internal__equipOptimizedLoadout(Automation.Utils.OakItem.Setup.PokemonExp);
 
             // Use the user's default setting, if no other quest requires pokéball
-        Automation.Utils.Pokeball.disableAutomationFilter();
+            Automation.Utils.Pokeball.disableAutomationFilter();
 
             // Go kill some pokemon
             Automation.Utils.Route.moveToBestRouteForExp();

--- a/src/lib/Focus/ShadowPurification.js
+++ b/src/lib/Focus/ShadowPurification.js
@@ -1,0 +1,277 @@
+/**
+ * @class The AutomationFocusShadowPurification regroups the 'Focus on' button's 'Shadow cure' functionalities
+ */
+class AutomationFocusShadowPurification
+{
+    /******************************************************************************\
+    |***    Focus specific members, should only be used by focus sub-classes    ***|
+    \******************************************************************************/
+
+    /**
+     * @brief Adds the 'Shadow purify' functionality to the 'Focus on' list
+     *
+     * @param {Array} functionalitiesList: The list to add the functionality to
+     */
+    static __registerFunctionalities(functionalitiesList)
+    {
+        this.__internal__buildShadowDungeonList();
+
+        const isUnlockedCallback = function (){ return pokeballFilterOptions.shadow.canUse(); };
+
+        functionalitiesList.push(
+            {
+                id: "ShadowPurification",
+                name: "Shadow purify",
+                tooltip: "Hunts for pokémons that are corrupted by shadow",
+                run: function (){ this.__internal__start(); }.bind(this),
+                stop: function (){ this.__internal__stop(); }.bind(this),
+                isUnlocked: isUnlockedCallback,
+                refreshRateAsMs: Automation.Focus.__noFunctionalityRefresh
+            });
+    }
+
+    /*********************************************************************\
+    |***    Internal members, should never be used by other classes    ***|
+    \*********************************************************************/
+
+    static __internal__shadowPurificationLoop = null;
+    static __internal__shadowDungeonData = [];
+
+    static __internal__currentDungeonData = null;
+
+    /**
+     * @brief Starts the shadow purification automation
+     */
+    static __internal__start()
+    {
+        // Set shadow purification loop
+        this.__internal__shadowPurificationLoop = setInterval(this.__internal__focusOnShadowPurification.bind(this), 10000); // Runs every 10 seconds
+        this.__internal__focusOnShadowPurification();
+
+        // Disable other modes button
+        const disableReason = "The 'Focus on Shadow purify' feature is enabled";
+        Automation.Menu.setButtonDisabledState(Automation.Click.Settings.FeatureEnabled, true, disableReason);
+
+        // Force enable other modes
+        Automation.Click.toggleAutoClick(true);
+    }
+
+    /**
+     * @brief Stops the shadow purification automation
+     */
+    static __internal__stop()
+    {
+        this.__internal__currentRouteData = null;
+        this.__internal__currentDungeonData = null;
+
+        // Unregister the loop
+        clearInterval(this.__internal__shadowPurificationLoop);
+        this.__internal__shadowPurificationLoop = null;
+
+        // Disable automation catch filter
+        Automation.Utils.Pokeball.disableAutomationFilter();
+
+        // Reset other modes status
+        Automation.Click.toggleAutoClick();
+
+        // Re-enable other modes button
+        Automation.Menu.setButtonDisabledState(Automation.Click.Settings.FeatureEnabled, false);
+    }
+
+    /**
+     * @brief The shadow purification main loop
+     *
+     * @note If the user is in a state in which he cannot be moved, the feature is automatically disabled.
+     */
+    static __internal__focusOnShadowPurification()
+    {
+        // Already fighting, nothing to do for now
+        if (Automation.Utils.isInInstanceState())
+        {
+            if ((this.__internal__currentDungeonData == null)
+                || !this.__internal__doesDungeonHaveAnyUncaughtShadowPokemon(this.__internal__currentDungeonData.dungeon, true))
+            {
+                Automation.Focus.__ensureNoInstanceIsInProgress();
+            }
+            return;
+        }
+
+        // If the currently used dungeon still has contagious pokémons, continue with it
+        if ((this.__internal__currentDungeonData != null)
+            && this.__internal__doesDungeonHaveAnyUncaughtShadowPokemon(this.__internal__currentDungeonData.dungeon, true))
+        {
+            this.__internal__captureShadowPokemons();
+            return;
+        }
+
+        // Try the next dungeon
+        this.__internal__setNextShadowDungeon();
+
+        if (this.__internal__currentDungeonData != null)
+        {
+            this.__internal__captureShadowPokemons();
+        }
+        else
+        {
+            // TODO: farm XP until every pokemon are purified
+
+            // No more location available, stop the focus
+            Automation.Menu.forceAutomationState(Automation.Focus.Settings.FeatureEnabled, false);
+            Automation.Notifications.sendWarningNotif("No more dungeon available to capture Shadow pokémons.\nTurning the feature off",
+                                                      "Focus");
+        }
+    }
+
+    /**
+     * @brief Goes to the selected location to catch pokémons
+     */
+    static __internal__captureShadowPokemons()
+    {
+        // Equip the Oak item catch loadout
+        Automation.Focus.__equipLoadout(Automation.Utils.OakItem.Setup.PokemonCatch);
+
+        // Ensure that the player has some balls available
+        if (!Automation.Focus.__ensurePlayerHasEnoughBalls(Automation.Focus.__pokeballToUseSelectElem.value))
+        {
+            Automation.Utils.disableAutomationFilter();
+            return;
+        }
+
+        // Go farm some dungeon token if needed
+        if (App.game.wallet.currencies[GameConstants.Currency.dungeonToken]() < this.__internal__currentDungeonData.dungeon.tokenCost)
+        {
+            Automation.Utils.disableAutomationFilter();
+            Automation.Focus.__goToBestRouteForDungeonToken();
+            return;
+        }
+
+        // Equip an "Already caught shadow" pokeball
+        Automation.Utils.Pokeball.catchEverythingWith(Automation.Focus.__pokeballToUseSelectElem.value);
+        Automation.Utils.Pokeball.restrictCaptureToShadow(false);
+
+        // Move to dungeon if needed
+        if (!Automation.Utils.Route.isPlayerInTown(this.__internal__currentDungeonData.dungeon.name))
+        {
+            Automation.Utils.Route.moveToTown(this.__internal__currentDungeonData.dungeon.name);
+
+            // Let a second for the menu to show up
+            setTimeout(this.__internal__captureShadowPokemons.bind(this), 1000);
+            return;
+        }
+
+        // Enable auto dungeon fight
+        Automation.Menu.forceAutomationState(Automation.Dungeon.Settings.FeatureEnabled, true);
+
+        // Bypass user settings, especially the 'Skip fights' one
+        Automation.Dungeon.AutomationRequestedMode = Automation.Dungeon.InternalModes.ForcePokemonFight;
+    }
+
+    /**
+     * @brief Gets the next dungeon to catch Shadow pokémons
+     */
+    static __internal__setNextShadowDungeon()
+    {
+        // Remove the current dungeon from the list if completed
+        if ((this.__internal__currentDungeonData != null)
+            && !this.__internal__doesDungeonHaveAnyUncaughtShadowPokemon(this.__internal__currentDungeonData.dungeon))
+        {
+            const index = this.__internal__shadowDungeonData.indexOf(this.__internal__currentDungeonData);
+            this.__internal__shadowDungeonData.splice(index, 1);
+        }
+
+        // Set the next best dungeon
+        this.__internal__currentDungeonData = this.__internal__shadowDungeonData.find(
+            (data) => this.__internal__doesDungeonHaveAnyUncaughtShadowPokemon(data.dungeon, true)
+                      // Don't consider dungeon that the player can't access yet
+                   && Automation.Utils.Route.canMoveToTown(TownList[data.dungeon.name]), this);
+    }
+
+    /**
+     * @brief Builds the internal list of dungeon with at least one uncaught shadow pokémon
+     */
+    static __internal__buildShadowDungeonList()
+    {
+        for (const dungeonName of Object.keys(dungeonList))
+        {
+            const town = TownList[dungeonName];
+
+            // Orre is the only subregion where Shadow pokemon appears
+            if ((town.region != GameConstants.Region.hoenn)
+                || (town.subRegion != GameConstants.HoennSubRegions.Orre))
+            {
+                continue;
+            }
+
+            const dungeon = dungeonList[dungeonName];
+            // Don't add dungeons that are already cured
+            if (this.__internal__doesDungeonHaveAnyUncaughtShadowPokemon(dungeon))
+            {
+                this.__internal__shadowDungeonData.push({ dungeon });
+            }
+        }
+    }
+
+    /**
+     * @brief Checks if any shadow pokémon from the given @p dungeon needs to be caught
+     *
+     * @param dungeon: The dungeon to check
+     * @param {boolean} onlyConsiderAvailablePokemons: Whether only currently available pokémon should be considered
+     *
+     * @returns True if every pokémons are caught, false otherwise
+     */
+    static __internal__doesDungeonHaveAnyUncaughtShadowPokemon(dungeon, onlyConsiderAvailablePokemons = false)
+    {
+        const pokemonList = this.__internal__getEveryPokemonForDungeon(dungeon, onlyConsiderAvailablePokemons);
+
+        return pokemonList.some((pokemonName) =>
+            {
+                const pokemon = App.game.party.getPokemonByName(pokemonName);
+
+                return !(pokemon?.shadow != GameConstants.ShadowStatus.None);
+            });
+    }
+
+    /**
+     * @brief Gets the list of possible pokémon for the given @p dungeon
+     *
+     * @param dungeon: The dungeon to get the pokémon of
+     * @param {boolean} onlyConsiderAvailablePokemons: Whether only currently available pokémon should be considered
+     *
+     * @returns The list of pokémon
+     */
+    static __internal__getEveryPokemonForDungeon(dungeon, onlyConsiderAvailablePokemons)
+    {
+        let pokemonList = [];
+
+        // Concatenate bosses and enemies
+        const enemyList = [...dungeon.enemyList];
+        for (const boss of dungeon.bossList)
+        {
+            enemyList.push(boss)
+        }
+
+        // Add shadow pokemons
+        for (const enemy of enemyList)
+        {
+            // Don't consider locked enemies, if we're only considering available pokémons
+            if (onlyConsiderAvailablePokemons)
+            {
+                const isEnemyLocked = enemy.options?.requirement ? !enemy.options?.requirement.isCompleted() : false;
+                if (isEnemyLocked) continue;
+            }
+
+            for (const pokemon of enemy.team)
+            {
+                // Only consider Shadow pokémons
+                if (pokemon.shadow != 1) continue;
+
+                if (!pokemonList.includes(pokemon.name))
+                {
+                    pokemonList.push(pokemon.name);
+                }
+            }
+        }
+
+        return pokemonList;
+    }
+}

--- a/src/lib/Utils/Pokeball.js
+++ b/src/lib/Utils/Pokeball.js
@@ -1,5 +1,5 @@
 /**
- * @class The AutomationUtilsPokeball regroups helpers related to pokeclicker ball filters
+ * @class The AutomationUtilsPokeball regroups helpers related to pokeclicker's catch filters
  */
 class AutomationUtilsPokeball
 {
@@ -21,7 +21,7 @@ class AutomationUtilsPokeball
     }
 
     /**
-     * @brief Disables the automation filter
+     * @brief Disables automation catch filter
      */
     static disableAutomationFilter()
     {
@@ -29,7 +29,7 @@ class AutomationUtilsPokeball
     }
 
     /**
-     * @brief Enables the automation filter
+     * @brief Enables the automation catch filter
      */
     static enableAutomationFilter()
     {


### PR DESCRIPTION
The shadow pokémons were introduced in the v0.10.14 update. 
Such pokémon only appear in the new Orre sub-region of Hoenn.

Capturing Shadow pokémon will update their status and they will need to be purified at the Purify Chamber.

This new "Focus on" feature will automatically move to dungeons were there is at least one uncaught shadow pokémon.
It will equip the configure the pokémon catching filter to catch every uncaught shadow pokémon.
Once every shadow pokémon are captured, it will then move to the next dungeon.

The dungeon will try to purify pokémons between each run.
Once all available shadow pokémons are caught, the automation will farm Exp and Purify the remaining shadow pokémons.

Fixes #321 