### PR TITLE
CatchFilters: Handle v0.10.18 new order setting

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@ Pokeclicker-automation aims at automating some recurring tasks that can be a bit
 This script collection does not aim at cheating.
 It will never perform actions that the game would not allow.
 
-Last known compatible pokeclicker version: 0.10.18
+Last known compatible pokeclicker version: 0.10.19
 
 For more details, please refer to the [wiki](../../wiki)
 


### PR DESCRIPTION
The v0.10.18 added a setting to invert the filter priority order.

The automation now puts its filter to the top when this new setting is disabled and to the bottom when enabled.

Fixes #337