### PR TITLE
Hatchery: Fixup sorting button miss-alignment

### DIFF
--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -1735,6 +1735,7 @@ class AutomationMenu
                 width: 25px;
                 height: 25px;
                 white-space: pre;
+                top: 8px;
             }
             .automationDirectionSortButton label
             {


### PR DESCRIPTION
The button was 8px to high compared to the rest of the line