### PR TITLE
Farm: Forbid the Sprinklotad for pinkan unlock

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,9 +11,9 @@ jobs:
   Run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 

--- a/src/lib/Farm.js
+++ b/src/lib/Farm.js
@@ -1172,7 +1172,7 @@ class AutomationFarm
         pinkanConfig[BerryType.Qualot] = [ 10, 14 ];
         pinkanConfig[BerryType.Magost] = [ 11, 13 ];
         pinkanConfig[BerryType.Watmel] = [ 12 ];
-        this.__internal__addUnlockMutationStrategy(BerryType.Pinkan, pinkanConfig);
+        this.__internal__addUnlockMutationStrategy(BerryType.Pinkan, pinkanConfig, 1, null, [ OakItemType.Sprinklotad ]);
 
         // Make the pinkan berry optional, since it's not required by any other berry strategy
         const pinkanStrategy = this.__internal__unlockStrategySelection.at(-1);

--- a/tst/tests/Farm/UnlockStrategies.test.in.js
+++ b/tst/tests/Farm/UnlockStrategies.test.in.js
@@ -1417,7 +1417,7 @@ describe(`${AutomationTestUtils.categoryPrefix}Gen 3 unlocks`, () =>
         expectedConfig[BerryType.Watmel] = [ 12 ];
         const expectedOrder = [ BerryType.Watmel, BerryType.Magost, BerryType.Qualot, BerryType.Mago,
                                 BerryType.Nanab, BerryType.Persim, BerryType.Pecha ];
-        runBerryMutationTest(BerryType.Pinkan, expectedConfig, expectedOrder);
+        runBerryMutationTest(BerryType.Pinkan, expectedConfig, expectedOrder, null, [ OakItemType.Sprinklotad ]);
     });
 
     // Test the Gen 3 berry gathering


### PR DESCRIPTION
The Sprinklotad Oak item can mutate the Watmel berry into a Shuca, ruining the strategy

It should prevent #344 from happening, as long as the user did not disable the `Update oak item loadout when needed` advanced setting