### PR TITLE
Focus: Fixup pokeball filter crash

### DIFF
--- a/src/lib/Focus/PokerusCure.js
+++ b/src/lib/Focus/PokerusCure.js
@@ -188,7 +188,7 @@ class AutomationFocusPokerusCure
         // Ensure that the player has some balls available
         if (!Automation.Focus.__ensurePlayerHasEnoughBalls(Automation.Focus.__pokeballToUseSelectElem.value))
         {
-            Automation.Utils.disableAutomationFilter();
+            Automation.Utils.Pokeball.disableAutomationFilter();
             return;
         }
 
@@ -196,7 +196,7 @@ class AutomationFocusPokerusCure
         if ((this.__internal__currentDungeonData != null)
             && App.game.wallet.currencies[GameConstants.Currency.dungeonToken]() < this.__internal__currentDungeonData.dungeon.tokenCost)
         {
-            Automation.Utils.disableAutomationFilter();
+            Automation.Utils.Pokeball.disableAutomationFilter();
             Automation.Focus.__goToBestRouteForDungeonToken();
             return;
         }

--- a/src/lib/Focus/ShadowPurification.js
+++ b/src/lib/Focus/ShadowPurification.js
@@ -145,14 +145,14 @@ class AutomationFocusShadowPurification
         // Ensure that the player has some balls available
         if (!Automation.Focus.__ensurePlayerHasEnoughBalls(Automation.Focus.__pokeballToUseSelectElem.value))
         {
-            Automation.Utils.disableAutomationFilter();
+            Automation.Utils.Pokeball.disableAutomationFilter();
             return;
         }
 
         // Go farm some dungeon token if needed
         if (App.game.wallet.currencies[GameConstants.Currency.dungeonToken]() < this.__internal__currentDungeonData.dungeon.tokenCost)
         {
-            Automation.Utils.disableAutomationFilter();
+            Automation.Utils.Pokeball.disableAutomationFilter();
             Automation.Focus.__goToBestRouteForDungeonToken();
             return;
         }


### PR DESCRIPTION
The disableAutomationFilter function was moved to the Pokeball class. 
It was not updated everywhere in the codebase.
The right class is now used everywhere.