### PR TITLE
Safari: Fixup repeat type reseting to "only-once"

### DIFF
--- a/src/lib/Instances/Safari.js
+++ b/src/lib/Instances/Safari.js
@@ -655,16 +655,15 @@ class AutomationSafari
         // Don't move if the player is still moving
         if (Safari.walking || Safari.isMoving) return;
 
-        let dest;
+        let dest = this.__internal__safariMovesList.at(-1);
         if (this.__internal__safariMovesList.length > 2)
         {
-            dest = this.__internal__safariMovesList.at(-1);
             this.__internal__safariMovesList.pop();
         }
-        else
+        else if ((dest.x == Safari.playerXY.x) && (dest.y == Safari.playerXY.y))
         {
             // Two moves left, alternate between those until a fight pops
-            dest = this.__internal__safariMovesList.find(t => ((t.x != Safari.playerXY.x) || (t.y != Safari.playerXY.y)));
+            dest = this.__internal__safariMovesList[0];
         }
         this.__internal__moveToTile(dest.x, dest.y);
     }

--- a/src/lib/Instances/Safari.js
+++ b/src/lib/Instances/Safari.js
@@ -23,6 +23,9 @@ class AutomationSafari
             Automation.Utils.LocalStorage.setDefaultValue(this.Settings.CollectItems, true);
             Automation.Utils.LocalStorage.setDefaultValue(this.Settings.FocusOnBaitAchievements, false);
 
+            // Set to solo run by default
+            Automation.Utils.LocalStorage.setDefaultValue(this.Settings.InfinitRepeat, false);
+
             this.__internal__buildMenu();
 
             // Disable the feature by default
@@ -164,9 +167,6 @@ class AutomationSafari
         /**************************\
         |***   Repeat button    ***|
         \**************************/
-
-        // Set to solo run by default
-        Automation.Utils.LocalStorage.setValue(this.Settings.InfinitRepeat, false);
 
         const repeatButtonContainer = document.createElement("div");
         repeatButtonContainer.style.display = "inline-block";


### PR DESCRIPTION
The default was always set to false during Automation start-up. It's now only set if no value was previously set.

---

When the following case occurred:
![image](https://github.com/Farigh/pokeclicker-automation/assets/11090416/5f74f01a-8f1b-4cb3-b7ba-62f93cb6e931)
(With the target area in red)

The automation was stuck and never moved.
The automation target order was changed to prevent this to occur.
