### PR TITLE
Focus.Achievements: Handle Orre quests

### DIFF
--- a/src/lib/Farm.js
+++ b/src/lib/Farm.js
@@ -861,7 +861,7 @@ class AutomationFarm
 
         if (App.game.farming.hasBerry(berryType))
         {
-            App.game.farming.plant(index, berryType, true);
+            App.game.farming.plant(index, berryType);
             this.__internal__plantedBerryCount++;
             return true;
         }
@@ -1916,7 +1916,7 @@ class AutomationFarm
                         if (App.game.farming.plotList[plotIndex].isUnlocked
                             && App.game.farming.plotList[plotIndex].isEmpty())
                         {
-                            App.game.farming.plant(plotIndex, berryType, true);
+                            App.game.farming.plant(plotIndex, berryType);
 
                             // Subtract the harvest amount (-1 for the planted berry)
                             neededAmount -= (berryHarvestAmount - 1);

--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -370,9 +370,15 @@ class AutomationFocusAchievements
     static __internal__getRegionFromCategoryName(categoryName)
     {
         // Handle Sevii Island content at the same time as Hoenn content
-        if (categoryName == "sevii")
+        if ((categoryName == "sevii"))
         {
             return GameConstants.Region.hoenn;
+        }
+
+        // Handle Orre content at the same time as Sinnoh content
+        if ((categoryName == "orre"))
+        {
+            return GameConstants.Region.sinnoh;
         }
 
         // Handle Magikarp Jump Island content at the same time as Galar content, unless the user chose to do it last


### PR DESCRIPTION
Orre quests are now set to be handled at the same time as Sinnoh ones

Fixes #355 