### PR TITLE
Dungeon: Add chest pick up min rarity setting

### DIFF
--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -370,13 +370,13 @@ class AutomationFocusAchievements
     static __internal__getRegionFromCategoryName(categoryName)
     {
         // Handle Sevii Island content at the same time as Hoenn content
-        if ((categoryName == "sevii"))
+        if (categoryName == "sevii")
         {
             return GameConstants.Region.hoenn;
         }
 
         // Handle Orre content at the same time as Sinnoh content
-        if ((categoryName == "orre"))
+        if (categoryName == "orre")
         {
             return GameConstants.Region.sinnoh;
         }

--- a/src/lib/Hatchery.js
+++ b/src/lib/Hatchery.js
@@ -798,7 +798,7 @@ class AutomationHatchery
     static __internal__addFossilsToHatchery()
     {
         const currentlyHeldFossils =
-            UndergroundItems.list.filter(it => it.valueType === UndergroundItemValueType.Fossil && player.itemList[it.itemName]() > 0);
+            UndergroundItems.list.filter((it) => it.valueType === UndergroundItemValueType.Fossil && player.itemList[it.itemName]() > 0);
 
         let i = 0;
         while (App.game.breeding.hasFreeEggSlot() && (i < currentlyHeldFossils.length))

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -1383,6 +1383,9 @@ class AutomationMenu
                 border-radius: 5px;
                 width: fit-content;
                 position: absolute;
+
+                /* Work around any overlapping issues */
+                z-index: 9999;
             }
 
             .automationCustomDropdownOptions.visible


### PR DESCRIPTION
The user can now choose the minimum rarity for chest pick up. 
![image](https://github.com/Farigh/pokeclicker-automation/assets/11090416/e0b0bc93-b313-49d2-b648-7b10fc13e5b3)

Any rarity lower than the selected one will be ignored.

This setting is ignored if the chest pick up feature is disabled.

---

Removed the 'Skip chests pickup' setting

The chest min rarity dropdown is now used for this as well

Fixes #357 