### PR TITLE
Focus.Quests: Don't try to catch shadows if dungeon doesn't have any

### DIFF
--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -420,7 +420,8 @@ class AutomationFocusQuests
         }
         else if (Automation.Utils.isInstanceOf(quest, "DefeatDungeonQuest"))
         {
-            const catchShadows = currentQuests.some((quest) => Automation.Utils.isInstanceOf(quest, "CatchShadowsQuest"));
+            const catchShadows = currentQuests.some((quest) => Automation.Utils.isInstanceOf(quest, "CatchShadowsQuest"))
+                              && Automation.Dungeon.hasShadowPokemons(quest.dungeon);
             this.__internal__workOnDefeatDungeonQuest(quest.dungeon, catchShadows);
         }
         else if (Automation.Utils.isInstanceOf(quest, "DefeatGymQuest"))

--- a/src/lib/Focus/ShadowPurification.js
+++ b/src/lib/Focus/ShadowPurification.js
@@ -217,11 +217,8 @@ class AutomationFocusShadowPurification
     {
         for (const dungeonName of Object.keys(dungeonList))
         {
-            const town = TownList[dungeonName];
-
-            // Orre is the only subregion where Shadow pokemon appears
-            if ((town.region != GameConstants.Region.hoenn)
-                || (town.subRegion != GameConstants.HoennSubRegions.Orre))
+            // Only consider dungeons that have shadow pokémons
+            if (!Automation.Dungeon.hasShadowPokemons(dungeonName))
             {
                 continue;
             }

--- a/src/lib/Instances/Dungeon.js
+++ b/src/lib/Instances/Dungeon.js
@@ -64,6 +64,22 @@ class AutomationDungeon
     }
 
     /**
+     * @brief Checks if the given dungeon has any shadow pokémon
+     *
+     * @param {string} dungeonName: The name of the dungeon
+     *
+     * @return true if the dungeon has shadow pokémons, false otherwise
+     */
+    static hasShadowPokemons(dungeonName)
+    {
+        const town = TownList[dungeonName];
+
+        // Orre is the only subregion where shadow pokemons appear
+        return (town.region == GameConstants.Region.hoenn)
+            && (town.subRegion == GameConstants.HoennSubRegions.Orre);
+    }
+
+    /**
      * @brief Asks the Dungeon automation to stop after the current run
      *
      * @note This will reset any "after run" callback
@@ -446,7 +462,7 @@ class AutomationDungeon
         //    - The player is in a town (dungeons are attached to town)
         //    - The player has bought the dungeon ticket
         //    - The player has enough dungeon token
-        if (App.game.gameState === GameConstants.GameState.town
+        if ((App.game.gameState === GameConstants.GameState.town)
             && Automation.Utils.isInstanceOf(player.town(), "DungeonTown")
             && App.game.keyItems.hasKeyItem(KeyItemType.Dungeon_ticket)
             && (App.game.wallet.currencies[GameConstants.Currency.dungeonToken]() >= player.town().dungeon.tokenCost))


### PR DESCRIPTION
The automation will try to kill two birds with one stone when both `Defeat the <Dungeon> <n> times` and `Catch <n> Shadow Pokémon` quests are active.

It will now only try to capture shadow pokémons the former quest's dungeon if it can have shadow pokémons.

Fixes ? #359 