### PR TITLE
v0.10.20 regressions fixup

### DIFF
--- a/src/lib/Focus.js
+++ b/src/lib/Focus.js
@@ -192,7 +192,7 @@ class AutomationFocus
             const pokeballItem = ItemList[pokeballName];
 
             // No more money, or too expensive, go farm some money
-            if ((App.game.wallet.currencies[Currency.money]() < pokeballItem.totalPrice(10))
+            if ((App.game.wallet.currencies[GameConstants.Currency.money]() < pokeballItem.totalPrice(10))
                 || (pokeballItem.totalPrice(1) !== pokeballItem.basePrice))
             {
                 this.__internal__goToBestGymForMoney();

--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -243,7 +243,7 @@ class AutomationFocusAchievements
     {
         let targetedDungeonName = GameConstants.RegionDungeons.flat()[this.__internal__currentAchievement.property.dungeonIndex];
         // If we don't have enough tokens, go farm some
-        if (TownList[targetedDungeonName].dungeon.tokenCost > App.game.wallet.currencies[Currency.dungeonToken]())
+        if (TownList[targetedDungeonName].dungeon.tokenCost > App.game.wallet.currencies[GameConstants.Currency.dungeonToken]())
         {
             Automation.Focus.__goToBestRouteForDungeonToken();
             return;

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -584,7 +584,7 @@ class AutomationFocusQuests
     static __internal__workOnDefeatDungeonQuest(dungeonName, catchShadows)
     {
         // If we don't have enough tokens, go farm some
-        if (TownList[dungeonName].dungeon.tokenCost > App.game.wallet.currencies[Currency.dungeonToken]())
+        if (TownList[dungeonName].dungeon.tokenCost > App.game.wallet.currencies[GameConstants.Currency.dungeonToken]())
         {
             this.__internal__workOnUsePokeballQuest(Automation.Focus.__pokeballToUseSelectElem.value);
             return;

--- a/src/lib/Utils/Route.js
+++ b/src/lib/Utils/Route.js
@@ -267,7 +267,7 @@ class AutomationUtilsRoute
         const catchTimeTicks = App.game.pokeballs.calculateCatchTime(ballTypeToUse) / 50;
 
         // The bonus is the same, no matter the amount
-        const dungeonTokenBonus = App.game.wallet.calcBonus(new Amount(1, Currency.dungeonToken));
+        const dungeonTokenBonus = App.game.wallet.calcBonus(new Amount(1, GameConstants.Currency.dungeonToken));
 
         const pokeballBonus = App.game.pokeballs.getCatchBonus(ballTypeToUse);
         const oakBonus = App.game.oakItems.calculateBonus(OakItemType.Magic_Ball);

--- a/src/lib/Utils/Route.js
+++ b/src/lib/Utils/Route.js
@@ -28,7 +28,7 @@ class AutomationUtilsRoute
     static moveToRoute(route, region)
     {
         // Don't move if the player is already there, or the game would not allow it
-        if (((player.route() === route) && (player.region === region))
+        if (((player.route === route) && (player.region === region))
             || !this.canMoveToRoute(route, region))
         {
             return;
@@ -81,7 +81,7 @@ class AutomationUtilsRoute
     static isPlayerInTown(townName)
     {
         // player.town() points to the last visited town, so we need to check if the current route is 0 as well
-        return (player.route() == 0) && (player.town().name == townName);
+        return (player.route == 0) && (player.town().name == townName);
     }
 
     /**

--- a/tst/stubs/GameConstants.pokeclicker.stub.js
+++ b/tst/stubs/GameConstants.pokeclicker.stub.js
@@ -265,6 +265,3 @@ class GameConstants
     static GYM_GEMS = 5;
     static MAX_AVAILABLE_REGION = this.Region.alola;
 }
-
-// Aliases
-let Currency = GameConstants.Currency;

--- a/tst/stubs/MapHelper.pokeclicker.stub.js
+++ b/tst/stubs/MapHelper.pokeclicker.stub.js
@@ -19,7 +19,7 @@ class MapHelper
 
         if (this.accessToRoute(route, region))
         {
-            player.__route = route;
+            player.route = route;
             // Skipped subregion
             if (player.region != region)
             {

--- a/tst/stubs/Player.pokeclicker.stub.js
+++ b/tst/stubs/Player.pokeclicker.stub.js
@@ -12,7 +12,7 @@ class Player
         this.__itemListCount = [];
 
         this.__highestRegion = 0;
-        this.__route = 0;
+        this.route = 0;
 
         this.__initItemList();
     }
@@ -25,11 +25,6 @@ class Player
     loseItem(itemName, amount)
     {
         this.__itemListCount[itemName] -= amount;
-    }
-
-    route()
-    {
-        return this.__route;
     }
 
     /***************************\

--- a/tst/tests/Utils/Route.test.in.js
+++ b/tst/tests/Utils/Route.test.in.js
@@ -73,7 +73,7 @@ beforeEach(() =>
     App.game.party.__reset();
     App.game.party.caughtPokemon = onlyEggsPokemons;
     player.region = -1;
-    player.__route = -1;
+    player.route = -1;
 });
 
 // Test moveToBestRouteForExp() method
@@ -85,7 +85,7 @@ describe(`${AutomationTestUtils.categoryPrefix}Check moveToBestRouteForExp() met
         App.game.party.__clickAttack = 500;
 
         Automation.Utils.Route.moveToBestRouteForExp();
-        expect(player.route()).toEqual(3);
+        expect(player.route).toEqual(3);
         expect(player.region).toEqual(GameConstants.Region.kanto);
     });
 
@@ -95,7 +95,7 @@ describe(`${AutomationTestUtils.categoryPrefix}Check moveToBestRouteForExp() met
         App.game.party.__clickAttack = 95000;
 
         Automation.Utils.Route.moveToBestRouteForExp();
-        expect(player.route()).toEqual(37);
+        expect(player.route).toEqual(37);
         expect(player.region).toEqual(GameConstants.Region.johto);
     });
 
@@ -106,7 +106,7 @@ describe(`${AutomationTestUtils.categoryPrefix}Check moveToBestRouteForExp() met
         App.game.challenges.list.disableClickAttack.__active = true;
 
         Automation.Utils.Route.moveToBestRouteForExp();
-        expect(player.route()).toEqual(25);
+        expect(player.route).toEqual(25);
         expect(player.region).toEqual(GameConstants.Region.kanto);
     });
 });
@@ -123,7 +123,7 @@ describe(`${AutomationTestUtils.categoryPrefix}Check moveToHighestDungeonTokenIn
         App.game.party.__clickAttack = 5;
 
         Automation.Utils.Route.moveToHighestDungeonTokenIncomeRoute(GameConstants.Pokeball.Pokeball);
-        expect(player.route()).toEqual(2);
+        expect(player.route).toEqual(2);
         expect(player.region).toEqual(GameConstants.Region.kanto);
     });
 
@@ -136,7 +136,7 @@ describe(`${AutomationTestUtils.categoryPrefix}Check moveToHighestDungeonTokenIn
         App.game.party.__clickAttack = 5;
 
         Automation.Utils.Route.moveToHighestDungeonTokenIncomeRoute(GameConstants.Pokeball.Ultraball);
-        expect(player.route()).toEqual(22);
+        expect(player.route).toEqual(22);
         expect(player.region).toEqual(GameConstants.Region.kanto);
     });
 
@@ -145,7 +145,7 @@ describe(`${AutomationTestUtils.categoryPrefix}Check moveToHighestDungeonTokenIn
         App.game.party.__clickAttack = 10000;
 
         Automation.Utils.Route.moveToHighestDungeonTokenIncomeRoute(GameConstants.Pokeball.Ultraball);
-        expect(player.route()).toEqual(29);
+        expect(player.route).toEqual(29);
         expect(player.region).toEqual(GameConstants.Region.johto);
     });
 
@@ -155,7 +155,7 @@ describe(`${AutomationTestUtils.categoryPrefix}Check moveToHighestDungeonTokenIn
         App.game.challenges.list.disableClickAttack.__active = true;
 
         Automation.Utils.Route.moveToHighestDungeonTokenIncomeRoute(GameConstants.Pokeball.Ultraball);
-        expect(player.route()).toEqual(25);
+        expect(player.route).toEqual(25);
         expect(player.region).toEqual(GameConstants.Region.kanto);
     });
 });


### PR DESCRIPTION
The new version 0.10.20 juste came out a broke some interfaces.

This PR fixes the most obvious ones (hopefully the only ones) : 
   - `Currency` is now only accessible via `GameConstants`
   - `player.route` is not a callback anymore
   
Adresses (part of) #363 