### PR TITLE
Hatchery: Add Category sorting priority

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@ Pokeclicker-automation aims at automating some recurring tasks that can be a bit
 This script collection does not aim at cheating.
 It will never perform actions that the game would not allow.
 
-Last known compatible pokeclicker version: 0.10.19
+Last known compatible pokeclicker version: 0.10.20
 
 For more details, please refer to the [wiki](../../wiki)
 

--- a/tst/imports/Pokeclicker.import.js
+++ b/tst/imports/Pokeclicker.import.js
@@ -96,6 +96,7 @@ import "tst/stubs/MapHelper.pokeclicker.stub.js";
 import "tst/stubs/Player.pokeclicker.stub.js";
 import "tst/stubs/Save.pokeclicker.stub.js";
 import "tst/stubs/Statistics.pokeclicker.stub.js";
+import "tst/stubs/Category.pokeclicker.stub.js";
 
 // Import the main class
 import "tst/stubs/App.pokeclicker.stub.js";

--- a/tst/stubs/Category.pokeclicker.stub.js
+++ b/tst/stubs/Category.pokeclicker.stub.js
@@ -1,0 +1,16 @@
+// Stub of https://github.com/pokeclicker/pokeclicker/blob/9828628acc9142075e6108b54b5b992bc2196282/src/modules/party/Category.ts#L19
+class PokemonCategories {
+    /***************************\
+    |*  Pokéclicker interface  *|
+    \***************************/
+
+    static __categories = [
+                              { id: 0, name: () => 'None', color: () => '#333333' },
+                              { id: 1, name: () => 'Favorite', color: () => '#e74c3c' }
+                          ];
+
+    static categories()
+    {
+        return this.__categories
+    }
+}

--- a/tst/stubs/Pokemon/PartyPokemon.pokeclicker.stub.js
+++ b/tst/stubs/Pokemon/PartyPokemon.pokeclicker.stub.js
@@ -6,6 +6,7 @@ class PartyPokemon
     {
         this.attackBonusPercent = 0;
         this.attackBonusAmount = 0;
+        this.category = [0]
         this.breading = false;
         this.baseAttack = baseAttack;
         this.effortPoints = 0;
@@ -40,5 +41,36 @@ class PartyPokemon
     {
         const power = App.game.challenges.list.slowEVs.active() ? GameConstants.EP_CHALLENGE_MODIFIER : 1;
         return Math.floor(this.effortPoints / GameConstants.EP_EV_RATIO / power);
+    }
+
+    /***************************\
+    |*   Test-only interface   *|
+    \***************************/
+
+    __addCategory(id)
+    {
+        if (id == 0)
+        {
+            this.category = [0];
+        }
+        else if (!this.category.includes(id))
+        {
+            this.category.push(id);
+        }
+    }
+
+    __removeCategory(id)
+    {
+        if ((id == 0) && (this.category.length == 1))
+        {
+            // Can't remove None category without another category present
+            return;
+        }
+
+        const index = this.category.indexOf(id);
+        if (index > -1)
+        {
+            this.category.splice(index, 1);
+        }
     }
 }


### PR DESCRIPTION
Adresses #270 

I was interested in this feature ! I too wanted to prioritize my roster pokemons while being able to sort on breading efficiency for example.

I also added a watcher to update the select whenever categories are updated by the user.
Because this feature is likely to be the most restrictive (least amount of positive matches), I believe it's most efficient to use it as the very first sort option.

![image](https://github.com/Farigh/pokeclicker-automation/assets/35381919/f8ff007e-3e25-4d0f-b14f-2c049b6c992d)