### PR TITLE
Focus.Quests: Fixup pokéball filter for shadow quests

### DIFF
--- a/src/lib/Farm.js
+++ b/src/lib/Farm.js
@@ -528,6 +528,9 @@ class AutomationFarm
         }
     }
 
+    /**
+     * @brief Catches any wandering pokémon present on any farm plot
+     */
     static __internal__catchWanderingPokemons()
     {
         if (Automation.Utils.LocalStorage.getValue(this.Settings.AutoCatchWanderers) !== "true")

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -593,6 +593,7 @@ class AutomationFocusQuests
         if (catchShadows)
         {
             this.__internal__equipOptimizedLoadout(Automation.Utils.OakItem.Setup.PokemonCatch);
+            Automation.Utils.Pokeball.catchEverythingWith(Automation.Focus.__pokeballToUseSelectElem.value);
             Automation.Utils.Pokeball.restrictCaptureToShadow(true);
             Automation.Utils.Pokeball.enableAutomationFilter();
         }


### PR DESCRIPTION
The automation filter was never cleared and any previously set restriction would temper with the capture.

The filter is now reset properly

Fixes #371