### PR TITLE
Focus.Achievements: Make types skippable

### DIFF
--- a/src/lib/Click.js
+++ b/src/lib/Click.js
@@ -152,7 +152,8 @@ class AutomationClick
         clickIntervalContainer.appendChild(document.createTextNode("Click interval :"));
 
         // Add tooltip
-        const clickIntervalTooltip = "Set the interval between each click in milliseconds.";
+        const clickIntervalTooltip = "Set the interval between each click in milliseconds.\n"
+                                     "Note that the game has a minimum hard-cap of 50ms";
         clickIntervalContainer.classList.add("hasAutomationTooltip");
         clickIntervalContainer.classList.add("clickAttackIntervalAutomationTooltip");
         clickIntervalContainer.setAttribute("automation-tooltip-text", clickIntervalTooltip);

--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -7,9 +7,11 @@ class AutomationFocusAchievements
     |***    Focus specific members, should only be used by focus sub-classes    ***|
     \******************************************************************************/
 
-    static __internal__advancedSettings = {
-                                              DoMagikarpJumpLast: "Focus-Achievements-DoMagikarpIslandLast"
-                                          };
+    static __internal__advancedSettings =
+        {
+            DoMagikarpJumpLast: "Focus-Achievements-DoMagikarpIslandLast",
+            AchievementEnabled: function(type, amount) { return `Focus-Achievements-${type}-${amount}-Enabled`; }.bind(this)
+        };
 
     // Internal copy of supported achievements left to perform
     static __internal__filteredAchievementList = [];
@@ -21,12 +23,6 @@ class AutomationFocusAchievements
      */
     static __registerFunctionalities(functionalitiesList)
     {
-        // For now, initialize the achievement list here
-        this.__internal__filteredAchievementList = AchievementHandler.achievementList.filter(
-            (achievement) => Automation.Utils.isInstanceOf(achievement.property, "RouteKillRequirement")
-                          || Automation.Utils.isInstanceOf(achievement.property, "ClearGymRequirement")
-                          || Automation.Utils.isInstanceOf(achievement.property, "ClearDungeonRequirement"))
-
         functionalitiesList.push(
             {
                 id: "Achievements",
@@ -62,12 +58,16 @@ class AutomationFocusAchievements
 
         button.addEventListener("click", function()
             {
-                // Force current achievement update
+                // Don't do anything if the feature is disabled
                 if (this.__internal__currentAchievement)
                 {
-                    this.__internal__currentAchievement = this.__internal__getNextAchievement();
+                    // Force current achievement update
+                    this.__internal__currentAchievement = null;
                 }
             }.bind(this), false);
+
+        // Build the achievement selection settings
+        this.__internal__buildAchievementSelectionSettings(parent);
     }
 
     /*********************************************************************\
@@ -76,6 +76,64 @@ class AutomationFocusAchievements
 
     static __internal__achievementLoop = null;
     static __internal__currentAchievement = null;
+
+    /**
+     * @brief Builds the achivement selection settings
+     *
+     * @param {Element} parent: The parent div to add the settings to
+     */
+    static __internal__buildAchievementSelectionSettings(parent)
+    {
+        const descriptionElem = document.createElement("span");
+        descriptionElem.textContent = "Choose which achievement should be performed, or skipped";
+        descriptionElem.style.display = "inline-block";
+        descriptionElem.style.marginTop = "10px";
+        parent.appendChild(descriptionElem);
+
+        const tableContainer = document.createElement("div");
+        tableContainer.classList.add("automationTabSubContent");
+        parent.appendChild(tableContainer);
+
+        const tableElem = document.createElement("table");
+        tableElem.style.width = "100%";
+        tableContainer.appendChild(tableElem);
+
+        for (const achievementData of this.__internal__getAchievementsData())
+        {
+            const rowElem = document.createElement("tr");
+            tableElem.appendChild(rowElem);
+
+            const labelCellElem = document.createElement("td");
+            labelCellElem.style.width = "100%"; // Make the cell take the maximum place, for menu consistency
+            labelCellElem.style.paddingLeft = "5px";
+            labelCellElem.style.paddingRight = "7px";
+            labelCellElem.innerHTML = this.__internal__getAchievementLabel(achievementData);
+            rowElem.appendChild(labelCellElem);
+
+            const toggleCellElem = document.createElement("td");
+            toggleCellElem.style.paddingRight = "5px"; // Align toogle with ones outside the sub-content div
+            rowElem.appendChild(toggleCellElem);
+
+            const storageKey = this.__internal__advancedSettings.AchievementEnabled(achievementData.type, achievementData.amount);
+
+            // Enable the achievement by default, unless the user chose to disable settings by default
+            Automation.Utils.LocalStorage.setDefaultValue(storageKey, !Automation.Menu.DisableSettingsByDefault);
+
+            const toggleButton = Automation.Menu.addLocalStorageBoundToggleButton(storageKey);
+            toggleCellElem.appendChild(toggleButton);
+
+            // Every time the status of an achievement changes, we need to refresh the currently selected one
+            toggleButton.addEventListener("click", function()
+                {
+                    // Don't do anything if the feature is disabled
+                    if (this.__internal__currentAchievement)
+                    {
+                        // Force current achievement update
+                        this.__internal__currentAchievement = null;
+                    }
+                }.bind(this), false);
+        }
+    }
 
     /**
      * @brief Starts the achievements automation
@@ -301,6 +359,14 @@ class AutomationFocusAchievements
                     return false;
                 }
 
+                // User might have disable this type of achievements
+                const achievementStorageKey = this.__internal__advancedSettings.AchievementEnabled(achievement.property.constructor.name,
+                                                                                                   achievement.property.requiredValue);
+                if (Automation.Utils.LocalStorage.getValue(achievementStorageKey) !== "true")
+                {
+                    return false;
+                }
+
                 // Consider RouteKill achievements, if the player can move to the target route
                 if (Automation.Utils.isInstanceOf(achievement.property, "RouteKillRequirement"))
                 {
@@ -332,7 +398,8 @@ class AutomationFocusAchievements
                     const dungeonName = GameConstants.RegionDungeons.flat()[achievement.property.dungeonIndex];
                     const town = TownList[dungeonName];
                     return (Automation.Utils.Route.canMoveToRegion(town.region)
-                            && MapHelper.accessToTown(dungeonName));
+                            && MapHelper.accessToTown(dungeonName)
+                            && App.game.keyItems.hasKeyItem(KeyItemType.Dungeon_ticket));
                 }
 
                 return false;
@@ -418,5 +485,54 @@ class AutomationFocusAchievements
 
         // Any unknown content (new sub-region) should be considered last
         return GameConstants.Region[categoryName] ?? GameConstants.Region.final;
+    }
+
+    /**
+     * @brief Gets the list of supported achievement description and associated settings storage key
+     *
+     * @return A list of {description, storage key}
+     */
+    static __internal__getAchievementsData()
+    {
+        // Initialize the achievement list
+        this.__internal__filteredAchievementList = AchievementHandler.achievementList.filter(
+            (achievement) => Automation.Utils.isInstanceOf(achievement.property, "RouteKillRequirement")
+                          || Automation.Utils.isInstanceOf(achievement.property, "ClearGymRequirement")
+                          || Automation.Utils.isInstanceOf(achievement.property, "ClearDungeonRequirement"))
+
+        // Use a set to guarantee unicity
+        let uniqueTypes = new Set();
+
+        let result = [];
+        for (const achievement of this.__internal__filteredAchievementList)
+        {
+            const data = { type: achievement.property.constructor.name, amount: achievement.property.requiredValue };
+            const setKey = `${data.type}-${data.amount}`;
+
+            if (!uniqueTypes.has(setKey))
+            {
+                result.push(data);
+                uniqueTypes.add(setKey);
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * @brief Gets the label to display in the advanced settings list for the given @p achievementData
+     *
+     * @param achievementData: The data to compute the label of
+     *
+     * @returns The HTML-formated label
+     */
+    static __internal__getAchievementLabel(achievementData)
+    {
+        const label = (achievementData.type == "RouteKillRequirement") ? `Defeat ${achievementData.amount} Pokémon on <Route>`
+                    : (achievementData.type == "ClearGymRequirement") ? `Defeat <Gym> in <Region> ${achievementData.amount} times`
+                    :/*achievementData.type == "ClearDungeonRequirement"*/ `Clear <Dungeon> ${achievementData.amount} times`;
+
+        // Escape HTML special char
+        return label.replaceAll(/<([^>]+)>/g, "<i>&lt;$1&gt;</i>").replace(/.$/, "");
     }
 }

--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -11,6 +11,9 @@ class AutomationFocusAchievements
                                               DoMagikarpJumpLast: "Focus-Achievements-DoMagikarpIslandLast"
                                           };
 
+    // Internal copy of supported achievements left to perform
+    static __internal__filteredAchievementList = [];
+
     /**
      * @brief Adds the Achievements functionality to the 'Focus on' list
      *
@@ -18,6 +21,12 @@ class AutomationFocusAchievements
      */
     static __registerFunctionalities(functionalitiesList)
     {
+        // For now, initialize the achievement list here
+        this.__internal__filteredAchievementList = AchievementHandler.achievementList.filter(
+            (achievement) => Automation.Utils.isInstanceOf(achievement.property, "RouteKillRequirement")
+                          || Automation.Utils.isInstanceOf(achievement.property, "ClearGymRequirement")
+                          || Automation.Utils.isInstanceOf(achievement.property, "ClearDungeonRequirement"))
+
         functionalitiesList.push(
             {
                 id: "Achievements",
@@ -274,12 +283,19 @@ class AutomationFocusAchievements
     {
         let result = null;
 
-        const availableAchievements = AchievementHandler.achievementList.filter(
+        let hasCompletedAchievements = false;
+        const availableAchievements = this.__internal__filteredAchievementList.filter(
             (achievement) =>
             {
-                // Only handle supported kinds of achievements, if achievable and not already completed
-                if (achievement.isCompleted()
-                    || !achievement.achievable()
+                // Only handle achievements that are not already completed
+                if (achievement.isCompleted())
+                {
+                    hasCompletedAchievements = true;
+                    return false;
+                }
+
+                // Only handle achievable achievements
+                if (!achievement.achievable()
                     || (achievement.property.region > player.highestRegion()))
                 {
                     return false;
@@ -321,6 +337,13 @@ class AutomationFocusAchievements
 
                 return false;
             });
+
+        // Filter the list if any completed achievement were found
+        if (hasCompletedAchievements)
+        {
+            this.__internal__filteredAchievementList = this.__internal__filteredAchievementList.filter(
+                (achievement) => !achievement.isCompleted());
+        }
 
         if (availableAchievements.length > 0)
         {

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -138,7 +138,7 @@ class AutomationFocusQuests
             rowElem.appendChild(labelCellElem);
 
             const toggleCellElem = document.createElement("td");
-            toggleCellElem.style.paddingRight = "5px"; // Align toogle with ones outside the sub-content div
+            toggleCellElem.style.paddingRight = "5px"; // Align toggle with ones outside the sub-content div
             rowElem.appendChild(toggleCellElem);
 
             const storageKey = this.__internal__advancedSettings.QuestEnabled(quest);

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -107,7 +107,7 @@ class AutomationFocusQuests
     {
         const tooltip = "Skipping quests can be cost-heavy"
         const descriptionElem = document.createElement("span");
-        descriptionElem.textContent = "Choose which quest should be performed, or skipped. ⚠️";
+        descriptionElem.textContent = "Choose which quest should be performed, or skipped ⚠️";
         descriptionElem.classList.add("hasAutomationTooltip");
         descriptionElem.classList.add("rightMostAutomationTooltip");
         descriptionElem.classList.add("shortTransitionAutomationTooltip");
@@ -129,12 +129,16 @@ class AutomationFocusQuests
             tableElem.appendChild(rowElem);
 
             const labelCellElem = document.createElement("td");
+            labelCellElem.style.width = "100%"; // Make the cell take the maximum place, for menu consistency
+            labelCellElem.style.paddingLeft = "5px";
+            labelCellElem.style.paddingRight = "7px";
             let label = this.__internal__questLabels[quest];
             label = label.replaceAll(/<([^>]+)>/g, "<i>&lt;$1&gt;</i>").replace(/.$/, "");
             labelCellElem.innerHTML = label;
             rowElem.appendChild(labelCellElem);
 
             const toggleCellElem = document.createElement("td");
+            toggleCellElem.style.paddingRight = "5px"; // Align toogle with ones outside the sub-content div
             rowElem.appendChild(toggleCellElem);
 
             const storageKey = this.__internal__advancedSettings.QuestEnabled(quest);

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -67,9 +67,9 @@ class AutomationFocusQuests
     static __internal__initializeQuestData()
     {
         this.__internal__questLabels["DefeatPokemonsQuest"] = "Defeat <n> Pokémon on <Route>.";
-        this.__internal__questLabels["CapturePokemonsQuest"] = "Capture <n> Pokémon.";
-        this.__internal__questLabels["CapturePokemonTypesQuest"] = "Capture <n> <Type> Pokémon.";
-        this.__internal__questLabels["ClearBattleFrontierQuest"] = "Clear <n> stages in the Battle Frontier.";
+        this.__internal__questLabels["CapturePokemonsQuest"] = "Capture or hatch <n> Pokémon.";
+        this.__internal__questLabels["CapturePokemonTypesQuest"] = "Capture or hatch <n> <Type> Pokémon.";
+        this.__internal__questLabels["ClearBattleFrontierQuest"] = "Clear <n> Stages in the Battle Frontier.";
         this.__internal__questLabels["GainFarmPointsQuest"] = "Gain <n> Farm Points.";
         this.__internal__questLabels["GainMoneyQuest"] = "Gain <n> Pokédollars.";
         this.__internal__questLabels["GainTokensQuest"] = "Gain <n> Dungeon Tokens.";
@@ -80,7 +80,7 @@ class AutomationFocusQuests
         this.__internal__questLabels["CatchShiniesQuest"] = "Catch 1 shiny Pokémon.";
         this.__internal__questLabels["CatchShadowsQuest"] = "Catch <n> Shadow Pokémon.";
         this.__internal__questLabels["DefeatGymQuest"] = "Defeat <Gym leader> <n> times.";
-        this.__internal__questLabels["DefeatDungeonQuest"] = "Defeat the <Dungeon> <n> times.";
+        this.__internal__questLabels["DefeatDungeonQuest"] = "Defeat the <Dungeon name> dungeon in <Town> <n> times.";
         this.__internal__questLabels["UsePokeballQuest"] = "Use <n> <Balls type>.";
         this.__internal__questLabels["UseOakItemQuest"] = "Equip the <Oak item> and <Action>.";
         this.__internal__questLabels["HarvestBerriesQuest"] = "Harvest <n> <Berry type> Berries at the farm.";

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -1547,7 +1547,7 @@ class AutomationMenu
             }
 
             /*********************\
-            |*   Toogle button   *|
+            |*   Toggle button   *|
             \*********************/
 
             .automation-toggle-button

--- a/src/lib/Shop.js
+++ b/src/lib/Shop.js
@@ -312,9 +312,9 @@ class AutomationShop
         itemData.htmlElems.warning.appendChild(warningIcon);
 
         // Add the toggle button
-        const toogleCell = document.createElement("td");
-        toogleCell.style.paddingLeft = "4px";
-        itemData.htmlElems.row.appendChild(toogleCell);
+        const toggleCell = document.createElement("td");
+        toggleCell.style.paddingLeft = "4px";
+        itemData.htmlElems.row.appendChild(toggleCell);
 
         const itemEnabledKey = this.__internal__advancedSettings.ItemEnabled(itemData.item.name);
         const buttonElem = Automation.Menu.addLocalStorageBoundToggleButton(itemEnabledKey);
@@ -326,7 +326,7 @@ class AutomationShop
                                                  || itemData.isPurchasable();
             }, false);
 
-        toogleCell.appendChild(buttonElem);
+        toggleCell.appendChild(buttonElem);
 
         // Buy count
         const tableBuyLabelCell = document.createElement("td");


### PR DESCRIPTION
The player might not want to do every single achievements, especially the high amount ones.

Toggles are now available in the advanced settings to choose which one to perform, or skip :
![image](https://github.com/user-attachments/assets/2f9cb7ce-f9cc-4be2-b290-90e418445062)

Part of #97