### PR TITLE
Focus: Fixup force enabled modes

### DIFF
--- a/src/lib/Focus/PokerusCure.js
+++ b/src/lib/Focus/PokerusCure.js
@@ -87,16 +87,16 @@ class AutomationFocusPokerusCure
      */
     static __internal__start()
     {
-        // Set pokérus cure loop
-        this.__internal__pokerusCureLoop = setInterval(this.__internal__focusOnPokerusCure.bind(this), 10000); // Runs every 10 seconds
-        this.__internal__focusOnPokerusCure();
-
         // Disable other modes button
         const disableReason = "The 'Focus on Pokérus cure' feature is enabled";
         Automation.Menu.setButtonDisabledState(Automation.Click.Settings.FeatureEnabled, true, disableReason);
 
         // Force enable other modes
         Automation.Click.toggleAutoClick(true);
+
+        // Set pokérus cure loop
+        this.__internal__pokerusCureLoop = setInterval(this.__internal__focusOnPokerusCure.bind(this), 10000); // Runs every 10 seconds
+        this.__internal__focusOnPokerusCure();
     }
 
     /**

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -164,10 +164,6 @@ class AutomationFocusQuests
         // Only set a loop if there is none active
         if (this.__internal__autoQuestLoop === null)
         {
-            // Set auto-quest loop
-            this.__internal__autoQuestLoop = setInterval(this.__internal__questLoop.bind(this), 1000); // Runs every second
-            this.__internal__questLoop();
-
             // Disable other modes button
             const disableReason = "The 'Focus on Quests' feature is enabled";
             Automation.Menu.setButtonDisabledState(Automation.Click.Settings.FeatureEnabled, true, disableReason);
@@ -180,6 +176,10 @@ class AutomationFocusQuests
             Automation.Click.toggleAutoClick(true);
             Automation.Hatchery.toggleAutoHatchery(true);
             Automation.Underground.toggleAutoMining(true);
+
+            // Set auto-quest loop
+            this.__internal__autoQuestLoop = setInterval(this.__internal__questLoop.bind(this), 1000); // Runs every second
+            this.__internal__questLoop();
         }
     }
 

--- a/src/lib/Focus/ShadowPurification.js
+++ b/src/lib/Focus/ShadowPurification.js
@@ -47,16 +47,16 @@ class AutomationFocusShadowPurification
      */
     static __internal__start()
     {
-        // Set shadow purification loop
-        this.__internal__shadowPurificationLoop = setInterval(this.__internal__focusOnShadowPurification.bind(this), 10000); // Runs every 10 seconds
-        this.__internal__focusOnShadowPurification();
-
         // Disable other modes button
         const disableReason = "The 'Focus on Shadow purify' feature is enabled";
         Automation.Menu.setButtonDisabledState(Automation.Click.Settings.FeatureEnabled, true, disableReason);
 
         // Force enable other modes
         Automation.Click.toggleAutoClick(true);
+
+        // Set shadow purification loop
+        this.__internal__shadowPurificationLoop = setInterval(this.__internal__focusOnShadowPurification.bind(this), 10000); // Runs every 10 seconds
+        this.__internal__focusOnShadowPurification();
     }
 
     /**


### PR DESCRIPTION
Found a small bug on Focus' that can self-disable. If the focus has nothing to do from the start, it disables itself right away but doesn't reset any "forced" modes.

For instance, on a save where every Pokémon is purified, enabling the ShadowPurification Focus will permanently disable the Click Automation toggle. I haven't found a way to unlock the button without reloading the game.

This is due to the fact that the loop is started before the forced modes are set. Meaning that the loop will run once, self-disable (which will reset any forced modes), and only then will the forced modes be set.

Simply starting the loop at the end of the initialization solves this issue 🚀