### PR TITLE
Improve Gym for Gem and click attack computation

### DIFF
--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -80,7 +80,7 @@ class AutomationFocusQuests
         this.__internal__questLabels["CatchShiniesQuest"] = "Catch 1 shiny Pokémon.";
         this.__internal__questLabels["CatchShadowsQuest"] = "Catch <n> Shadow Pokémon.";
         this.__internal__questLabels["DefeatGymQuest"] = "Defeat <Gym leader> <n> times.";
-        this.__internal__questLabels["DefeatDungeonQuest"] = "Defeat the <Dungeon name> dungeon in <Town> <n> times.";
+        this.__internal__questLabels["DefeatDungeonQuest"] = "Defeat the <Dungeon name> dungeon in <Region> <n> times.";
         this.__internal__questLabels["UsePokeballQuest"] = "Use <n> <Balls type>.";
         this.__internal__questLabels["UseOakItemQuest"] = "Equip the <Oak item> and <Action>.";
         this.__internal__questLabels["HarvestBerriesQuest"] = "Harvest <n> <Berry type> Berries at the farm.";

--- a/src/lib/Utils/Battle.js
+++ b/src/lib/Utils/Battle.js
@@ -36,21 +36,17 @@ class AutomationUtilsBattle
         // We now need to compute the click attack manually,
         // since the magikarp island has a dedicated computation that will completly ruin everything...
 
-        // From https://github.com/pokeclicker/pokeclicker/blob/cbfa24800d68d08f863c671d99dfc8d3f832db51/src/scripts/party/Party.ts#L287-L304
+        // From https://github.com/pokeclicker/pokeclicker/blob/4921661cd9b1635f9fd745aba62102ac3f5786ff/src/scripts/party/Party.ts#L293
 
-        // Base power
-        // Shiny pokemon help with a 100% boost
-        // Resistant pokemon give a 100% boost
         let caughtPokemon = App.game.party.caughtPokemon;
         if (getMagikarpValue)
         {
             // Only magikarps can attack in magikarp jump subregion
             caughtPokemon = caughtPokemon.filter((p) => Math.floor(p.id) == 129);
         }
-        const caught = caughtPokemon.length;
-        const shiny = caughtPokemon.filter(p => p.shiny).length;
-        const resistant = caughtPokemon.filter(p => p.pokerus >= GameConstants.Pokerus.Resistant).length;
-        const clickAttack = Math.pow(caught + shiny + resistant + 1, 1.4);
+
+        const partyClickBonus = caughtPokemon.reduce((total, p) => total + p.clickAttackBonus(), 1);
+        const clickAttack = Math.pow(partyClickBonus, 1.4);
 
         const bonus = App.game.party.multiplier.getBonus('clickAttack', false);
 

--- a/src/lib/Utils/Gym.js
+++ b/src/lib/Utils/Gym.js
@@ -62,23 +62,23 @@ class AutomationUtilsGym
             const currentGymClickAttack = isMagikarpJump ? magikarpPlayerClickAttack
                                                          : playerClickAttack;
 
-            let currentGymGemPerTick = 0;
+            let currentGymGemPerClear = 0;
+            let currentGymTickToClear = 0;
             const gymPokemons = gym.getPokemonList()
             for (const pokemon of gymPokemons)
             {
-                const pokemonData = pokemonMap[pokemon.name];
-                if (!pokemonData.type.includes(pokemonType))
-                {
-                    continue;
-                }
-
                 const currentPokemonTickToDefeat = Automation.Utils.Battle.getGameTickCountNeededToDefeatPokemon(
                     pokemon.maxHealth, currentGymClickAttack, totalAtkPerSecondByRegion.get(gymRegion));
-                currentGymGemPerTick += (GameConstants.GYM_GEMS / currentPokemonTickToDefeat);
+                currentGymTickToClear += currentPokemonTickToDefeat;
+
+                const pokemonData = pokemonMap[pokemon.name];
+                if (pokemonData.type.includes(pokemonType))
+                {
+                    currentGymGemPerClear += GameConstants.GYM_GEMS;
+                }
             }
 
-            // TODO (26/06/2022): Be more precise, all pokemons do not have the same health
-            currentGymGemPerTick /= gymPokemons.length;
+            const currentGymGemPerTick = currentGymGemPerClear / currentGymTickToClear;
 
             // Compare with a 1/1000 precision
             if (Math.ceil(currentGymGemPerTick * 1000) >= Math.ceil(bestGymRate * 1000))

--- a/tst/imports/Pokeclicker.import.js
+++ b/tst/imports/Pokeclicker.import.js
@@ -50,6 +50,7 @@ import "tst/stubs/Items/FluteEffectRunner.pokeclicker.stub.js";
 import "tst/stubs/Items/Pokeball.pokeclicker.stub.js";
 import "tst/stubs/Items/PokeballItem.pokeclicker.stub.js";
 import "tst/stubs/Items/Pokeballs.pokeclicker.stub.js";
+import "tst/stubs/Items/HeldItem.pokeclicker.stub.js";
 
 // Import pokeclicker OakItems types and classes
 import "tst/stubs/OakItems/OakItem.pokeclicker.stub.js";

--- a/tst/stubs/GameConstants.pokeclicker.stub.js
+++ b/tst/stubs/GameConstants.pokeclicker.stub.js
@@ -1,4 +1,4 @@
-// Stub of https://github.com/pokeclicker/pokeclicker/blob/cbeab9a0e658aa84ee2ba028f6ae83421c92776a/src/modules/GameConstants.ts
+// Stub of https://github.com/pokeclicker/pokeclicker/blob/4921661cd9b1635f9fd745aba62102ac3f5786ff/src/modules/GameConstants.ts
 class GameConstants
 {
     static clipNumber(num, min, max)
@@ -170,6 +170,16 @@ class GameConstants
             Resistant: 3,
             Uninfected: 0
         };
+
+    static ShadowStatus =
+        {
+            0: "None",
+            1: "Shadow",
+            2: "Purified",
+            None: 0,
+            Shadow: 1,
+            Purified: 2
+        }
 
     static Region =
         {

--- a/tst/stubs/Items/HeldItem.pokeclicker.stub.js
+++ b/tst/stubs/Items/HeldItem.pokeclicker.stub.js
@@ -1,0 +1,43 @@
+// Stub of https://github.com/pokeclicker/pokeclicker/blob/4921661cd9b1635f9fd745aba62102ac3f5786ff/src/scripts/items/HeldItem.ts#L3
+class HeldItem extends Item
+{
+    // Stripped: description, displayName, regionUnlocked, canUse
+    constructor(name, basePrice, currency = GameConstants.Currency.money)
+    {
+        super(name, basePrice, currency);
+    }
+}
+
+// Stub of https://github.com/pokeclicker/pokeclicker/blob/4921661cd9b1635f9fd745aba62102ac3f5786ff/src/scripts/items/HeldItem.ts#L54
+class AttackBonusHeldItem extends HeldItem {
+    // Stripped: applyBonus
+    constructor(name, basePrice, currency = GameConstants.Currency.money, _attackBonus)
+    {
+        super(name, basePrice, currency);
+
+        this._attackBonus = _attackBonus;
+    }
+
+    get attackBonus()
+    {
+        return this._attackBonus;
+    }
+}
+
+// Stub of https://github.com/pokeclicker/pokeclicker/blob/4921661cd9b1635f9fd745aba62102ac3f5786ff/src/scripts/items/HeldItem.ts#L108
+class HybridAttackBonusHeldItem extends AttackBonusHeldItem {
+    constructor(name, basePrice, currency = GameConstants.Currency.money, attackBonus, _clickAttackBonus)
+    {
+        super(name, basePrice, currency, attackBonus);
+
+        this._clickAttackBonus = _clickAttackBonus;
+    }
+
+    get clickAttackBonus()
+    {
+        return this._clickAttackBonus;
+    }
+}
+
+ItemList.Agile_Scroll = new HybridAttackBonusHeldItem('Agile_Scroll', 10000, GameConstants.Currency.money, 0.5, 2.0);
+ItemList.Strong_Scroll = new HybridAttackBonusHeldItem('Strong_Scroll', 10000, GameConstants.Currency.money, 2.0, 0.5);

--- a/tst/stubs/Pokemon/PartyPokemon.pokeclicker.stub.js
+++ b/tst/stubs/Pokemon/PartyPokemon.pokeclicker.stub.js
@@ -1,7 +1,7 @@
-// Stub of : https://github.com/pokeclicker/pokeclicker/blob/cbeab9a0e658aa84ee2ba028f6ae83421c92776a/src/scripts/party/PartyPokemon.ts#L16
+// Stub of https://github.com/pokeclicker/pokeclicker/blob/4921661cd9b1635f9fd745aba62102ac3f5786ff/src/scripts/party/PartyPokemon.ts#L20
 class PartyPokemon
 {
-    // Stripped: evolutions
+    // Stripped: levelEvolutionTriggered, defaultFemaleSprite, hideShinyImage, showShadowImage, nickname
     constructor(id, name, baseAttack, shiny)
     {
         this.attackBonusPercent = 0;
@@ -13,11 +13,14 @@ class PartyPokemon
         this.id = id;
         this.level = 1;
         this.pokerus = GameConstants.Pokerus.Uninfected;
+        this.shadow = GameConstants.ShadowStatus.None;
         this.name = name;
         this.shiny = shiny;
         this.proteinsUsed = function() { return this.__proteinsUsed; }.bind(this);
+        this.heldItem = function() { return this.__heldItem; }.bind(this);
 
         this.__proteinsUsed = 0;
+        this.__heldItem = undefined;
     }
 
     calculateAttack(ignoreLevel = false)
@@ -25,7 +28,22 @@ class PartyPokemon
         const attackBonusMultiplier = 1 + (this.attackBonusPercent / 100);
         const levelMultiplier = ignoreLevel ? 1 : this.level / 100;
         const evsMultiplier = this.calculateEVAttackBonus();
-        return Math.max(1, Math.floor((this.baseAttack * attackBonusMultiplier + this.attackBonusAmount) * levelMultiplier * evsMultiplier));
+        const heldItemMultiplier = this.heldItemAttackBonus();
+        const shadowMultiplier = this.shadowAttackBonus();
+        return Math.max(1, Math.floor((this.baseAttack * attackBonusMultiplier + this.attackBonusAmount) * levelMultiplier * evsMultiplier * heldItemMultiplier * shadowMultiplier));
+    }
+
+    clickAttackBonus()
+    {
+        // Caught + Shiny + Resistant + Purified
+        const caughtBonus = 1;
+        const shinyBonus = this.shiny ? 1 : 0;
+        const resistantBonus = this.pokerus >= GameConstants.Pokerus.Resistant ? 1 : 0;
+        const purifiedBonus = this.shadow == GameConstants.ShadowStatus.Purified ? 1 : 0;
+        const bonus = caughtBonus + shinyBonus + resistantBonus + purifiedBonus;
+
+        const heldItemMultiplier = this.heldItem() instanceof HybridAttackBonusHeldItem ? this.heldItem().clickAttackBonus : 1;
+        return bonus * heldItemMultiplier;
     }
 
     calculateEVAttackBonus()
@@ -41,6 +59,16 @@ class PartyPokemon
     {
         const power = App.game.challenges.list.slowEVs.active() ? GameConstants.EP_CHALLENGE_MODIFIER : 1;
         return Math.floor(this.effortPoints / GameConstants.EP_EV_RATIO / power);
+    }
+
+    shadowAttackBonus()
+    {
+        return this.shadow == GameConstants.ShadowStatus.Shadow ? 0.8 : (this.shadow == GameConstants.ShadowStatus.Purified ? 1.2 : 1);
+    }
+
+    heldItemAttackBonus()
+    {
+        return this.heldItem && this.heldItem() instanceof AttackBonusHeldItem ? this.heldItem().attackBonus : 1;
     }
 
     /***************************\

--- a/tst/tests/Utils/Gym.test.in.js
+++ b/tst/tests/Utils/Gym.test.in.js
@@ -80,7 +80,7 @@ describe(`${AutomationTestUtils.categoryPrefix}Check findBestGymForFarmingType()
         expect(result).not.toBe(null);
         expect(result.Name).toEqual("Elite Bruno");
         expect(result.Town).toEqual("Indigo Plateau Kanto");
-        expect(result.Rate).toBeCloseTo(0.51);
+        expect(result.Rate).toBeCloseTo(0.517);
     });
 
     test('Higher click attack', () =>


### PR DESCRIPTION
Hi !

### Gym efficiency accuracy

Improved the accuracy of gym's gems/tick computation. As pointed at by the todo, health difference between Pokémons wasn't properly taken into account. The difference is minor but gets at bit bigger in the late game.

For instance if one pokémon is defeated in 1 tick and another in 3 ticks: previous calculation yields `((5/3) + (5/1)) / 2 = 3.333 gems/t`, instead it should yield `(5+5) / (3+1) = 2.5 gems/t`. Simplified to "in a total of 4 ticks we would get 10 gems".

### Click attack

The current click attack computation wasn't taking Purified pokémons into account, which also give a +100% bonus.

![Capture d'écran 2024-07-28 172247](https://github.com/user-attachments/assets/b23864b7-4851-4dbe-bea5-c7c827abad65)

I took the opportunity to update the calculation method to get closer to the one currently used by the game. That is by using `PartyPokemon.clickAttackBonus`, introduced in v0.10.18, which computes (and caches!) a pokémon's total bonus. It also already handles the scrolls that will arrive in the next update (though I think a lot more changes will be necessary ;))