### PR TITLE
Mine: Disable Underground automation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@ Pokeclicker-automation aims at automating some recurring tasks that can be a bit
 This script collection does not aim at cheating.
 It will never perform actions that the game would not allow.
 
-Last known compatible pokeclicker version: 0.10.21
+Last known compatible pokeclicker version: 0.10.23
 
 For more details, please refer to the [wiki](../../wiki)
 

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -168,14 +168,14 @@ class AutomationFocusQuests
             const disableReason = "The 'Focus on Quests' feature is enabled";
             Automation.Menu.setButtonDisabledState(Automation.Click.Settings.FeatureEnabled, true, disableReason);
             Automation.Menu.setButtonDisabledState(Automation.Hatchery.Settings.FeatureEnabled, true, disableReason);
-            Automation.Menu.setButtonDisabledState(Automation.Underground.Settings.FeatureEnabled, true, disableReason);
+            // TODO Fix this one up : Automation.Menu.setButtonDisabledState(Automation.Underground.Settings.FeatureEnabled, true, disableReason);
 
             this.__internal__takeOverFarmIfNeeded();
 
             // Force enable other modes
             Automation.Click.toggleAutoClick(true);
             Automation.Hatchery.toggleAutoHatchery(true);
-            Automation.Underground.toggleAutoMining(true);
+            // TODO Fix this one up : Automation.Underground.toggleAutoMining(true);
 
             // Set auto-quest loop
             this.__internal__autoQuestLoop = setInterval(this.__internal__questLoop.bind(this), 1000); // Runs every second
@@ -228,7 +228,7 @@ class AutomationFocusQuests
         Automation.Click.toggleAutoClick();
         Automation.Hatchery.toggleAutoHatchery();
         Automation.Farm.toggleAutoFarming();
-        Automation.Underground.toggleAutoMining();
+        // TODO Fix this one up : Automation.Underground.toggleAutoMining();
 
         // Stop any gym auto-fight
         Automation.Menu.forceAutomationState(Automation.Gym.Settings.FeatureEnabled, false);
@@ -241,7 +241,7 @@ class AutomationFocusQuests
         Automation.Menu.setButtonDisabledState(Automation.Hatchery.Settings.FeatureEnabled, false);
         Automation.Menu.setButtonDisabledState(Automation.Farm.Settings.FeatureEnabled, false);
         Automation.Menu.setButtonDisabledState(Automation.Farm.Settings.FocusOnUnlocks, false);
-        Automation.Menu.setButtonDisabledState(Automation.Underground.Settings.FeatureEnabled, false);
+        // TODO Fix this one up : Automation.Menu.setButtonDisabledState(Automation.Underground.Settings.FeatureEnabled, false);
 
         // Disable automation catch filter
         Automation.Utils.Pokeball.disableAutomationFilter();

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -1043,7 +1043,7 @@ class AutomationMenu
 
         button.setAttribute("disabled", newState ? "true" : "false");
 
-        if (newState &&  (reason !== ""))
+        if (newState && (reason !== ""))
         {
             button.parentElement.setAttribute("automation-tooltip-disable-reason", "\n" + reason + this.TooltipSeparator);
         }

--- a/src/lib/Underground.js
+++ b/src/lib/Underground.js
@@ -9,9 +9,7 @@ class AutomationUnderground
     static Settings = {
                           FeatureEnabled: "Mining-Enabled",
                           UseRestoreItems: "Mining-UseRestoreItems",
-                          RestrictRestoreItemsToMiningQuests: "Mining-RestrictRestoreItemsToMiningQuests",
-                          TradeDiamonds: "Mining-TradeDiamonds",
-                          TradeAnyToDiamonds: "Mining-TradeAnyToDiamonds"
+                          RestrictRestoreItemsToMiningQuests: "Mining-RestrictRestoreItemsToMiningQuests"
                       };
 
     /**
@@ -64,20 +62,12 @@ class AutomationUnderground
                 this.__internal__autoMiningLoop = setInterval(this.__internal__miningLoop.bind(this), 10000); // Runs every 10 seconds
                 this.__internal__miningLoop();
             }
-            if (this.__internal__autoSellingLoop === null)
-            {
-                this.__internal__autoSellingLoop = setInterval(this.__internal__tradeDiamondsLoop.bind(this), 5 * 60 * 1000); // Runs every 5 minutes
-                // Call it manually once to avoid waiting 5 minutes
-                this.__internal__tradeDiamondsLoop();
-            }
         }
         else
         {
             // Unregister the loops
             clearInterval(this.__internal__autoMiningLoop);
             this.__internal__autoMiningLoop = null;
-            clearInterval(this.__internal__autoSellingLoop);
-            this.__internal__autoSellingLoop = null;
         }
     }
 
@@ -154,47 +144,6 @@ class AutomationUnderground
         let restrictRestoreLabel = 'Only use restore items when a mining quest is active';
         Automation.Menu.addLabeledAdvancedSettingsToggleButton(
             restrictRestoreLabel, this.Settings.RestrictRestoreItemsToMiningQuests, "", miningSettingPanel);
-
-        // Split the two setting groups
-        miningSettingPanel.appendChild(document.createElement("br"))
-
-        /********************************\
-        |* Trade for increased diamonds *|
-        \********************************/
-
-        let tradeDiamondsLabel = 'Automatically trade daily deals for increased diamond value';
-        let tradeDiamondsTooltip = "Enabling this feature will check for daily deals\n"
-                                 + "that will grand item worth more diamonds, and trade those."
-                                 + Automation.Menu.TooltipSeparator
-                                 + "Unless the below setting is enabled, only diamond-valued items\n"
-                                 + "will be exchanged."
-                                 + Automation.Menu.TooltipSeparator
-                                 + "Sell-locked items, in the Treasures tab, will never be sold,\n"
-                                 + "but might be aquired through tradings.";
-        const tradeDiamondsButton = Automation.Menu.addLabeledAdvancedSettingsToggleButton(
-            tradeDiamondsLabel, this.Settings.TradeDiamonds, tradeDiamondsTooltip, miningSettingPanel);
-        tradeDiamondsButton.addEventListener("click",
-                                             function()
-                                             {
-                                                 this.__internal__tradeDiamondsIfMineEnabled(this.Settings.TradeDiamonds);
-                                             }.bind(this), false);
-
-        /*******************************\
-        |* Trade anything for diamonds *|
-        \*******************************/
-
-        // Disable this setting by default
-        Automation.Utils.LocalStorage.setDefaultValue(this.Settings.TradeAnyToDiamonds, false);
-
-        let tradeAnyToDiamondsLabel = 'Enable trading items that do not have any diamond value';
-        let tradeAnyToDiamondsTooltip = "Enabling this will trade non-diamond-valued items for diamond-valued ones.";
-        const tradeAnyToDiamondsButton = Automation.Menu.addLabeledAdvancedSettingsToggleButton(
-            tradeAnyToDiamondsLabel, this.Settings.TradeAnyToDiamonds, tradeAnyToDiamondsTooltip, miningSettingPanel);
-        tradeAnyToDiamondsButton.addEventListener("click",
-                                                  function()
-                                                  {
-                                                      this.__internal__tradeDiamondsIfMineEnabled(this.Settings.TradeAnyToDiamonds);
-                                                  }.bind(this), false);
     }
 
     /**
@@ -490,83 +439,5 @@ class AutomationUnderground
         }
 
         return itemsState;
-    }
-
-    /**
-     * @brief Performs a daily deals run if the feature is enabled
-     *        This is used as an advanced settings toggle buttons callback
-     *
-     * @param {string} eventSource: The setting button that was clicked
-     */
-    static __internal__tradeDiamondsIfMineEnabled(eventSource)
-    {
-        // Only trigger the trade if the feature is enabled, and the setting was turned on
-        if ((Automation.Utils.LocalStorage.getValue(this.Settings.FeatureEnabled) === "true")
-            && (Automation.Utils.LocalStorage.getValue(eventSource) === "true"))
-        {
-            this.__internal__tradeDiamondsLoop();
-        }
-    }
-
-    /**
-     * @brief Check for daily deals opportunities to make more diamonds and trade those that are beneficial
-     */
-    static __internal__tradeDiamondsLoop()
-    {
-        if (Automation.Utils.LocalStorage.getValue(this.Settings.TradeDiamonds) !== "true")
-        {
-            return;
-        }
-
-        const shouldTradeAll = Automation.Utils.LocalStorage.getValue(this.Settings.TradeAnyToDiamonds) === "true";
-
-        const deals = DailyDeal.list()
-        let dealsDone = 0;
-        let totalProfit = 0;
-        for (const [ dealIndex, deal ] of deals.entries())
-        {
-            // Do not trade if either:
-            //   - The player does not own the source item
-            //   - The source is locked
-            //   - The destination is not diamond-valued
-            //   - The source is not diamond-valued and the player did not allow such trade
-            if (!deal.item1
-                || (deal.item1.sellLocked && deal.item1.sellLocked())
-                || (deal.item2.valueType != UndergroundItemValueType.Diamond)
-                || (!shouldTradeAll && (deal.item1.valueType != UndergroundItemValueType.Diamond)))
-            {
-                continue;
-            }
-
-            let fromValue = 0;
-            let toValue = deal.amount2 * deal.item2.value;
-
-            // Compute the diamond value, if any
-            if (deal.item1.valueType == UndergroundItemValueType.Diamond)
-            {
-                fromValue = deal.amount1 * deal.item1.value;
-            }
-
-            const tradeProfit = toValue - fromValue;
-            if (tradeProfit > 0)
-            {
-                const item1amount = player.itemList[deal.item1.itemName]();
-                const maxPossibleTrades = Math.floor(item1amount / deal.amount1);
-
-                if (maxPossibleTrades > 0)
-                {
-                    DailyDeal.use(dealIndex, maxPossibleTrades);
-                    dealsDone += maxPossibleTrades;
-                    totalProfit += tradeProfit * maxPossibleTrades;
-                }
-            }
-        }
-
-        if (dealsDone > 0)
-        {
-            let diamondImage = '<img src="assets/images/currency/diamond.svg" height="25px">';
-            Automation.Notifications.sendNotif(`Performed ${dealsDone} underground daily deals for a total profit of ${totalProfit} ${diamondImage}`,
-                                               "Mining");
-        }
     }
 }

--- a/src/lib/Underground.js
+++ b/src/lib/Underground.js
@@ -42,6 +42,9 @@ class AutomationUnderground
      */
     static toggleAutoMining(enable)
     {
+        // TODO This feature needs a full rework
+        return;
+
         if (!App.game.underground.canAccess())
         {
             return;
@@ -79,7 +82,6 @@ class AutomationUnderground
 
     static __internal__autoMiningLoop = null;
     static __internal__innerMiningLoop = null;
-    static __internal__autoSellingLoop = null;
 
     static __internal__actionCount = 0;
 
@@ -107,11 +109,24 @@ class AutomationUnderground
                             + "The hammer will then be used if more than 3 blocks\n"
                             + "can be destroyed on an item within its range\n"
                             + "The chisel will then be used to finish the remaining blocks\n";
+
+        // Warn the user that this feature is not available for now
+        autoMiningTooltip = "⚠️ Since v0.10.23 this feature does not work anymore ⚠️"
+                          + Automation.Menu.TooltipSeparator
+                          + "A full rework was performed by the pokeclicker team.\n"
+                          + "This requires a full rework of the automation.";
+
         let miningButton =
             Automation.Menu.addAutomationButton("Mining", this.Settings.FeatureEnabled, autoMiningTooltip, this.__internal__undergroundContainer);
-        miningButton.addEventListener("click", this.toggleAutoMining.bind(this), false);
+        // TODO Restore this once the feature is back
+        // miningButton.addEventListener("click", this.toggleAutoMining.bind(this), false);
 
-        this.__internal__buildAdvancedSettings(this.__internal__undergroundContainer);
+        // this.__internal__buildAdvancedSettings(this.__internal__undergroundContainer);
+
+        // Disable the feature until a new one is implemented
+        Automation.Menu.forceAutomationState(this.Settings.FeatureEnabled, false);
+        Automation.Menu.setButtonDisabledState(this.Settings.FeatureEnabled, true);
+        miningButton.parentElement.setAttribute("automation-tooltip-disable-reason", "\n");
     }
 
     /**


### PR DESCRIPTION
The v0.10.23 update includes a major rework to the Underground feature.
That includes completely removing daily deals and chains.
Instead, players will be able to trade items of the same type at a rate of 3 to 1 at any time.

For example, shards can be traded for other shards, plates can either
be sold for gems or traded for other plates,
and diamond items can only be sold for diamonds.

---

For now the feature has been disabled completely : 
![image](https://github.com/user-attachments/assets/1f056947-081b-4452-a2d1-45dc78b4df92)

The trade feature has been removed, since it's not a thing anymore.

Fixes #386 