### PR TITLE
Mine: Don't do anything while searching for a new mine

### DIFF
--- a/src/lib/Underground.js
+++ b/src/lib/Underground.js
@@ -147,7 +147,9 @@ class AutomationUnderground
     static __internal__miningLoop()
     {
         // Don't run an additionnal loop if another one is already in progress
-        if (this.__internal__innerMiningLoop !== null)
+        // Or the user launched a mine discovery
+        if ((this.__internal__innerMiningLoop !== null)
+            || (App.game.underground.mine.timeUntilDiscovery > 0))
         {
             return;
         }


### PR DESCRIPTION
The user can search for a new mine, in such case don't try anything until the timer is elapsed.

Part of #389 