### PR TITLE
Dungeon: Don't change catch settings during automation mode

### DIFF
--- a/src/lib/Instances/Dungeon.js
+++ b/src/lib/Instances/Dungeon.js
@@ -586,9 +586,10 @@ class AutomationDungeon
                     {
                         this.__internal__moveToCell(this.__internal__floorEndPosition);
 
-                        // Equip the selected pokeball (if None is set, keep the user in-game setting)
+                        // Equip the selected pokeball (if None is set, or the automation forced a mode, keep the user in-game setting)
                         const ballToCatchBoss = this.__internal__dungeonBossCatchPokeballSelectElem.value;
-                        if (ballToCatchBoss != GameConstants.Pokeball.None)
+                        if ((ballToCatchBoss != GameConstants.Pokeball.None)
+                            && (this.AutomationRequestedMode == this.InternalModes.None))
                         {
                             Automation.Utils.Pokeball.catchEverythingWith(ballToCatchBoss);
                         }


### PR DESCRIPTION
If the user sets a pokéball type to catch bosses and the automation forced a dungeon run, it would cause the automation setting to be overridden and it would never go back to the proper one.

The catch settings are now only changed if no automation mode is set.