### PR TITLE
Menu: Allow every pokeball in drop-down lists

### DIFF
--- a/src/lib/Focus.js
+++ b/src/lib/Focus.js
@@ -85,7 +85,7 @@ class AutomationFocus
         }
 
         // Ensure that the player has some balls available
-        if (!this.__ensurePlayerHasEnoughBalls(this.__pokeballToUseSelectElem.value))
+        if (!this.__ensurePlayerHasEnoughBalls(this.__pokeballToUseSelectElem.selectedValue))
         {
             return;
         }
@@ -94,10 +94,10 @@ class AutomationFocus
         this.__equipLoadout(Automation.Utils.OakItem.Setup.PokemonCatch);
 
         // Equip an "Already caught" pokeball
-        Automation.Utils.Pokeball.catchEverythingWith(this.__pokeballToUseSelectElem.value);
+        Automation.Utils.Pokeball.catchEverythingWith(this.__pokeballToUseSelectElem.selectedValue);
 
         // Move to the highest unlocked route
-        Automation.Utils.Route.moveToHighestDungeonTokenIncomeRoute(this.__pokeballToUseSelectElem.value);
+        Automation.Utils.Route.moveToHighestDungeonTokenIncomeRoute(this.__pokeballToUseSelectElem.selectedValue);
     }
 
     /**
@@ -348,12 +348,10 @@ class AutomationFocus
 
         this.__internal__setBallToUseToCatchDefaultValue();
 
-        this.__pokeballToUseSelectElem =
-            Automation.Menu.addPokeballList("focusPokeballToUseSelection",
-                                            generalTabContainer,
-                                            this.Settings.BallToUseToCatch,
-                                            "Pokeball to use for catching :",
-                                            pokeballToUseTooltip);
+        this.__pokeballToUseSelectElem = Automation.Menu.addPokeballList(this.Settings.BallToUseToCatch,
+                                                                         "Pokeball to use for catching",
+                                                                         pokeballToUseTooltip);
+        generalTabContainer.appendChild(this.__pokeballToUseSelectElem);
     }
 
     /**

--- a/src/lib/Focus.js
+++ b/src/lib/Focus.js
@@ -189,6 +189,14 @@ class AutomationFocus
             const pokeballName = GameConstants.Pokeball[ballType];
             const pokeballItem = ItemList[pokeballName];
 
+            // Disable the feature if we are not able to buy more balls (for now, only money currency is supported)
+            if (pokeballItem.currency != GameConstants.Currency.money)
+            {
+                Automation.Menu.forceAutomationState(this.Settings.FeatureEnabled, false);
+                Automation.Notifications.sendWarningNotif("No more pokéball of the selected type are available", "Focus");
+                return false;
+            }
+
             // No more money, or too expensive, go farm some money
             if ((App.game.wallet.currencies[GameConstants.Currency.money]() < pokeballItem.totalPrice(10))
                 || (pokeballItem.totalPrice(1) !== pokeballItem.basePrice))

--- a/src/lib/Focus.js
+++ b/src/lib/Focus.js
@@ -13,9 +13,7 @@ class AutomationFocus
                           FeatureEnabled: "Focus-Enabled",
                           FocusedTopic: "Focus-SelectedTopic",
                           OakItemLoadoutUpdate: "Focus-OakItemLoadoutUpdate",
-                          BallToUseToCatch: "Focus-BallToUseToCatch",
-                          DefaultCaughtBall: "Focus-DefaultCaughtBall",
-                          DefaultContagiousCaughtBall: "Focus-DefaultContagiousCaughtBall"
+                          BallToUseToCatch: "Focus-BallToUseToCatch"
                       };
 
     /**
@@ -347,6 +345,9 @@ class AutomationFocus
         const pokeballToUseTooltip = "Defines which pokeball will be equipped to catch\n"
                                    + "already caught pokémon, when needed"
                                    + disclaimer;
+
+        this.__internal__setBallToUseToCatchDefaultValue();
+
         this.__pokeballToUseSelectElem =
             Automation.Menu.addPokeballList("focusPokeballToUseSelection",
                                             generalTabContainer,
@@ -655,5 +656,21 @@ class AutomationFocus
 
         Automation.Utils.Route.moveToTown(this.__internal__lastFocusData.bestGymTown);
         this.__enableAutoGymFight(this.__internal__lastFocusData.bestGym);
+    }
+
+    /**
+     * @brief Sets the default value of the BallToUseToCatch setting
+     */
+    static __internal__setBallToUseToCatchDefaultValue()
+    {
+        // Set the most effective available ball in priority
+        for (const ball of [ GameConstants.Pokeball.Ultraball, GameConstants.Pokeball.Greatball, GameConstants.Pokeball.Pokeball ])
+        {
+            if (App.game.pokeballs.pokeballs[ball].unlocked())
+            {
+                Automation.Utils.LocalStorage.setDefaultValue(this.Settings.BallToUseToCatch, ball);
+                break;
+            }
+        }
     }
 }

--- a/src/lib/Focus/PokerusCure.js
+++ b/src/lib/Focus/PokerusCure.js
@@ -186,7 +186,7 @@ class AutomationFocusPokerusCure
         Automation.Focus.__equipLoadout(Automation.Utils.OakItem.Setup.PokemonCatch);
 
         // Ensure that the player has some balls available
-        if (!Automation.Focus.__ensurePlayerHasEnoughBalls(Automation.Focus.__pokeballToUseSelectElem.value))
+        if (!Automation.Focus.__ensurePlayerHasEnoughBalls(Automation.Focus.__pokeballToUseSelectElem.selectedValue))
         {
             Automation.Utils.Pokeball.disableAutomationFilter();
             return;
@@ -206,7 +206,7 @@ class AutomationFocusPokerusCure
 
         // Equip an "Already caught contagious" pokeball
         const pokeballToUse = (currentLocationData.needsBeastBall) ? GameConstants.Pokeball.Beastball
-                                                                   : Automation.Focus.__pokeballToUseSelectElem.value;
+                                                                   : Automation.Focus.__pokeballToUseSelectElem.selectedValue;
 
         Automation.Utils.Pokeball.onlyCatchContagiousWith(pokeballToUse);
 

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -410,7 +410,7 @@ class AutomationFocusQuests
         if (Automation.Utils.isInstanceOf(quest, "CapturePokemonsQuest")
             || Automation.Utils.isInstanceOf(quest, "GainTokensQuest"))
         {
-            this.__internal__workOnUsePokeballQuest(Automation.Focus.__pokeballToUseSelectElem.value);
+            this.__internal__workOnUsePokeballQuest(Automation.Focus.__pokeballToUseSelectElem.selectedValue);
         }
         else if (Automation.Utils.isInstanceOf(quest, "CapturePokemonTypesQuest"))
         {
@@ -456,7 +456,7 @@ class AutomationFocusQuests
             if (currentQuests.some((quest) => Automation.Utils.isInstanceOf(quest, "CatchShiniesQuest")))
             {
                 // Buy some ball to be prepared
-                this.__internal__tryBuyBallIfUnderThreshold(Automation.Focus.__pokeballToUseSelectElem.value, 10);
+                this.__internal__tryBuyBallIfUnderThreshold(Automation.Focus.__pokeballToUseSelectElem.selectedValue, 10);
                 this.__internal__equipOptimizedLoadout(Automation.Utils.OakItem.Setup.PokemonCatch);
             }
             else if (currentQuests.some((quest) => Automation.Utils.isInstanceOf(quest, "GainMoneyQuest")))
@@ -530,7 +530,7 @@ class AutomationFocusQuests
     static __internal__workOnCapturePokemonTypesQuest(quest)
     {
         // Add a pokeball to the Caught type and set the PokemonCatch setup
-        const hasBalls = this.__internal__trySelectBallToCatch(Automation.Focus.__pokeballToUseSelectElem.value);
+        const hasBalls = this.__internal__trySelectBallToCatch(Automation.Focus.__pokeballToUseSelectElem.selectedValue);
 
         if (hasBalls)
         {
@@ -590,14 +590,14 @@ class AutomationFocusQuests
         // If we don't have enough tokens, go farm some
         if (TownList[dungeonName].dungeon.tokenCost > App.game.wallet.currencies[GameConstants.Currency.dungeonToken]())
         {
-            this.__internal__workOnUsePokeballQuest(Automation.Focus.__pokeballToUseSelectElem.value);
+            this.__internal__workOnUsePokeballQuest(Automation.Focus.__pokeballToUseSelectElem.selectedValue);
             return;
         }
 
         if (catchShadows)
         {
             this.__internal__equipOptimizedLoadout(Automation.Utils.OakItem.Setup.PokemonCatch);
-            Automation.Utils.Pokeball.catchEverythingWith(Automation.Focus.__pokeballToUseSelectElem.value);
+            Automation.Utils.Pokeball.catchEverythingWith(Automation.Focus.__pokeballToUseSelectElem.selectedValue);
             Automation.Utils.Pokeball.restrictCaptureToShadow(true);
             Automation.Utils.Pokeball.enableAutomationFilter();
         }
@@ -706,7 +706,7 @@ class AutomationFocusQuests
     {
         if (quest.item == OakItemType.Magic_Ball)
         {
-            this.__internal__workOnUsePokeballQuest(Automation.Focus.__pokeballToUseSelectElem.value);
+            this.__internal__workOnUsePokeballQuest(Automation.Focus.__pokeballToUseSelectElem.selectedValue);
         }
         else
         {

--- a/src/lib/Focus/ShadowPurification.js
+++ b/src/lib/Focus/ShadowPurification.js
@@ -143,7 +143,7 @@ class AutomationFocusShadowPurification
         Automation.Focus.__equipLoadout(Automation.Utils.OakItem.Setup.PokemonCatch);
 
         // Ensure that the player has some balls available
-        if (!Automation.Focus.__ensurePlayerHasEnoughBalls(Automation.Focus.__pokeballToUseSelectElem.value))
+        if (!Automation.Focus.__ensurePlayerHasEnoughBalls(Automation.Focus.__pokeballToUseSelectElem.selectedValue))
         {
             Automation.Utils.Pokeball.disableAutomationFilter();
             return;
@@ -158,7 +158,7 @@ class AutomationFocusShadowPurification
         }
 
         // Equip an "Already caught shadow" pokeball
-        Automation.Utils.Pokeball.catchEverythingWith(Automation.Focus.__pokeballToUseSelectElem.value);
+        Automation.Utils.Pokeball.catchEverythingWith(Automation.Focus.__pokeballToUseSelectElem.selectedValue);
         Automation.Utils.Pokeball.restrictCaptureToShadow(false);
 
         // Move to dungeon if needed

--- a/src/lib/Instances/Dungeon.js
+++ b/src/lib/Instances/Dungeon.js
@@ -253,12 +253,12 @@ class AutomationDungeon
                                        + Automation.Menu.TooltipSeparator
                                        + "Selecting 'None' will leave the in-game value unchanged";
         this.__internal__dungeonBossCatchPokeballSelectElem =
-            Automation.Menu.addPokeballList("selectedDungeonBossCatchPokeball",
-                                            dungeonSettingsPanel,
-                                            this.Settings.BossCatchPokeballToUse,
-                                            "Pokéball to equip for the boss :",
+            Automation.Menu.addPokeballList(this.Settings.BossCatchPokeballToUse,
+                                            "Pokéball to equip for the boss",
                                             bossCatchPokeballTooltip,
                                             true);
+        dungeonSettingsPanel.appendChild(this.__internal__dungeonBossCatchPokeballSelectElem);
+        this.__internal__dungeonBossCatchPokeballSelectElem.style.marginBottom = "3px";
 
         // Add the chest min rarity setting
         this.__internal__buildChestMinRarityDropdownList(dungeonSettingsPanel);
@@ -595,7 +595,7 @@ class AutomationDungeon
                         this.__internal__moveToCell(this.__internal__floorEndPosition);
 
                         // Equip the selected pokeball (if None is set, or the automation forced a mode, keep the user in-game setting)
-                        const ballToCatchBoss = this.__internal__dungeonBossCatchPokeballSelectElem.value;
+                        const ballToCatchBoss = this.__internal__dungeonBossCatchPokeballSelectElem.selectedValue;
                         if ((ballToCatchBoss != GameConstants.Pokeball.None)
                             && (this.AutomationRequestedMode == this.InternalModes.None))
                         {

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -894,7 +894,7 @@ class AutomationMenu
         // Don't consider the saved value if the user does not have access to the corresponding ball yet
         if ((savedValue != null)
             && (savedValue != GameConstants.Pokeball.None)
-            && !Automation.Utils.isBallPurchasable(savedValue))
+            && !App.game.pokeballs.pokeballs[savedValue].unlocked())
         {
             Automation.Utils.LocalStorage.unsetValue(setting);
             savedValue = null;
@@ -918,7 +918,7 @@ class AutomationMenu
                 for (var i = this.__internal__lockedBalls.length - 1; i >= 0; i--)
                 {
                     const ballValue = this.__internal__lockedBalls[i];
-                    if (Automation.Utils.isBallPurchasable(ballValue))
+                    if (App.game.pokeballs.pokeballs[ballValue].unlocked())
                     {
                         for (const elemData of this.__internal__pokeballListElems)
                         {
@@ -1092,7 +1092,7 @@ class AutomationMenu
     }
 
     /**
-     * @brief Populates the drop-down list with the pokeballs that can be bought at the Poké Mart
+     * @brief Populates the drop-down list with all the pokeballs type
      *
      * If any pokeball can't be bought yet, it will be hidden to the player.
      *
@@ -1102,7 +1102,7 @@ class AutomationMenu
      */
     static __internal__populatePokeballOptions(selectedValue, listElem, addNoneOption)
     {
-        const options = [ GameConstants.Pokeball.Pokeball, GameConstants.Pokeball.Greatball, GameConstants.Pokeball.Ultraball ];
+        const options = App.game.pokeballs.pokeballs.map(p => p.type);
 
         if (addNoneOption)
         {
@@ -1118,7 +1118,7 @@ class AutomationMenu
             opt.textContent = GameConstants.Pokeball[ball];
 
             if ((ball != GameConstants.Pokeball.None)
-                && !Automation.Utils.isBallPurchasable(ball))
+                && !App.game.pokeballs.pokeballs[ball].unlocked())
             {
                 if (!this.__internal__lockedBalls.includes(ball))
                 {

--- a/src/lib/Utils.js
+++ b/src/lib/Utils.js
@@ -47,20 +47,6 @@ class AutomationUtils
     }
 
     /**
-     * @brief Determines if the provided @p ball can be bought by the user
-     *
-     * @param ball: The ball to check
-     *
-     * @return True if the ball can be bought, false otherwise
-     */
-    static isBallPurchasable(ball)
-    {
-        return ((ball == GameConstants.Pokeball.Pokeball) && TownList["Viridian City"].isUnlocked())
-            || ((ball == GameConstants.Pokeball.Greatball) && TownList["Lavender Town"].isUnlocked())
-            || ((ball == GameConstants.Pokeball.Ultraball) && TownList["Fuchsia City"].isUnlocked());
-    }
-
-    /**
      * @brief Checks if two arrays are equals
      *
      * Arrays are equals if:


### PR DESCRIPTION
The drop-down list for both `Focus` and `Dungeon` panels now list all available pokéballs.

Since it can be a bit difficult to identify each pokéball by only its name, the corresponding image is now displayed in the list as well: 
![image](https://github.com/user-attachments/assets/76f75621-af42-487f-8ba9-81ca2161802f)

---

In case the player runs out of the selected ball, the `Focus` feature will:
  - Buy new one if it can be using Money
  - Stop and display a warning message if its only available in a currency other than money

Closes #384 