### PR TITLE
Focus.PokerusCure: Support trainer shadow pokemons

### DIFF
--- a/src/lib/Focus/PokerusCure.js
+++ b/src/lib/Focus/PokerusCure.js
@@ -527,24 +527,53 @@ class AutomationFocusPokerusCure
             // Add pokemon bosses
             for (const boss of dungeon.bossList)
             {
-                // Only consider pokémons
-                if (!Automation.Utils.isInstanceOf(boss, "DungeonBossPokemon"))
+                // Consider pokémons
+                if (Automation.Utils.isInstanceOf(boss, "DungeonBossPokemon"))
                 {
-                    continue;
-                }
+                    // Don't consider locked bosses, if we're only considering available pokémons
+                    if (onlyConsiderAvailablePokemons)
+                    {
+                        const isBossLocked = boss.options?.requirement
+                                        ? !this.__internal__isRequirementCompleted(boss.options?.requirement, dungeonRegion)
+                                        : false;
+                        if (isBossLocked) continue;
+                    }
 
-                // Don't consider locked bosses, if we're only considering available pokémons
-                if (onlyConsiderAvailablePokemons)
-                {
-                    const isBossLocked = boss.options?.requirement
-                                       ? !this.__internal__isRequirementCompleted(boss.options?.requirement, dungeonRegion)
-                                       : false;
-                    if (isBossLocked) continue;
+                    if (!pokemonList.includes(boss.name))
+                    {
+                        pokemonList.push(boss.name);
+                    }
                 }
-
-                if (!pokemonList.includes(boss.name))
+                // Or trainer bosses shadow pokemons
+                else if (Automation.Utils.isInstanceOf(boss, "DungeonTrainer"))
                 {
-                    pokemonList.push(boss.name);
+                    const shadowPokemons = boss.team.filter(p => p.shadow == 1);
+
+                    for (const pokemon of shadowPokemons)
+                    {
+                        if (!pokemonList.includes(pokemon.name))
+                        {
+                            pokemonList.push(pokemon.name);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Add any trainer shadow pokemons
+        for (const trainer of dungeon.enemyList)
+        {
+            // Only consider trainers
+            if (!Automation.Utils.isInstanceOf(trainer, "DungeonTrainer"))
+            {
+                continue;
+            }
+
+            for (const pokemon of trainer.team.filter(p => p.shadow == 1))
+            {
+                if (!pokemonList.includes(pokemon.name))
+                {
+                    pokemonList.push(pokemon.name);
                 }
             }
         }

--- a/src/lib/Focus/ShadowPurification.js
+++ b/src/lib/Focus/ShadowPurification.js
@@ -275,6 +275,12 @@ class AutomationFocusShadowPurification
         // Add shadow pokemons
         for (const enemy of enemyList)
         {
+            // Only consider trainers
+            if (!Automation.Utils.isInstanceOf(enemy, "DungeonTrainer"))
+            {
+                continue;
+            }
+
             // Don't consider locked enemies, if we're only considering available pokémons
             if (onlyConsiderAvailablePokemons)
             {

--- a/src/lib/Utils/Route.js
+++ b/src/lib/Utils/Route.js
@@ -201,7 +201,8 @@ class AutomationUtilsRoute
         const needsNewRoad = (this.__internal__lastHighestRegion !== player.highestRegion())
                           || (this.__internal__lastBestRouteData.maxHealth > playerSingleAttackByRegion.get(this.__internal__lastBestRouteData.route.region))
                           || ((this.__internal__lastNextBestRouteData != null)
-                              && (this.__internal__lastNextBestRouteData.maxHealth < playerSingleAttackByRegion.get(this.__internal__lastNextBestRouteData.route.region)));
+                              && (this.__internal__lastNextBestRouteData.maxHealth < playerSingleAttackByRegion.get(this.__internal__lastNextBestRouteData.route.region)))
+                          || !this.canMoveToRoute(this.__internal__lastBestRouteData.route.number, this.__internal__lastBestRouteData.route.region, this.__internal__lastBestRouteData.route.route);
 
         if (needsNewRoad)
         {
@@ -240,9 +241,12 @@ class AutomationUtilsRoute
             // This can happen if the player is in a new region and the docks are not unlocked yet
             if (this.__internal__lastBestRouteData == null)
             {
-                // If no routes are below the user attack, just choose the 1st ones
-                this.__internal__lastBestRouteData = this.__internal__routeMaxHealthData[0];
-                this.__internal__lastNextBestRouteData = this.__internal__routeMaxHealthData[1];
+                // If no routes are below the user attack, just choose the 1st accessible ones
+                const accessibleRoutes = Automation.Utils.Route.__internal__routeMaxHealthData.filter(
+                    routeData => Automation.Utils.Route.canMoveToRoute(routeData.route.number, routeData.route.region, routeData.route))
+
+                this.__internal__lastBestRouteData = accessibleRoutes[0];
+                this.__internal__lastNextBestRouteData = accessibleRoutes[0];
             }
         }
 


### PR DESCRIPTION
Trainer shadow pokemons can be caught.
The script now considers those for dungeons.

Fixes #403 