### PR TITLE
Farm: Fixup early shovels

### DIFF
--- a/src/lib/Farm.js
+++ b/src/lib/Farm.js
@@ -2594,7 +2594,15 @@ class AutomationFarm
             return true;
         }
 
-        const totalCount = App.game.farming.berryInventory[berryType]() + this.__internal__getPlantedBerriesCount(berryType);
+        let totalCount = App.game.farming.berryInventory[berryType]();
+
+        // TODO Make if faster by including planted berries count even when the auto-shovel is enabled
+        // (can't be done for now because the next strategy would shovel the target berry)
+        if (Automation.Utils.LocalStorage.getValue(this.Settings.UseShovel) !== "true")
+        {
+            totalCount += this.__internal__getPlantedBerriesCount(berryType);
+        }
+
         return (totalCount < targetCount);
     }
 }


### PR DESCRIPTION
When the player had enough berries in stock or on the plots, the next strategy would be started.

If the auto-shovel feature was enabled, this resulted in shoveling the ones of the previous strategy that were still growing.

After the shoveling, the count was then too low, so the strategy switched back to the previous one.

To prevent this problem, only the crops in stock are now considered.

Fixes #429 