### PR TITLE
Focus: PokerusCure: Reduce dungeon token over-consumption

### DIFF
--- a/src/lib/Focus/PokerusCure.js
+++ b/src/lib/Focus/PokerusCure.js
@@ -230,6 +230,16 @@ class AutomationFocusPokerusCure
             // Enable auto dungeon fight
             Automation.Menu.forceAutomationState(Automation.Dungeon.Settings.FeatureEnabled, true);
 
+            // Avoid wasting dungeon tokens if the run conditions are already met
+            Automation.Dungeon.setBeforeNewRunCallBack(function()
+                {
+                    if (!this.__internal__doesDungeonHaveAnyPokemonNeedingCure(this.__internal__currentDungeonData.dungeon, true))
+                    {
+                        // Reload the Focus automation
+                        this.__internal__focusOnPokerusCure();
+                    }
+                }.bind(this));
+
             // Only force pokemon fights if one of those needs curing
             if (this.__internal__doesAnyPokemonNeedCuring(this.__internal__currentDungeonData.nonBossPokemons, true))
             {


### PR DESCRIPTION
When all dungeon pokémons are cured, the automation still ran for a few runs before switching to the next one.

This wasted some dungeon tokens unnecessarily.
This is even more problematic when the pokemon is not available after its first acounter (The Genesect High-speed pokémon for example)

The automation will now check if the dungeon has been cured before launching a new dungeon run.