### PR TITLE
Focus: PokerusCure: Add support for mimic pokémons

### DIFF
--- a/src/lib/Focus/Achievements.js
+++ b/src/lib/Focus/Achievements.js
@@ -376,7 +376,7 @@ class AutomationFocusAchievements
         Automation.Menu.forceAutomationState(Automation.Dungeon.Settings.FeatureEnabled, true);
 
         // Bypass user settings like the stop on pokedex one
-        Automation.Dungeon.AutomationRequestedMode = Automation.Dungeon.InternalModes.ForceDungeonCompletion;
+        Automation.Dungeon.AutomationRequestedModes = [ Automation.Dungeon.InternalModes.ForceDungeonCompletion ];
     }
 
     /**

--- a/src/lib/Focus/PokerusCure.js
+++ b/src/lib/Focus/PokerusCure.js
@@ -48,6 +48,9 @@ class AutomationFocusPokerusCure
         // Disable Alternate forms skipping by default
         Automation.Utils.LocalStorage.setDefaultValue(this.__internal__advancedSettings.SkipAlternateForms, false);
 
+        // Enable mimic pokémons by default
+        Automation.Utils.LocalStorage.setDefaultValue(this.__internal__advancedSettings.IncludeMimicPokemons, true);
+
         // Beastball usage setting
         const tooltip = "Allows the automation to use Beastball to catch UltraBeast pokémons."
                       + Automation.Menu.TooltipSeparator
@@ -64,6 +67,13 @@ class AutomationFocusPokerusCure
                                                                this.__internal__advancedSettings.SkipAlternateForms,
                                                                alternateTooltip,
                                                                parent);
+
+        // Mimic pokemon inclusion setting
+        const mimicTooltip = "If enabled, the dungeon automation will force chest pickup";
+        Automation.Menu.addLabeledAdvancedSettingsToggleButton("Include mimic pokémons from dungeon chests",
+                                                               this.__internal__advancedSettings.IncludeMimicPokemons,
+                                                               mimicTooltip,
+                                                               parent);
     }
 
     /*********************************************************************\
@@ -72,6 +82,7 @@ class AutomationFocusPokerusCure
 
     static __internal__advancedSettings = {
                                               AllowBeastBallUsage: "Focus-PokerusCure-AllowBeastBallUsage",
+                                              IncludeMimicPokemons: "Focus-PokerusCure-IncludeMimicPokemons",
                                               SkipAlternateForms: "Focus-PokerusCure-SkipAlternateForms"
                                           };
 
@@ -244,12 +255,18 @@ class AutomationFocusPokerusCure
             if (this.__internal__doesAnyPokemonNeedCuring(this.__internal__currentDungeonData.nonBossPokemons, true))
             {
                 // Bypass user settings, especially the 'Skip fights' one
-                Automation.Dungeon.AutomationRequestedMode = Automation.Dungeon.InternalModes.ForcePokemonFight;
+                Automation.Dungeon.AutomationRequestedModes = [ Automation.Dungeon.InternalModes.ForcePokemonFight ];
             }
             else
             {
                 // Go straight to the boss if every other pokemons have been cured
-                Automation.Dungeon.AutomationRequestedMode = Automation.Dungeon.InternalModes.ForceDungeonCompletion;
+                Automation.Dungeon.AutomationRequestedModes = [ Automation.Dungeon.InternalModes.ForceDungeonCompletion ];
+            }
+
+            if ((Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.IncludeMimicPokemons) === "true")
+                && this.__internal__doesAnyPokemonNeedCuring(this.__internal__currentDungeonData.mimicPokemons, true))
+            {
+                Automation.Dungeon.AutomationRequestedModes.push(Automation.Dungeon.InternalModes.ForceChestOpening);
             }
         }
     }
@@ -299,11 +316,15 @@ class AutomationFocusPokerusCure
                       // Don't consider dungeon that the player can't access yet
                    && Automation.Utils.Route.canMoveToTown(TownList[data.dungeon.name]), this);
 
-        if (this.__internal__currentDungeonData)
+        if (this.__internal__currentDungeonData != null)
         {
             // Save current instance non-boss pokémons for dungeon strategy optimisation
             this.__internal__currentDungeonData.nonBossPokemons =
                 this.__internal__getEveryPokemonForDungeon(this.__internal__currentDungeonData.dungeon, false, true);
+
+            // Save current instance mimic pokémons for dungeon strategy optimisation
+            this.__internal__currentDungeonData.mimicPokemons =
+                this.__internal__getEveryMimicPokemonForDungeon(this.__internal__currentDungeonData.dungeon);
 
             // Determine if the beast ball is the only catching option
             this.__internal__currentDungeonData.needsBeastBall =
@@ -388,9 +409,22 @@ class AutomationFocusPokerusCure
      */
     static __internal__doesDungeonHaveAnyPokemonNeedingCure(dungeon, onlyConsiderAvailableContagiousPokemons = false)
     {
+        // Check for pokémons needing cure in the standard pokemon list
         const pokemonList = this.__internal__getEveryPokemonForDungeon(dungeon, onlyConsiderAvailableContagiousPokemons);
+        if (this.__internal__doesAnyPokemonNeedCuring(pokemonList, onlyConsiderAvailableContagiousPokemons))
+        {
+            return true;
+        }
 
-        return this.__internal__doesAnyPokemonNeedCuring(pokemonList, onlyConsiderAvailableContagiousPokemons);
+        if (onlyConsiderAvailableContagiousPokemons
+            && (Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.IncludeMimicPokemons) !== "true"))
+        {
+            return false;
+        }
+
+        // Check for pokémons needing cure in the mimic pokemon list
+        const mimicList = this.__internal__getEveryMimicPokemonForDungeon(dungeon);
+        return this.__internal__doesAnyPokemonNeedCuring(mimicList, onlyConsiderAvailableContagiousPokemons);
     }
 
     /**
@@ -404,7 +438,7 @@ class AutomationFocusPokerusCure
     static __internal__doesAnyPokemonNeedCuring(pokemonList, onlyConsiderAvailableContagiousPokemons)
     {
         // Skip UltraBeast pokémons if the player disabled the feature or there is no Beastball left
-        const skipUltraBeasts = (Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.AllowBeastBallUsage) == "false")
+        const skipUltraBeasts = (Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.AllowBeastBallUsage) === "false")
                              || (App.game.pokeballs.getBallQuantity(GameConstants.Pokeball.Beastball) === 0);
 
         return pokemonList.some((pokemonName) =>
@@ -452,7 +486,13 @@ class AutomationFocusPokerusCure
      */
     static __internal__doesDungeonNeedBeastBalls(dungeon)
     {
-        const pokemonList = this.__internal__getEveryPokemonForDungeon(dungeon, true);
+        let pokemonList = this.__internal__getEveryPokemonForDungeon(dungeon, true);
+
+        if (Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.IncludeMimicPokemons) === "true")
+        {
+            pokemonList.concat(this.__internal__getEveryMimicPokemonForDungeon(dungeon));
+        }
+
         return pokemonList.every((pokemonName) =>
             {
                 const pokemon = App.game.party.getPokemonByName(pokemonName);
@@ -508,7 +548,8 @@ class AutomationFocusPokerusCure
         pokemonList.filter((item, index) => pokemonList.indexOf(item) === index);
 
         // Filter alternate forms, if asked for
-        if (onlyConsiderAvailablePokemons && Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.SkipAlternateForms) == "true")
+        if (onlyConsiderAvailablePokemons
+            && (Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.SkipAlternateForms) === "true"))
         {
             // Alternate forms have a floating point id
             pokemonList = pokemonList.filter((pokemonName) => Number.isInteger(pokemonMap[pokemonName].id));
@@ -573,7 +614,36 @@ class AutomationFocusPokerusCure
         }
 
         // Filter alternate forms, if asked for
-        if (onlyConsiderAvailablePokemons && Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.SkipAlternateForms) == "true")
+        if (onlyConsiderAvailablePokemons
+            && (Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.SkipAlternateForms) === "true"))
+        {
+            // Alternate forms have a floating point id
+            pokemonList = pokemonList.filter((pokemonName) => Number.isInteger(pokemonMap[pokemonName].id));
+        }
+
+        return pokemonList;
+    }
+
+    /**
+     * @brief Gets the list of possible mimic pokémon that can be found in chests for the given @p dungeon
+     *
+     * @param dungeon: The dungeon to get the pokémon of
+     * @param {boolean} onlyConsiderAvailablePokemons: Whether only currently available pokémon should be considered
+     *
+     * @returns The list of pokémon
+     */
+    static __internal__getEveryMimicPokemonForDungeon(dungeon)
+    {
+        let pokemonList = dungeon.normalEncounterList.filter((encounter) =>
+            {
+                // Only consider mimics
+                return encounter.mimic
+                    // Filter hidden entries
+                    && !encounter.hide;
+            }).map(p => p.pokemonName);
+
+        // Filter alternate forms, if asked for
+        if (Automation.Utils.LocalStorage.getValue(this.__internal__advancedSettings.SkipAlternateForms) === "true")
         {
             // Alternate forms have a floating point id
             pokemonList = pokemonList.filter((pokemonName) => Number.isInteger(pokemonMap[pokemonName].id));

--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -625,8 +625,8 @@ class AutomationFocusQuests
         Automation.Menu.forceAutomationState(Automation.Dungeon.Settings.FeatureEnabled, true);
 
         // Bypass user settings like the stop on pokedex one
-        Automation.Dungeon.AutomationRequestedMode = (catchShadows) ? Automation.Dungeon.InternalModes.ForcePokemonFight
-                                                                    : Automation.Dungeon.InternalModes.ForceDungeonCompletion;
+        Automation.Dungeon.AutomationRequestedMode = (catchShadows) ? [ Automation.Dungeon.InternalModes.ForcePokemonFight ]
+                                                                    : [ Automation.Dungeon.InternalModes.ForceDungeonCompletion ];
     }
 
     /**

--- a/src/lib/Focus/ShadowPurification.js
+++ b/src/lib/Focus/ShadowPurification.js
@@ -179,7 +179,7 @@ class AutomationFocusShadowPurification
         Automation.Dungeon.setBeforeNewRunCallBack(this.__internal__tryToPurifyShadowPokemon.bind(this));
 
         // Bypass user settings, especially the 'Skip fights' one
-        Automation.Dungeon.AutomationRequestedMode = Automation.Dungeon.InternalModes.ForcePokemonFight;
+        Automation.Dungeon.AutomationRequestedMode = [ Automation.Dungeon.InternalModes.ForcePokemonFight ];
     }
 
     /**

--- a/src/lib/Instances/Dungeon.js
+++ b/src/lib/Instances/Dungeon.js
@@ -13,12 +13,12 @@ class AutomationDungeon
                       };
 
     static InternalModes = {
-                               None: 0,
                                ForceDungeonCompletion: 1,
-                               ForcePokemonFight: 2
+                               ForcePokemonFight: 2,
+                               ForceChestOpening: 3
                            };
 
-    static AutomationRequestedMode = this.InternalModes.None;
+    static AutomationRequestedModes = [];
 
     /**
      * @brief Builds the menu
@@ -405,7 +405,7 @@ class AutomationDungeon
         // Cleanup StopAfterThisRun internal mode that was set while the dungeon was not running
         if (this.__internal__stopAfterThisRun)
         {
-            this.AutomationRequestedMode = this.InternalModes.None;
+            this.AutomationRequestedModes = [];
             this.__internal__stopAfterThisRun = false;
         }
 
@@ -429,7 +429,7 @@ class AutomationDungeon
             this.__internal__autoDungeonLoop = null;
 
             // Reset any automation mode
-            this.AutomationRequestedMode = this.InternalModes.None;
+            this.AutomationRequestedModes = [];
             this.__internal__stopAfterThisRun = false;
 
             // Disable automation catch filter
@@ -450,12 +450,12 @@ class AutomationDungeon
      */
     static __internal__dungeonFightLoop()
     {
-        const forceDungeonProcessing = (this.AutomationRequestedMode == this.InternalModes.ForceDungeonCompletion)
-                                    || (this.AutomationRequestedMode == this.InternalModes.ForcePokemonFight);
+        const forceDungeonProcessing = (this.AutomationRequestedModes != []);
 
         const avoidFights = (Automation.Utils.LocalStorage.getValue(this.Settings.AvoidEncounters) === "true")
-                         && (this.AutomationRequestedMode != this.InternalModes.ForcePokemonFight);
-        const skipChests = (this.__internal__chestMinRarityDropdownList.selectedValue == this.__internal__chestTypes.skipall);
+                         && !this.AutomationRequestedModes.includes(this.InternalModes.ForcePokemonFight);
+        const skipChests = (this.__internal__chestMinRarityDropdownList.selectedValue == this.__internal__chestTypes.skipall)
+                        && !this.AutomationRequestedModes.includes(this.InternalModes.ForceChestOpening);
         const skipBoss = (Automation.Utils.LocalStorage.getValue(this.Settings.SkipBoss) === "true")
                       && !forceDungeonProcessing;
 
@@ -490,7 +490,7 @@ class AutomationDungeon
                 }
 
                 Automation.Menu.forceAutomationState(this.Settings.FeatureEnabled, false);
-                this.AutomationRequestedMode = this.InternalModes.None;
+                this.AutomationRequestedModes = [];
             }
             else
             {
@@ -597,7 +597,7 @@ class AutomationDungeon
                         // Equip the selected pokeball (if None is set, or the automation forced a mode, keep the user in-game setting)
                         const ballToCatchBoss = parseInt(Automation.Utils.LocalStorage.getValue(this.Settings.BossCatchPokeballToUse));
                         if ((ballToCatchBoss != GameConstants.Pokeball.None)
-                            && (this.AutomationRequestedMode == this.InternalModes.None))
+                            && (this.AutomationRequestedModes == []))
                         {
                             Automation.Utils.Pokeball.catchEverythingWith(ballToCatchBoss);
                         }
@@ -920,8 +920,8 @@ class AutomationDungeon
                 }
 
                 // The 'stop on pokedex' feature might be enable and the pokedex already completed
-                if ((this.AutomationRequestedMode != this.InternalModes.ForceDungeonCompletion)
-                    && (this.AutomationRequestedMode != this.InternalModes.ForcePokemonFight)
+                if (!this.AutomationRequestedModes.includes(this.InternalModes.ForceDungeonCompletion)
+                    && !this.AutomationRequestedModes.includes(this.InternalModes.ForcePokemonFight)
                     && (Automation.Utils.LocalStorage.getValue(this.Settings.StopOnPokedex) == "true")
                     && this.__internal__isDungeonCompleted())
                 {
@@ -1003,11 +1003,16 @@ class AutomationDungeon
      */
     static __internal__addChestPosition(cell)
     {
-        // Don't add the chest if its rarity is lower than the user selected one
-        const currentChestRarity = this.__internal__chestTypes[cell.tile.metadata.tier];
-        if (currentChestRarity < this.__internal__chestMinRarityDropdownList.selectedValue)
+        const forceChestOpening = this.AutomationRequestedModes.includes(this.InternalModes.ForceChestOpening);
+
+        if (!forceChestOpening)
         {
-            return;
+            // Don't add the chest if its rarity is lower than the user selected one
+            const currentChestRarity = this.__internal__chestTypes[cell.tile.metadata.tier];
+            if (currentChestRarity < this.__internal__chestMinRarityDropdownList.selectedValue)
+            {
+                return;
+            }
         }
 
         // Don't add the chest if it was already added to the list
@@ -1024,6 +1029,8 @@ class AutomationDungeon
      */
     static __internal__getChestLeftToOpenCount()
     {
+        const forceChestOpening = this.AutomationRequestedModes.includes(this.InternalModes.ForceChestOpening);
+
         let result = 0;
         for (const tile of DungeonRunner.map.board().flat().flat())
         {
@@ -1031,7 +1038,7 @@ class AutomationDungeon
             {
                 const currentChestRarity = Automation.Dungeon.__internal__chestTypes[tile.metadata.tier];
 
-                if (currentChestRarity >= this.__internal__chestMinRarityDropdownList.selectedValue)
+                if (forceChestOpening || (currentChestRarity >= this.__internal__chestMinRarityDropdownList.selectedValue))
                 {
                     result++;
                 }


### PR DESCRIPTION
Some pokémon can only be encountered as mimics in dungeon chests.

A new advanced settings option was added to enable/disable this. 
<img width="636" height="186" alt="image" src="https://github.com/user-attachments/assets/5ee638de-6442-4c62-901b-3ceb951849c9" />
It's enabled by default.

Fixes #436