### PR TITLE
Dungeon: Fixup dungeon not stoping on pokedex completion

### DIFF
--- a/src/lib/Focus/Quests.js
+++ b/src/lib/Focus/Quests.js
@@ -625,8 +625,8 @@ class AutomationFocusQuests
         Automation.Menu.forceAutomationState(Automation.Dungeon.Settings.FeatureEnabled, true);
 
         // Bypass user settings like the stop on pokedex one
-        Automation.Dungeon.AutomationRequestedMode = (catchShadows) ? [ Automation.Dungeon.InternalModes.ForcePokemonFight ]
-                                                                    : [ Automation.Dungeon.InternalModes.ForceDungeonCompletion ];
+        Automation.Dungeon.AutomationRequestedModes = (catchShadows) ? [ Automation.Dungeon.InternalModes.ForcePokemonFight ]
+                                                                     : [ Automation.Dungeon.InternalModes.ForceDungeonCompletion ];
     }
 
     /**

--- a/src/lib/Focus/ShadowPurification.js
+++ b/src/lib/Focus/ShadowPurification.js
@@ -179,7 +179,7 @@ class AutomationFocusShadowPurification
         Automation.Dungeon.setBeforeNewRunCallBack(this.__internal__tryToPurifyShadowPokemon.bind(this));
 
         // Bypass user settings, especially the 'Skip fights' one
-        Automation.Dungeon.AutomationRequestedMode = [ Automation.Dungeon.InternalModes.ForcePokemonFight ];
+        Automation.Dungeon.AutomationRequestedModes = [ Automation.Dungeon.InternalModes.ForcePokemonFight ];
     }
 
     /**

--- a/src/lib/Instances/Dungeon.js
+++ b/src/lib/Instances/Dungeon.js
@@ -450,7 +450,7 @@ class AutomationDungeon
      */
     static __internal__dungeonFightLoop()
     {
-        const forceDungeonProcessing = (this.AutomationRequestedModes != []);
+        const forceDungeonProcessing = (this.AutomationRequestedModes.length != 0);
 
         const avoidFights = (Automation.Utils.LocalStorage.getValue(this.Settings.AvoidEncounters) === "true")
                          && !this.AutomationRequestedModes.includes(this.InternalModes.ForcePokemonFight);


### PR DESCRIPTION
The regression was introduced by the AutomationRequestedModes rework (see #438).
The collection was compared to an empty array instead of checking its size.

Additionally, some references were not renamed properly in Quests and Shadow purification focus modes.

Fixes #439 